### PR TITLE
fix: guard nil-pointer dereferences in EAP send and ProfileCache.Get

### DIFF
--- a/internal/app/profile_cache.go
+++ b/internal/app/profile_cache.go
@@ -95,21 +95,22 @@ func NewProfileCache(db *gorm.DB, ttl time.Duration) *ProfileCache {
 //	    return fmt.Errorf("profile not found: %w", err)
 //	}
 func (pc *ProfileCache) Get(profileID int64) (*domain.RadiusProfile, error) {
-	if pc.db == nil {
-		return nil, errors.New("profile cache: database connection is nil")
-	}
-
 	// Try cache first
 	pc.mu.RLock()
 	entry, found := pc.cache[profileID]
 	pc.mu.RUnlock()
 
 	if found && time.Now().Before(entry.expiresAt) {
-		// Cache hit and not expired
+		// Cache hit and not expired: serve it even if no DB handle is configured.
 		return entry.profile, nil
 	}
 
-	// Cache miss or expired, fetch from database
+	// Cache miss or expired: a database read is required, so a DB handle must exist.
+	if pc.db == nil {
+		return nil, errors.New("profile cache: database connection is nil")
+	}
+
+	// Fetch from database
 	var profile domain.RadiusProfile
 	if err := pc.db.Where("id = ?", profileID).First(&profile).Error; err != nil {
 		return nil, err

--- a/internal/app/profile_cache.go
+++ b/internal/app/profile_cache.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"sync"
 	"time"
 
@@ -94,6 +95,10 @@ func NewProfileCache(db *gorm.DB, ttl time.Duration) *ProfileCache {
 //	    return fmt.Errorf("profile not found: %w", err)
 //	}
 func (pc *ProfileCache) Get(profileID int64) (*domain.RadiusProfile, error) {
+	if pc.db == nil {
+		return nil, errors.New("profile cache: database connection is nil")
+	}
+
 	// Try cache first
 	pc.mu.RLock()
 	entry, found := pc.cache[profileID]

--- a/internal/app/profile_cache_test.go
+++ b/internal/app/profile_cache_test.go
@@ -333,10 +333,9 @@ func TestProfileCache_GetWithNilDB(t *testing.T) {
 		stopClean: make(chan struct{}),
 	}
 
-	// Should panic when trying to get from nil DB (cache miss)
-	assert.Panics(t, func() {
-		_, _ = cache.Get(1) //nolint:errcheck
-	})
+	// Should return an error when the database connection is nil (cache miss).
+	_, err := cache.Get(1)
+	assert.Error(t, err)
 }
 
 func TestProfileCache_TTLExpiration(t *testing.T) {

--- a/internal/app/profile_cache_test.go
+++ b/internal/app/profile_cache_test.go
@@ -333,9 +333,17 @@ func TestProfileCache_GetWithNilDB(t *testing.T) {
 		stopClean: make(chan struct{}),
 	}
 
-	// Should return an error when the database connection is nil (cache miss).
+	// Cache miss with a nil DB must error instead of dereferencing pc.db.
 	_, err := cache.Get(1)
 	assert.Error(t, err)
+
+	// A populated, unexpired entry must still be served from memory even when
+	// no DB handle is configured (the nil-DB guard only applies to cache misses).
+	cached := &domain.RadiusProfile{ID: 1, Name: "cached"}
+	cache.Set(1, cached)
+	got, err := cache.Get(1)
+	assert.NoError(t, err)
+	assert.Equal(t, cached, got)
 }
 
 func TestProfileCache_TTLExpiration(t *testing.T) {

--- a/internal/radiusd/plugins/eap/coordinator.go
+++ b/internal/radiusd/plugins/eap/coordinator.go
@@ -166,7 +166,10 @@ func (c *Coordinator) handleChallengeResponse(ctx *EAPContext) (bool, bool, erro
 
 // SendEAPSuccess Send EAP-Success response
 func (c *Coordinator) SendEAPSuccess(w radius.ResponseWriter, r *radius.Request, response *radius.Packet, secret string) error {
-	eapMsg, _ := ParseEAPMessage(r.Packet)
+	eapMsg, err := ParseEAPMessage(r.Packet)
+	if err != nil || eapMsg == nil {
+		return fmt.Errorf("cannot send EAP-Success: failed to parse EAP message: %w", err)
+	}
 	identifier := eapMsg.Identifier
 
 	// Create the EAP-Success message
@@ -186,7 +189,10 @@ func (c *Coordinator) SendEAPSuccess(w radius.ResponseWriter, r *radius.Request,
 
 // SendEAPFailure Send EAP-Failure response
 func (c *Coordinator) SendEAPFailure(w radius.ResponseWriter, r *radius.Request, secret string, reason error) error {
-	eapMsg, _ := ParseEAPMessage(r.Packet)
+	eapMsg, err := ParseEAPMessage(r.Packet)
+	if err != nil || eapMsg == nil {
+		return fmt.Errorf("cannot send EAP-Failure: failed to parse EAP message: %w", err)
+	}
 	identifier := eapMsg.Identifier
 
 	// Create the EAP-Failure message


### PR DESCRIPTION
## 背景

运行 `go test ./...` 时，`internal/radiusd` 与 `internal/app` 两个包会卡到 10 分钟测试超时（每个约 600s）。根因相同：**nil 指针解引用**。

> 注：当前环境的 Go 1.26.3 (darwin/arm64) 工具链会把 nil 指针解引用变成死循环（busy-loop）而非可恢复的 panic（已用最小示例复现），从而把"会崩溃"的代码变成"挂死"。本 PR 修复的是代码中真实存在的 nil 解引用，同时也规避了该工具链行为。

## 修改

- **`internal/radiusd/plugins/eap/coordinator.go`** — `SendEAPSuccess` / `SendEAPFailure` 之前忽略了 `ParseEAPMessage` 的错误，在请求不含 EAP-Message 属性时直接对 nil `*EAPMessage` 取 `.Identifier`。现在解析失败时返回错误。这是生产路径上真实可达的 bug。
- **`internal/app/profile_cache.go`** — `ProfileCache.Get` 在 `db == nil` 时会解引用 nil `*gorm.DB`。现在返回错误；对应测试 `profile_cache_test.go` 由 `assert.Panics` 改为 `assert.Error`。

## 验证

- `go test ./...` 全部通过（`internal/radiusd` 从 601s 超时降至约 8.8s）。
- `go vet ./internal/app/ ./internal/radiusd/plugins/eap/` 干净。