### PR TITLE
fix(web): correct interpolation in system config success message

### DIFF
--- a/web/src/i18n/en-US.ts
+++ b/web/src/i18n/en-US.ts
@@ -557,7 +557,7 @@ const customEnglishMessages: TranslationMessages = {
       loading_message: 'Loading configuration, please wait...',
       loading_detail: 'Fetching configuration definitions and current values from backend API.',
       no_config_warning: 'No configuration items found. Please check if backend API is working properly.',
-      success_message: 'Successfully loaded {schemaCount} configuration definitions, {configCount} configuration values',
+      success_message: 'Successfully loaded %{schemaCount} configuration definitions, %{configCount} configuration values',
       groups: {
         radius: {
           title: 'RADIUS Configuration',

--- a/web/src/i18n/zh-CN.ts
+++ b/web/src/i18n/zh-CN.ts
@@ -557,7 +557,7 @@ const customChineseMessages: TranslationMessages = {
       loading_message: '加载配置中，请稍候...',
       loading_detail: '正在从后端API获取配置定义和当前配置值。',
       no_config_warning: '没有找到配置项，请检查后端API是否正常工作。',
-      success_message: '成功加载 {schemaCount} 个配置定义，{configCount} 个配置值',
+      success_message: '成功加载 %{schemaCount} 个配置定义，%{configCount} 个配置值',
       groups: {
         radius: {
           title: 'RADIUS 配置',


### PR DESCRIPTION
## 问题

系统配置页面顶部的成功提示直接显示了字面量占位符:

> ✓ 成功加载 **{schemaCount}** 个配置定义，**{configCount}** 个配置值

而不是实际数字。

## 原因

项目的 i18n 使用 `ra-i18n-polyglot`,其插值语法为 `%{var}`。`pages.system_config.success_message` 这条文案误用了 `{var}`(缺少 `%`),因此 polyglot 无法识别并按原样渲染。仓库内其他文案(如 `%{success}`、`%{username}`)均为正确写法,仅此一处遗漏。

## 修改

zh-CN.ts 与 en-US.ts 各一处,改为 `%{schemaCount}` / `%{configCount}`:

```diff
- 成功加载 {schemaCount} 个配置定义，{configCount} 个配置值
+ 成功加载 %{schemaCount} 个配置定义，%{configCount} 个配置值
```

## 验证

- 已扫描两个语言文件,确认无其他同类 `{var}` 漏写。
- `npx tsc --noEmit` 通过。

修复后正确显示「成功加载 9 个配置定义，9 个配置值」。

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>