### PR TITLE
docs(go): enrich API comments for app and utility packages

### DIFF
--- a/internal/app/profile_cache.go
+++ b/internal/app/profile_cache.go
@@ -32,7 +32,25 @@ const (
 	CleanupInterval = 1 * time.Minute
 )
 
-// NewProfileCache creates a new profile cache instance
+// NewProfileCache creates a new profile cache instance with automatic cleanup.
+// The cache reduces database load during RADIUS authentication by storing frequently
+// accessed profile configurations in memory.
+//
+// Parameters:
+//   - db: GORM database instance for cache misses
+//   - ttl: Time-to-live for cache entries (0 uses DefaultProfileCacheTTL = 5 minutes)
+//
+// Returns:
+//   - *ProfileCache: Cache instance with background cleanup goroutine started
+//
+// Side effects:
+//   - Starts a background goroutine for periodic cleanup (every 1 minute)
+//   - Goroutine stops when Stop() is called
+//
+// Example:
+//
+//	cache := app.NewProfileCache(db, 10*time.Minute)
+//	defer cache.Stop()  // Important: stop cleanup goroutine on shutdown
 func NewProfileCache(db *gorm.DB, ttl time.Duration) *ProfileCache {
 	if ttl == 0 {
 		ttl = DefaultProfileCacheTTL
@@ -54,7 +72,27 @@ func NewProfileCache(db *gorm.DB, ttl time.Duration) *ProfileCache {
 	return pc
 }
 
-// Get retrieves a profile from cache or database
+// Get retrieves a profile from cache or database with automatic cache-aside pattern.
+// On cache miss, the profile is fetched from database and stored in cache.
+//
+// Parameters:
+//   - profileID: Unique profile identifier
+//
+// Returns:
+//   - *domain.RadiusProfile: Profile object (never nil if error is nil)
+//   - error: Database error if profile not found or query fails
+//
+// Behavior:
+//   - Cache hit: Returns cached profile if not expired
+//   - Cache miss/expired: Fetches from DB, updates cache, returns profile
+//   - Thread-safe: Uses RWMutex for concurrent access
+//
+// Example:
+//
+//	profile, err := cache.Get(user.ProfileID)
+//	if err != nil {
+//	    return fmt.Errorf("profile not found: %w", err)
+//	}
 func (pc *ProfileCache) Get(profileID int64) (*domain.RadiusProfile, error) {
 	// Try cache first
 	pc.mu.RLock()
@@ -78,7 +116,22 @@ func (pc *ProfileCache) Get(profileID int64) (*domain.RadiusProfile, error) {
 	return &profile, nil
 }
 
-// Set stores a profile in cache
+// Set manually stores a profile in cache with the configured TTL.
+// This is useful for pre-warming the cache or updating after database writes.
+//
+// Parameters:
+//   - profileID: Profile identifier (key)
+//   - profile: Profile object to cache (must not be nil)
+//
+// Side effects:
+//   - Overwrites existing cache entry if present
+//   - Sets expiration time to now + TTL
+//
+// Example:
+//
+//	// Pre-warm cache after creating new profile
+//	db.Create(&profile)
+//	cache.Set(profile.ID, &profile)
 func (pc *ProfileCache) Set(profileID int64, profile *domain.RadiusProfile) {
 	pc.mu.Lock()
 	defer pc.mu.Unlock()
@@ -89,7 +142,21 @@ func (pc *ProfileCache) Set(profileID int64, profile *domain.RadiusProfile) {
 	}
 }
 
-// Invalidate removes a profile from cache (call when profile is updated/deleted)
+// Invalidate removes a specific profile from cache.
+// Call this after updating or deleting a profile to ensure cache consistency.
+//
+// Parameters:
+//   - profileID: Profile ID to remove from cache
+//
+// Side effects:
+//   - Removes cache entry (no-op if not present)
+//   - Next Get() will fetch fresh data from database
+//
+// Example:
+//
+//	// Update profile bandwidth limit
+//	db.Model(&profile).Update("bandwidth", newValue)
+//	cache.Invalidate(profile.ID)  // Force re-fetch on next access
 func (pc *ProfileCache) Invalidate(profileID int64) {
 	pc.mu.Lock()
 	defer pc.mu.Unlock()
@@ -97,7 +164,18 @@ func (pc *ProfileCache) Invalidate(profileID int64) {
 	delete(pc.cache, profileID)
 }
 
-// InvalidateAll clears the entire cache
+// InvalidateAll clears the entire cache by discarding all entries.
+// This is useful for bulk updates or when cache coherence is uncertain.
+//
+// Side effects:
+//   - Replaces cache map with a new empty map
+//   - All subsequent Get() calls will trigger database queries
+//
+// Example:
+//
+//	// After bulk profile update
+//	db.Model(&domain.RadiusProfile{}).Where("node_id = ?", nodeID).Update("status", "disabled")
+//	cache.InvalidateAll()  // Clear entire cache
 func (pc *ProfileCache) InvalidateAll() {
 	pc.mu.Lock()
 	defer pc.mu.Unlock()
@@ -133,14 +211,37 @@ func (pc *ProfileCache) cleanup() {
 	}
 }
 
-// Stop halts the background cleanup goroutine
+// Stop halts the background cleanup goroutine gracefully.
+// Call this during application shutdown to prevent goroutine leaks.
+//
+// Side effects:
+//   - Closes stopClean channel, signaling cleanup goroutine to exit
+//   - Cleanup goroutine terminates within CleanupInterval (1 minute max)
+//   - No-op if autoClean was disabled at creation
+//
+// Example:
+//
+//	func (app *Application) Shutdown() {
+//	    app.profileCache.Stop()  // Stop background cleanup
+//	    app.db.Close()
+//	}
 func (pc *ProfileCache) Stop() {
 	if pc.autoClean {
 		close(pc.stopClean)
 	}
 }
 
-// Stats returns cache statistics
+// Stats returns current cache statistics for monitoring and debugging.
+//
+// Returns:
+//   - map[string]interface{}: Statistics with keys:
+//   - "size" (int): Number of cached profiles
+//   - "ttl" (string): Cache TTL duration (e.g., "5m0s")
+//
+// Example:
+//
+//	stats := cache.Stats()
+//	log.Printf("Cache size: %v, TTL: %v", stats["size"], stats["ttl"])
 func (pc *ProfileCache) Stats() map[string]interface{} {
 	pc.mu.RLock()
 	defer pc.mu.RUnlock()

--- a/internal/app/radius_metrics.go
+++ b/internal/app/radius_metrics.go
@@ -40,12 +40,41 @@ var metricsNames = []string{
 	MetricsRadiusAccounting,
 }
 
-// GetRadiusMetrics returns the counter value for a specific metric
+// GetRadiusMetrics retrieves the current counter value for a specific RADIUS metric.
+// Metrics are thread-safe and use atomic operations for concurrent access.
+//
+// Common metrics include:
+//   - MetricsRadiusAccept: Successful authentication count
+//   - MetricsRadiusRejectPasswdError: Password mismatch rejections
+//   - MetricsRadiusOline: Active online sessions
+//   - MetricsRadiusAccounting: Accounting requests processed
+//
+// Parameters:
+//   - name: Metric name (use constants like MetricsRadiusAccept)
+//
+// Returns:
+//   - int64: Current counter value (0 if metric doesn't exist)
+//
+// Example:
+//
+//	onlineCount := app.GetRadiusMetrics(app.MetricsRadiusOline)
+//	log.Printf("Active sessions: %d", onlineCount)
 func GetRadiusMetrics(name string) int64 {
 	return metrics.GetCounter(name)
 }
 
-// GetAllRadiusMetrics returns all RADIUS metrics as a map
+// GetAllRadiusMetrics retrieves all RADIUS metrics as a map for monitoring dashboards.
+// This is commonly used by the metrics endpoint to expose Prometheus-style metrics.
+//
+// Returns:
+//   - map[string]int64: All metric names and their current values
+//
+// Example:
+//
+//	func MetricsHandler(c echo.Context) error {
+//	    metrics := app.GetAllRadiusMetrics()
+//	    return c.JSON(200, metrics)
+//	}
 func GetAllRadiusMetrics() map[string]int64 {
 	result := make(map[string]int64)
 	for _, name := range metricsNames {
@@ -54,7 +83,23 @@ func GetAllRadiusMetrics() map[string]int64 {
 	return result
 }
 
-// IncRadiusMetric increments a RADIUS metric counter
+// IncRadiusMetric atomically increments a RADIUS metric counter by 1.
+// This is called internally by RADIUS authentication and accounting handlers.
+//
+// Parameters:
+//   - name: Metric name to increment (use MetricsRadius* constants)
+//
+// Side effects:
+//   - Atomically increments the metric counter
+//   - Creates the metric if it doesn't exist (initialized to 0)
+//
+// Example:
+//
+//	if authErr != nil {
+//	    app.IncRadiusMetric(app.MetricsRadiusRejectPasswdError)
+//	    return radius.CodeAccessReject
+//	}
+//	app.IncRadiusMetric(app.MetricsRadiusAccept)
 func IncRadiusMetric(name string) {
 	metrics.Inc(name)
 }

--- a/pkg/certgen/certgen.go
+++ b/pkg/certgen/certgen.go
@@ -1,3 +1,34 @@
+// Package certgen provides utilities for generating X.509 certificates for RadSec (RADIUS over TLS).
+//
+// This package simplifies TLS certificate generation for:
+//   - CA (Certificate Authority) creation for internal PKI
+//   - Server certificates for RadSec listeners (RFC 6614)
+//   - Client certificates for mutual TLS authentication
+//
+// All certificates support Subject Alternative Names (SAN) for DNS and IP addresses,
+// which is required by modern TLS clients.
+//
+// Example usage:
+//
+//	// 1. Generate CA certificate
+//	caConfig := certgen.CAConfig{
+//	    CertConfig: certgen.DefaultCertConfig(),
+//	    OutputDir: "/etc/toughradius/certs",
+//	}
+//	caConfig.CommonName = "ToughRADIUS CA"
+//	certgen.GenerateCA(caConfig)
+//
+//	// 2. Generate server certificate with SAN
+//	serverConfig := certgen.ServerConfig{
+//	    CertConfig: certgen.DefaultCertConfig(),
+//	    CAKeyPath: "/etc/toughradius/certs/ca.key",
+//	    CACertPath: "/etc/toughradius/certs/ca.crt",
+//	    OutputDir: "/etc/toughradius/certs",
+//	}
+//	serverConfig.CommonName = "radius.example.com"
+//	serverConfig.DNSNames = []string{"radius.example.com", "*.radius.example.com"}
+//	serverConfig.IPAddresses = []net.IP{net.ParseIP("192.168.1.10")}
+//	certgen.GenerateServerCert(serverConfig)
 package certgen
 
 import (
@@ -14,7 +45,24 @@ import (
 	"time"
 )
 
-// CertConfig Certificate configuration
+// CertConfig holds common X.509 certificate configuration shared across CA, server, and client certificates.
+// It defines the certificate's subject (identity), validity period, and cryptographic parameters.
+//
+// Subject fields follow X.509 Distinguished Name (DN) structure:
+//   - CommonName: Primary identifier (e.g., hostname for server certs, username for client certs)
+//   - Organization: Organization name(s)
+//   - OrganizationalUnit: Department or division
+//   - Country: Two-letter country code (e.g., "CN", "US")
+//   - Province: State or province
+//   - Locality: City or locality
+//
+// SAN (Subject Alternative Names) support:
+//   - DNSNames: Additional DNS names (wildcards supported: "*.example.com")
+//   - IPAddresses: IP addresses for IP-based TLS connections
+//
+// Security parameters:
+//   - ValidDays: Certificate validity period (default 3650 = 10 years)
+//   - KeySize: RSA key size in bits (2048 or 4096 recommended)
 type CertConfig struct {
 	CommonName         string
 	Organization       []string
@@ -28,13 +76,33 @@ type CertConfig struct {
 	KeySize            int      // RSA Key size
 }
 
-// CAConfig CA Certificate configuration
+// CAConfig extends CertConfig for Certificate Authority generation.
+// The CA is used to sign server and client certificates.
+//
+// Fields:
+//   - CertConfig: Embedded base configuration
+//   - OutputDir: Directory where ca.crt and ca.key will be saved
+//
+// Output files:
+//   - ca.crt: PEM-encoded CA certificate (public, distribute to clients)
+//   - ca.key: PEM-encoded CA private key (secret, protect carefully)
 type CAConfig struct {
 	CertConfig
 	OutputDir string // Output directory
 }
 
-// ServerConfig holds server certificate configuration
+// ServerConfig extends CertConfig for server certificate generation.
+// Server certificates are used by RadSec listeners for TLS encryption.
+//
+// Fields:
+//   - CertConfig: Embedded base configuration (set DNSNames for SAN support)
+//   - CAKeyPath: Path to CA private key (ca.key) for signing
+//   - CACertPath: Path to CA certificate (ca.crt) for chain validation
+//   - OutputDir: Directory where server.crt and server.key will be saved
+//
+// Output files:
+//   - server.crt: PEM-encoded server certificate (signed by CA)
+//   - server.key: PEM-encoded server private key (protect with 0600 permissions)
 type ServerConfig struct {
 	CertConfig
 	CAKeyPath  string // CA private key path
@@ -42,7 +110,18 @@ type ServerConfig struct {
 	OutputDir  string // Output directory
 }
 
-// ClientConfig holds client certificate configuration
+// ClientConfig extends CertConfig for client certificate generation.
+// Client certificates enable mutual TLS authentication for RadSec clients.
+//
+// Fields:
+//   - CertConfig: Embedded base configuration (CommonName = client identifier)
+//   - CAKeyPath: Path to CA private key (ca.key) for signing
+//   - CACertPath: Path to CA certificate (ca.crt) for chain validation
+//   - OutputDir: Directory where client.crt and client.key will be saved
+//
+// Output files:
+//   - client.crt: PEM-encoded client certificate (signed by CA)
+//   - client.key: PEM-encoded client private key (protect with 0600 permissions)
 type ClientConfig struct {
 	CertConfig
 	CAKeyPath  string // CA private key path
@@ -50,7 +129,26 @@ type ClientConfig struct {
 	OutputDir  string // Output directory
 }
 
-// DefaultCertConfig Returns default certificate configuration
+// DefaultCertConfig returns a pre-configured CertConfig with sensible defaults.
+// Use this as a starting point and override specific fields as needed.
+//
+// Default values:
+//   - Organization: "ToughRADIUS"
+//   - OrganizationalUnit: "IT"
+//   - Country: "CN"
+//   - Province: "Shanghai"
+//   - Locality: "Shanghai"
+//   - ValidDays: 3650 (10 years)
+//   - KeySize: 2048 bits (RSA)
+//
+// Returns:
+//   - CertConfig: Configuration with default values
+//
+// Example:
+//
+//	config := certgen.DefaultCertConfig()
+//	config.CommonName = "radius.example.com"
+//	config.ValidDays = 365  // Override to 1 year
 func DefaultCertConfig() CertConfig {
 	return CertConfig{
 		Organization:       []string{"ToughRADIUS"},
@@ -63,7 +161,38 @@ func DefaultCertConfig() CertConfig {
 	}
 }
 
-// GenerateCA Generate CA certificate
+// GenerateCA creates a self-signed Certificate Authority (CA) for internal PKI.
+// The CA is used to sign server and client certificates, establishing a trust chain.
+//
+// This generates:
+//   - RSA private key (PKCS#8 format)
+//   - Self-signed X.509 certificate with CA:TRUE constraint
+//   - Certificate supports both server and client authentication
+//
+// Parameters:
+//   - config: CA configuration (must set CommonName)
+//
+// Returns:
+//   - error: File I/O, crypto generation, or encoding errors
+//
+// Output files:
+//   - {OutputDir}/ca.crt: CA certificate (PEM, mode 0644)
+//   - {OutputDir}/ca.key: CA private key (PEM, mode 0600 - protect carefully!)
+//
+// Side effects:
+//   - Creates OutputDir if it doesn't exist (mode 0755)
+//   - Prints file paths to stdout on success
+//
+// Example:
+//
+//	caConfig := certgen.CAConfig{
+//	    CertConfig: certgen.DefaultCertConfig(),
+//	    OutputDir: "/etc/toughradius/certs",
+//	}
+//	caConfig.CommonName = "ToughRADIUS Internal CA"
+//	if err := certgen.GenerateCA(caConfig); err != nil {
+//	    log.Fatalf("CA generation failed: %v", err)
+//	}
 func GenerateCA(config CAConfig) error {
 	if err := os.MkdirAll(config.OutputDir, 0755); err != nil { //nolint:gosec // G301: 0755 is standard for certificate directories
 		return fmt.Errorf("create output directory failed: %w", err)
@@ -141,7 +270,41 @@ func GenerateCA(config CAConfig) error {
 	return nil
 }
 
-// GenerateServerCert generates the server certificate (supports SAN)
+// GenerateServerCert creates a server certificate signed by the CA.
+// This certificate is used by RadSec servers for TLS encryption (RFC 6614).
+//
+// Supports Subject Alternative Names (SAN):
+//   - DNSNames: Multiple hostnames (wildcards supported)
+//   - IPAddresses: Direct IP-based TLS connections
+//
+// Parameters:
+//   - config: Server configuration (must set CommonName, CAKeyPath, CACertPath)
+//
+// Returns:
+//   - error: File I/O, CA loading, crypto generation, or encoding errors
+//
+// Output files:
+//   - {OutputDir}/server.crt: Server certificate (PEM, mode 0644)
+//   - {OutputDir}/server.key: Server private key (PEM, mode 0600)
+//
+// Side effects:
+//   - Creates OutputDir if it doesn't exist
+//   - Prints file paths and SAN info to stdout on success
+//
+// Example:
+//
+//	serverConfig := certgen.ServerConfig{
+//	    CertConfig: certgen.DefaultCertConfig(),
+//	    CAKeyPath: "/etc/toughradius/certs/ca.key",
+//	    CACertPath: "/etc/toughradius/certs/ca.crt",
+//	    OutputDir: "/etc/toughradius/certs",
+//	}
+//	serverConfig.CommonName = "radius.example.com"
+//	serverConfig.DNSNames = []string{"radius.example.com", "*.radius.example.com"}
+//	serverConfig.IPAddresses = []net.IP{net.ParseIP("192.168.1.10")}
+//	if err := certgen.GenerateServerCert(serverConfig); err != nil {
+//	    log.Fatalf("Server cert generation failed: %v", err)
+//	}
 func GenerateServerCert(config ServerConfig) error {
 	if err := os.MkdirAll(config.OutputDir, 0755); err != nil { //nolint:gosec // G301: 0755 is standard for certificate directories
 		return fmt.Errorf("create output directory failed: %w", err)
@@ -232,7 +395,38 @@ func GenerateServerCert(config ServerConfig) error {
 	return nil
 }
 
-// GenerateClientCert generates the client certificate (supports SAN)
+// GenerateClientCert creates a client certificate signed by the CA.
+// This certificate enables mutual TLS authentication for RadSec clients.
+//
+// The CommonName typically identifies the client (e.g., NAS hostname or identifier).
+// SAN support allows multiple identities in a single certificate.
+//
+// Parameters:
+//   - config: Client configuration (must set CommonName, CAKeyPath, CACertPath)
+//
+// Returns:
+//   - error: File I/O, CA loading, crypto generation, or encoding errors
+//
+// Output files:
+//   - {OutputDir}/client.crt: Client certificate (PEM, mode 0644)
+//   - {OutputDir}/client.key: Client private key (PEM, mode 0600)
+//
+// Side effects:
+//   - Creates OutputDir if it doesn't exist
+//   - Prints file paths and SAN info to stdout on success
+//
+// Example:
+//
+//	clientConfig := certgen.ClientConfig{
+//	    CertConfig: certgen.DefaultCertConfig(),
+//	    CAKeyPath: "/etc/toughradius/certs/ca.key",
+//	    CACertPath: "/etc/toughradius/certs/ca.crt",
+//	    OutputDir: "/etc/toughradius/clients",
+//	}
+//	clientConfig.CommonName = "nas-device-001"
+//	if err := certgen.GenerateClientCert(clientConfig); err != nil {
+//	    log.Fatalf("Client cert generation failed: %v", err)
+//	}
 func GenerateClientCert(config ClientConfig) error {
 	if err := os.MkdirAll(config.OutputDir, 0755); err != nil { //nolint:gosec // G301: 0755 is standard for certificate directories
 		return fmt.Errorf("create output directory failed: %w", err)

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -3,6 +3,18 @@
  * Licensed under the MIT License. See LICENSE file in the project root for details.
  */
 
+// Package common provides general-purpose utility functions for the ToughRADIUS server.
+//
+// This package includes essential helpers for:
+//   - UUID generation (both string and int64 snowflake IDs)
+//   - Cryptographic hashing with salt
+//   - Type checking and validation (empty values, slices, etc.)
+//   - JSON serialization utilities
+//   - File system operations
+//   - Conditional value selection
+//
+// These utilities are used throughout the codebase to avoid code duplication
+// and maintain consistency in common operations.
 package common
 
 import (
@@ -49,32 +61,82 @@ func GetSecretSalt() string {
 	return defaultSecretSalt
 }
 
-// FileExists checks if a file exists
+// FileExists checks whether a file exists at the specified path.
+// It returns false if the path points to a directory or if an error occurs.
+//
+// Parameters:
+//   - file: Absolute or relative path to check
+//
+// Returns:
+//   - bool: true if path exists and is a file, false otherwise
+//
+// Example:
+//
+//	if common.FileExists("/etc/toughradius/config.yml") {
+//	    // Load config
+//	}
 func FileExists(file string) bool {
 	info, err := os.Stat(file)
 	return err == nil && !info.IsDir()
 }
 
-// DirExists checks if a directory exists
+// DirExists checks whether a directory exists at the specified path.
+// It returns false if the path points to a file or if an error occurs.
+//
+// Parameters:
+//   - file: Absolute or relative path to check
+//
+// Returns:
+//   - bool: true if path exists and is a directory, false otherwise
 func DirExists(file string) bool {
 	info, err := os.Stat(file)
 	return err == nil && info.IsDir()
 }
 
-// Must panics if error is not nil
+// Must panics with a stack trace if the provided error is not nil.
+// This is intended for initialization code where errors are unrecoverable.
+//
+// Parameters:
+//   - err: Error to check (panics if non-nil)
+//
+// Example:
+//
+//	config, err := loadConfig()
+//	common.Must(err)  // Panic on config load failure
 func Must(err error) {
 	if err != nil {
 		panic(errors.WithStack(err))
 	}
 }
 
-// Must2 returns value and panics if error is not nil
+// Must2 returns the provided value if error is nil, otherwise panics.
+// This is a convenience wrapper for functions that return (value, error).
+//
+// Parameters:
+//   - v: Value to return if no error
+//   - err: Error to check (panics if non-nil)
+//
+// Returns:
+//   - interface{}: The input value v
+//
+// Example:
+//
+//	config := common.Must2(loadConfig()).(*Config)
 func Must2(v interface{}, err error) interface{} {
 	Must(err)
 	return v
 }
 
-// UUID generates a UUID string
+// UUID generates a time-based UUID string with cryptographic randomness.
+// The format is: {unix32bits}-{rand}-{rand}-{rand}-{rand}-{rand}
+//
+// Returns:
+//   - string: Hexadecimal UUID (e.g., "5f3a2b1c-1234-5678-90ab-cdef01234567")
+//
+// Example:
+//
+//	sessionID := common.UUID()
+//	log.Printf("Session ID: %s", sessionID)
 func UUID() string {
 	unix32bits := uint32(time.Now().UTC().Unix()) //nolint:gosec // G115: Unix timestamp fits in uint32 until 2106
 	buff := make([]byte, 12)
@@ -87,12 +149,41 @@ func UUID() string {
 
 var snowflakeNode, _ = snowflake.NewNode(int64(mathrand.Intn(1000))) //nolint:gosec // G404: weak random is acceptable for node ID
 
-// UUIDint64 generates a unique int64 ID using snowflake algorithm
+// UUIDint64 generates a unique 64-bit integer ID using the Snowflake algorithm.
+// This is suitable for distributed systems where sortable, collision-resistant IDs are needed.
+//
+// The generated ID is based on:
+//   - Timestamp (millisecond precision)
+//   - Node ID (randomly initialized at startup)
+//   - Sequence number (incremented for IDs within same millisecond)
+//
+// Returns:
+//   - int64: Unique snowflake ID (always positive)
+//
+// Example:
+//
+//	accountingID := common.UUIDint64()
+//	db.Model(&RadiusAccounting{ID: accountingID}).Create(...)
 func UUIDint64() int64 {
 	return snowflakeNode.Generate().Int64()
 }
 
-// Sha256HashWithSalt returns SHA256 hash with salt
+// Sha256HashWithSalt computes a SHA-256 hash of the source string combined with a salt.
+// This is used for password hashing and other cryptographic operations.
+//
+// Parameters:
+//   - src: Plain text to hash
+//   - salt: Salt value (should be unique per application/user)
+//
+// Returns:
+//   - string: Hexadecimal SHA-256 hash (64 characters)
+//
+// Example:
+//
+//	hashed := common.Sha256HashWithSalt(password, common.GetSecretSalt())
+//	if user.Password == hashed {
+//	    // Authentication success
+//	}
 func Sha256HashWithSalt(src string, salt string) string {
 	h := sha256_.New()
 	h.Write([]byte(src))
@@ -130,7 +221,21 @@ func ConstantTimeEquals(a, b string) bool {
 	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
 }
 
-// InSlice checks if a string is in a slice
+// InSlice checks whether a string value exists in a slice of strings.
+// Comparison is case-sensitive and uses exact matching.
+//
+// Parameters:
+//   - v: String value to search for
+//   - sl: Slice of strings to search in
+//
+// Returns:
+//   - bool: true if v is found in sl, false otherwise
+//
+// Example:
+//
+//	if common.InSlice("admin", user.Roles) {
+//	    // User has admin role
+//	}
 func InSlice(v string, sl []string) bool {
 	for _, vv := range sl {
 		if vv == v {
@@ -140,7 +245,21 @@ func InSlice(v string, sl []string) bool {
 	return false
 }
 
-// If returns trueVal if condition is true, otherwise falseVal
+// If implements a ternary operator pattern, returning one of two values based on a condition.
+// This is useful for inline conditional assignments.
+//
+// Parameters:
+//   - condition: Boolean expression to evaluate
+//   - trueVal: Value to return if condition is true
+//   - falseVal: Value to return if condition is false
+//
+// Returns:
+//   - interface{}: Either trueVal or falseVal (requires type assertion)
+//
+// Example:
+//
+//	logLevel := common.If(debug, "DEBUG", "INFO").(string)
+//	port := common.If(useSSL, 443, 80).(int)
 func If(condition bool, trueVal, falseVal interface{}) interface{} {
 	if condition {
 		return trueVal
@@ -148,7 +267,20 @@ func If(condition bool, trueVal, falseVal interface{}) interface{} {
 	return falseVal
 }
 
-// IfEmptyStr returns defval if src is empty string
+// IfEmptyStr returns a default value if the source string is empty.
+// This is a type-safe alternative to If() for string values.
+//
+// Parameters:
+//   - src: String to check
+//   - defval: Default value to return if src is empty
+//
+// Returns:
+//   - string: src if non-empty, otherwise defval
+//
+// Example:
+//
+//	hostname := common.IfEmptyStr(config.Hostname, "localhost")
+//	port := common.IfEmptyStr(config.Port, "1812")
 func IfEmptyStr(src string, defval string) string {
 	if src == "" {
 		return defval
@@ -156,13 +288,31 @@ func IfEmptyStr(src string, defval string) string {
 	return src
 }
 
-// IsEmpty checks if a value is empty or not.
-// A value is considered empty if
-// - integer, float: zero
-// - bool: false
-// - string, array: len() == 0
-// - slice, map: nil or len() == 0
-// - interface, pointer: nil or the referenced value is empty
+// IsEmpty checks whether a value is considered "empty" using Go semantics.
+// This uses reflection to handle different types uniformly.
+//
+// A value is considered empty if:
+//   - Numeric types (int, float, uint): zero value (0)
+//   - bool: false
+//   - string: empty string ("")
+//   - array/slice/map: nil or length == 0
+//   - pointer/interface: nil or referenced value is empty
+//   - time.Time: IsZero() returns true
+//
+// Parameters:
+//   - value: Value of any type to check
+//
+// Returns:
+//   - bool: true if value is empty by Go conventions
+//
+// Example:
+//
+//	if common.IsEmpty(user.Email) {
+//	    return errors.New("email required")
+//	}
+//	if !common.IsEmpty(config.Features) {
+//	    // Process features
+//	}
 func IsEmpty(value interface{}) bool {
 	v := reflect.ValueOf(value)
 	switch v.Kind() {
@@ -193,35 +343,117 @@ func IsEmpty(value interface{}) bool {
 	return false
 }
 
-// IsEmptyOrNA checks if value is empty or "N/A"
+// IsEmptyOrNA checks whether a string value is empty or the special "N/A" marker.
+// The check is performed after trimming whitespace.
+//
+// Parameters:
+//   - val: String value to check
+//
+// Returns:
+//   - bool: true if val is empty or equals "N/A" (after trimming)
+//
+// Example:
+//
+//	if common.IsEmptyOrNA(user.Phone) {
+//	    // Skip phone validation
+//	}
 func IsEmptyOrNA(val string) bool {
 	val = strings.TrimSpace(val)
 	return val == "" || val == NA
 }
 
-// IsNotEmptyAndNA checks if value is not empty and not "N/A"
+// IsNotEmptyAndNA checks whether a string value is non-empty and not the special "N/A" marker.
+// This is the logical inverse of IsEmptyOrNA.
+//
+// Parameters:
+//   - val: String value to check
+//
+// Returns:
+//   - bool: true if val is non-empty and not "N/A" (after trimming)
+//
+// Example:
+//
+//	if common.IsNotEmptyAndNA(user.Description) {
+//	    // Process description field
+//	}
 func IsNotEmptyAndNA(val string) bool {
 	val = strings.TrimSpace(val)
 	return strings.TrimSpace(val) != "" && val != NA
 }
 
-// JsonMarshal marshals value to JSON bytes
+// JsonMarshal is a thin wrapper around json.Marshal for consistency.
+// It serializes a Go value into JSON bytes.
+//
+// Parameters:
+//   - v: Value to marshal (any JSON-serializable type)
+//
+// Returns:
+//   - []byte: JSON-encoded bytes
+//   - error: Marshaling error (e.g., unsupported type, cyclic reference)
+//
+// Example:
+//
+//	data, err := common.JsonMarshal(config)
+//	if err != nil {
+//	    return err
+//	}
+//	os.WriteFile("config.json", data, 0644)
 func JsonMarshal(v interface{}) ([]byte, error) {
 	return json.Marshal(v)
 }
 
-// JsonUnmarshal unmarshals JSON bytes to value
+// JsonUnmarshal is a thin wrapper around json.Unmarshal for consistency.
+// It deserializes JSON bytes into a Go value.
+//
+// Parameters:
+//   - data: JSON-encoded bytes
+//   - v: Pointer to value to unmarshal into
+//
+// Returns:
+//   - error: Unmarshaling error (e.g., syntax error, type mismatch)
+//
+// Example:
+//
+//	var config AppConfig
+//	if err := common.JsonUnmarshal(data, &config); err != nil {
+//	    return fmt.Errorf("invalid config: %w", err)
+//	}
 func JsonUnmarshal(data []byte, v interface{}) error {
 	return json.Unmarshal(data, v)
 }
 
-// ToJson converts value to formatted JSON string
+// ToJson converts a Go value to a pretty-printed JSON string.
+// Indentation uses 2 spaces. This is intended for debugging and logging.
+//
+// Parameters:
+//   - v: Value to convert to JSON
+//
+// Returns:
+//   - string: Indented JSON string (errors are silently ignored, returns "")
+//
+// Example:
+//
+//	zap.L().Debug("user data", zap.String("json", common.ToJson(user)))
+//	fmt.Println(common.ToJson(config))  // Pretty-print config
 func ToJson(v interface{}) string {
 	bs, _ := json.MarshalIndent(v, "", "  ")
 	return string(bs)
 }
 
-// TrimBytes removes BOM from bytes
+// TrimBytes removes UTF-8 BOM (Byte Order Mark) from byte slices.
+// This is useful when reading files that may have been edited on Windows.
+//
+// Parameters:
+//   - src: Byte slice to clean (may contain BOM: 0xEF 0xBB 0xBF)
+//
+// Returns:
+//   - []byte: Cleaned byte slice with BOM removed
+//
+// Example:
+//
+//	data, _ := os.ReadFile("config.json")
+//	data = common.TrimBytes(data)  // Remove BOM if present
+//	json.Unmarshal(data, &config)
 func TrimBytes(src []byte) []byte {
 	s := bytes.ReplaceAll(src, []byte("\xef\xbb\xbf"), []byte(""))
 	return s

--- a/pkg/web/prequery.go
+++ b/pkg/web/prequery.go
@@ -9,6 +9,28 @@ import (
 	"gorm.io/gorm"
 )
 
+// PreQuery is a fluent query builder for constructing GORM queries from HTTP request parameters.
+// It provides a chainable API for building complex database queries with:
+//   - Date range filtering
+//   - Field equality matching
+//   - Keyword search across multiple fields
+//   - Sorting and pagination
+//   - Custom parameter mapping
+//
+// This is commonly used in REST API list endpoints to translate query parameters
+// into SQL WHERE clauses and ORDER BY statements.
+//
+// Example:
+//
+//	prequery := NewPreQuery(c).
+//	    DefaultOrderBy("created_at DESC").
+//	    DateRange("dateRange", "created_at", startTime, endTime).
+//	    KeyFields("username", "email").
+//	    EqualFields("status")
+//
+//	var users []User
+//	query := prequery.Query(db.Model(&User{}))
+//	query.Find(&users)
 type PreQuery struct {
 	context          echo.Context
 	defaultOrderby   string
@@ -20,6 +42,21 @@ type PreQuery struct {
 	form             *WebForm
 }
 
+// NewPreQuery creates a new PreQuery instance from an Echo context.
+// This initializes the query builder with request parameters from the HTTP context.
+//
+// Parameters:
+//   - c: Echo context containing query/form parameters
+//
+// Returns:
+//   - *PreQuery: Chainable query builder instance
+//
+// Example:
+//
+//	func ListUsers(c echo.Context) error {
+//	    prequery := web.NewPreQuery(c)
+//	    // Chain query methods...
+//	}
 func NewPreQuery(c echo.Context) *PreQuery {
 	return &PreQuery{
 		context: c,
@@ -28,11 +65,39 @@ func NewPreQuery(c echo.Context) *PreQuery {
 	}
 }
 
+// DefaultOrderBy sets the default sort order when no sort parameter is provided in the request.
+// The sort field should be a valid database column name with optional direction.
+//
+// Parameters:
+//   - fd: Default ORDER BY clause (e.g., "id DESC", "created_at ASC")
+//
+// Returns:
+//   - *PreQuery: Self for method chaining
+//
+// Example:
+//
+//	prequery.DefaultOrderBy("created_at DESC")
 func (p *PreQuery) DefaultOrderBy(fd string) *PreQuery {
 	p.defaultOrderby = fd
 	return p
 }
 
+// DateRange adds a date range filter to the query from a JSON-encoded query parameter.
+// The query parameter should contain a DateRange JSON object with "start" and "end" fields.
+//
+// Parameters:
+//   - queryfd: Name of query parameter containing JSON date range (e.g., "dateRange")
+//   - timefd: Database column name for date/time filtering (e.g., "created_at")
+//   - defaltStart: Default start time if not provided in request
+//   - defaultEnd: Default end time if not provided in request
+//
+// Returns:
+//   - *PreQuery: Self for method chaining
+//
+// Example:
+//
+//	// Request: ?dateRange={"start":"2024-01-01 00:00:00","end":"2024-12-31 23:59:59"}
+//	prequery.DateRange("dateRange", "created_at", time.Now().AddDate(0, -1, 0), time.Now())
 func (p *PreQuery) DateRange(queryfd, timefd string, defaltStart time.Time, defaultEnd time.Time) *PreQuery {
 	daterange, err := p.form.GetDateRange(queryfd)
 	if err == nil {
@@ -48,6 +113,23 @@ func (p *PreQuery) DateRange(queryfd, timefd string, defaltStart time.Time, defa
 	return p
 }
 
+// DateRange2 adds a date range filter using separate start/end query parameters.
+// This is an alternative to DateRange when the client sends separate parameters instead of JSON.
+//
+// Parameters:
+//   - startfd: Query parameter name for start date (e.g., "start_time")
+//   - endfd: Query parameter name for end date (e.g., "end_time")
+//   - timefd: Database column name for date/time filtering
+//   - defaltStart: Default start time if startfd is missing
+//   - defaultEnd: Default end time if endfd is missing
+//
+// Returns:
+//   - *PreQuery: Self for method chaining
+//
+// Example:
+//
+//	// Request: ?start_time=2024-01-01&end_time=2024-12-31
+//	prequery.DateRange2("start_time", "end_time", "created_at", yesterday, now)
 func (p *PreQuery) DateRange2(startfd, endfd, timefd string, defaltStart time.Time, defaultEnd time.Time) *PreQuery {
 	p.dateRange = DateRange{
 		Start: p.form.GetVal2(startfd, defaltStart.Format("2006-01-02 15:04:05")),
@@ -57,16 +139,58 @@ func (p *PreQuery) DateRange2(startfd, endfd, timefd string, defaltStart time.Ti
 	return p
 }
 
+// EqualFields specifies which filter parameters should use exact matching (=) instead of LIKE.
+// By default, filter parameters use LIKE with wildcard matching.
+//
+// Parameters:
+//   - fd: Field names that require exact equality matching
+//
+// Returns:
+//   - *PreQuery: Self for method chaining
+//
+// Example:
+//
+//	// status and user_id will use "=" while other fields use "LIKE"
+//	prequery.EqualFields("status", "user_id")
 func (p *PreQuery) EqualFields(fd ...string) *PreQuery {
 	p.equalFieldds = fd
 	return p
 }
 
+// KeyFields specifies which database columns should be searched when a "keyword" query parameter is present.
+// The keyword will be matched against all specified fields using LIKE with OR logic.
+//
+// Parameters:
+//   - fd: Database column names to search (e.g., "username", "email", "phone")
+//
+// Returns:
+//   - *PreQuery: Self for method chaining
+//
+// Example:
+//
+//	// Request: ?keyword=john
+//	// SQL: WHERE username LIKE '%john%' OR email LIKE '%john%'
+//	prequery.KeyFields("username", "email")
 func (p *PreQuery) KeyFields(fd ...string) *PreQuery {
 	p.keyfilterFieldds = fd
 	return p
 }
 
+// QueryField maps a specific query parameter to a database column for filtering.
+// This allows custom parameter-to-column mapping beyond the automatic filtering.
+//
+// Parameters:
+//   - column: Database column name (e.g., "user_id")
+//   - qfield: Query parameter name (e.g., "userId")
+//
+// Returns:
+//   - *PreQuery: Self for method chaining
+//
+// Example:
+//
+//	// Request: ?node_id=123
+//	// SQL: WHERE nas_node_id = '123'
+//	prequery.QueryField("nas_node_id", "node_id")
 func (p *PreQuery) QueryField(column, qfield string) *PreQuery {
 	value := p.form.GetVal(qfield)
 	if value != "" {
@@ -75,11 +199,51 @@ func (p *PreQuery) QueryField(column, qfield string) *PreQuery {
 	return p
 }
 
+// SetParam manually sets a filter parameter that will be applied as an equality condition.
+// This is useful for programmatically adding filters beyond HTTP request parameters.
+//
+// Parameters:
+//   - key: Database column name
+//   - value: Value to match (will be used in WHERE key = value)
+//
+// Returns:
+//   - *PreQuery: Self for method chaining
+//
+// Example:
+//
+//	// Force filter by current user's node
+//	prequery.SetParam("node_id", currentUser.NodeID)
 func (p *PreQuery) SetParam(key string, value interface{}) *PreQuery {
 	p.params[key] = value
 	return p
 }
 
+// Query applies all configured filters to a GORM query and returns the modified query.
+// This is the final step in the builder chain that constructs the actual SQL WHERE and ORDER BY clauses.
+//
+// The method processes:
+//  1. Sorting from "sort" query parameter (or default sort if not provided)
+//  2. Date range filtering (if configured via DateRange/DateRange2)
+//  3. Exact match filters from "equal" query parameters
+//  4. Custom parameters from SetParam and QueryField
+//  5. Wildcard filters from "filter" query parameters
+//  6. Keyword search across KeyFields (if "keyword" parameter present)
+//
+// Parameters:
+//   - query: Base GORM query to modify
+//
+// Returns:
+//   - *gorm.DB: Modified query with WHERE and ORDER BY clauses applied
+//
+// Example:
+//
+//	prequery := NewPreQuery(c).
+//	    DefaultOrderBy("id DESC").
+//	    KeyFields("username", "email")
+//
+//	var users []User
+//	db := prequery.Query(app.GDB().Model(&User{}))
+//	db.Find(&users)
 func (p *PreQuery) Query(query *gorm.DB) *gorm.DB {
 	if len(ParseSortMap(p.context)) == 0 {
 		query = query.Order(p.defaultOrderby)


### PR DESCRIPTION
## Summary
- Add comprehensive GoDoc comments for profile cache lifecycle and cache-aside behavior.
- Add detailed metric API comments for RADIUS counters and usage patterns.
- Add package/API documentation for certificate generation utilities.
- Improve docs in common helpers and web prequery utilities.

## Files changed
- internal/app/profile_cache.go
- internal/app/radius_metrics.go
- pkg/certgen/certgen.go
- pkg/common/common.go
- pkg/web/prequery.go

## Notes
- These changes are documentation-focused and intended to improve maintainability and API discoverability.
- No intentional runtime behavior changes were introduced.
