### PR TITLE
card export: fix form action bug

### DIFF
--- a/console/admin/views/card_list.html
+++ b/console/admin/views/card_list.html
@@ -34,6 +34,11 @@
     function do_export(){
         $("#query_form").attr("action", "/card/export");
         $("#query_form").submit();
+        setTimeout(function(){  // after downloaded, rollback the "action"
+            $("#query_form").attr("action", "/card/list");
+        }, 0);
+
+
     }
 
 </script>


### PR DESCRIPTION
when doing /card/export, after downloaded, rollback the "action" to old