### PR TITLE
chore(ci): harden workflows and unify build metadata injection

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,13 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/web"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   GO_VERSION: '1.24'
   CGO_ENABLED: 0
@@ -14,6 +21,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -46,6 +54,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -86,6 +95,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     needs: [lint, test]
+    timeout-minutes: 45
     strategy:
       matrix:
         goos: [linux, darwin, windows]
@@ -139,9 +149,9 @@ jobs:
           fi
           
           go build -ldflags "-s -w \
-            -X main.version=${{ steps.version.outputs.version }} \
-            -X main.buildTime=${{ steps.version.outputs.build_time }} \
-            -X main.gitCommit=${{ steps.version.outputs.git_commit }}" \
+            -X main.Version=${{ steps.version.outputs.version }} \
+            -X main.BuildTime=${{ steps.version.outputs.build_time }} \
+            -X main.GitCommit=${{ steps.version.outputs.git_commit }}" \
             -o "dist/${BINARY_NAME}" main.go
           
           echo "✅ Built ${{ matrix.goos }}/${{ matrix.goarch }}"
@@ -156,6 +166,7 @@ jobs:
   security:
     name: Security Scan
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -180,12 +191,13 @@ jobs:
           cache: true
 
       - name: Run govulncheck
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest
-          govulncheck ./... || true
+          govulncheck ./...
 
       - name: Run gosec
-        uses: securego/gosec@master
+        uses: securego/gosec@v2.22.4
         with:
           args: -exclude-generated ./...
-        continue-on-error: true
+        continue-on-error: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,10 +5,19 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: docker-publish-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build-and-push-docker-image:
     name: Build Docker image and push to repositories
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - name: Checkout code
@@ -40,7 +49,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.MY_GITHUB_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build image and push to Docker Hub and GitHub Container Registry
         id: docker_build

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*'
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   issues: read

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "develop")
 BUILD_TIME ?= $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
 GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
-LDFLAGS := -s -w -X main.version=$(VERSION) -X main.buildTime=$(BUILD_TIME) -X main.gitCommit=$(GIT_COMMIT)
+LDFLAGS := -s -w -X main.Version=$(VERSION) -X main.BuildTime=$(BUILD_TIME) -X main.GitCommit=$(GIT_COMMIT)
 
 # 默认目标
 help:

--- a/main.go
+++ b/main.go
@@ -24,11 +24,14 @@ import (
 var g errgroup.Group
 
 // Build information, injected via ldflags at compile time
-// Example: go build -ldflags "-X main.version=1.0.0 -X main.buildTime=2024-01-01T00:00:00Z -X main.gitCommit=abc123"
+// Example: go build -ldflags "-X main.Version=1.0.0 -X main.BuildTime=2024-01-01T00:00:00Z -X main.GitCommit=abc123"
 var (
-	version   = "develop"
-	buildTime = "unknown"
-	gitCommit = "unknown"
+	// Version is the application version injected at build time.
+	Version = "develop"
+	// BuildTime is the UTC build timestamp injected at build time.
+	BuildTime = "unknown"
+	// GitCommit is the source commit hash injected at build time.
+	GitCommit = "unknown"
 )
 
 var (
@@ -40,9 +43,9 @@ var (
 )
 
 func PrintVersion() {
-	_, _ = fmt.Fprintf(os.Stdout, "ToughRADIUS %s\n", version)                         //nolint:errcheck
-	_, _ = fmt.Fprintf(os.Stdout, "Build Time: %s\n", buildTime)                       //nolint:errcheck
-	_, _ = fmt.Fprintf(os.Stdout, "Git Commit: %s\n", gitCommit)                       //nolint:errcheck
+	_, _ = fmt.Fprintf(os.Stdout, "ToughRADIUS %s\n", Version)                         //nolint:errcheck
+	_, _ = fmt.Fprintf(os.Stdout, "Build Time: %s\n", BuildTime)                       //nolint:errcheck
+	_, _ = fmt.Fprintf(os.Stdout, "Git Commit: %s\n", GitCommit)                       //nolint:errcheck
 	_, _ = fmt.Fprintf(os.Stdout, "Go Version: %s\n", runtime.Version())               //nolint:errcheck
 	_, _ = fmt.Fprintf(os.Stdout, "OS/Arch:    %s/%s\n", runtime.GOOS, runtime.GOARCH) //nolint:errcheck
 }


### PR DESCRIPTION
## Summary
- Harden GitHub workflows with explicit permissions, concurrency control, and job timeouts.
- Improve security scan behavior in CI:
  - pin securego/gosec to a fixed version
  - make scans strict on push to main, while allowing non-blocking mode on PRs
- Expand Dependabot coverage to npm (/web) and github-actions.
- Unify build metadata symbols and ldflags keys to uppercase:
  - main.Version
  - main.BuildTime
  - main.GitCommit
  across main.go, Makefile, and workflows.

## Files changed
- .github/workflows/ci.yml
- .github/workflows/docker-publish.yml
- .github/workflows/release-publish.yml
- .github/dependabot.yml
- main.go
- Makefile

## Validation
- go test ./... passed locally
- verified ldflags injection with uppercase symbols via runtime version output
- local pre-push quality gate passed (tests, go vet, formatting, build, golangci-lint)
