### PR TITLE
test: PostgreSQL-backed integration suite + dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+// ToughRADIUS development container.
+//
+// Provides a reproducible environment (Go + Node + PostgreSQL) for building the
+// backend/frontend and running the container-backed integration suite. The
+// PostgreSQL "db" service is wired via TEST_DATABASE_* so the integration tests
+// run out of the box:
+//
+//   go test -tags=integration ./test/integration/...
+//
+{
+  "name": "ToughRADIUS Dev",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspaces/toughradius",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20"
+    }
+  },
+  // Web/Admin API (1816) and Vite dev server (5173/3000).
+  "forwardPorts": [1816, 5173, 3000],
+  "postCreateCommand": "go mod download && (cd web && npm ci)",
+  "remoteUser": "vscode",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "golang.go",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode"
+      ]
+    }
+  }
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,37 @@
+# Compose stack backing the ToughRADIUS dev container (see devcontainer.json).
+# `app` is the workspace container (Go provided by the base image, Node added via
+# devcontainer feature); `db` is a PostgreSQL instance the integration suite
+# connects to through the TEST_DATABASE_* environment variables.
+services:
+  app:
+    image: mcr.microsoft.com/devcontainers/go:1-bookworm
+    volumes:
+      - ..:/workspaces/toughradius:cached
+    command: sleep infinity
+    environment:
+      TEST_DATABASE_HOST: db
+      TEST_DATABASE_PORT: "5432"
+      TEST_DATABASE_USER: toughradius
+      TEST_DATABASE_PASSWORD: toughradius
+      TEST_DATABASE_NAME: postgres
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: toughradius
+      POSTGRES_PASSWORD: toughradius
+      POSTGRES_DB: postgres
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U toughradius -d postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+volumes:
+  pgdata:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,61 @@ jobs:
           fail_ci_if_error: false
         continue-on-error: true
 
-  build:
+  integration:
+    name: Integration (PostgreSQL)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: toughradius
+          POSTGRES_PASSWORD: toughradius
+          POSTGRES_DB: postgres
+        ports:
+          - 15432:5432
+        options: >-
+          --health-cmd "pg_isready -U toughradius -d postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+
+      - name: Build Frontend (required for go:embed)
+        working-directory: ./web
+        run: |
+          npm ci
+          npm run build
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Run PostgreSQL integration tests
+        env:
+          TEST_DATABASE_HOST: 127.0.0.1
+          TEST_DATABASE_PORT: '15432'
+          TEST_DATABASE_USER: toughradius
+          TEST_DATABASE_PASSWORD: toughradius
+          TEST_DATABASE_NAME: postgres
+          INTEGRATION_REQUIRED: '1'
+        run: go test -tags=integration -count=1 -v ./test/integration/...
+
+
     name: Build
     runs-on: ubuntu-latest
     needs: [lint, test]

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ __debug_bin
 /.fleet/
 /testdatas/
 /toughradius.yml
+/.toughradius/
 /.env
 /tmp/
 log_info.log

--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -1,0 +1,31 @@
+// Project tasks configuration. See https://zed.dev/docs/tasks for documentation.
+[
+  {
+    // Start the ToughRADIUS backend (Web/Admin API + RADIUS auth/acct + RadSec).
+    // SQLite is supported because CGO is disabled.
+    "label": "Dev: Backend (go run)",
+    "command": "go run main.go -c toughradius.yml",
+    "env": { "CGO_ENABLED": "0" },
+    "cwd": "$ZED_WORKTREE_ROOT",
+    "use_new_terminal": false,
+    "allow_concurrent_runs": false,
+    "reveal": "always",
+    "reveal_target": "dock",
+    "hide": "never",
+    "shell": "system",
+    "save": "all"
+  },
+  {
+    // Start the React Admin frontend dev server (Vite, hot reload).
+    "label": "Dev: Frontend (vite)",
+    "command": "npm run dev",
+    "cwd": "$ZED_WORKTREE_ROOT/web",
+    "use_new_terminal": false,
+    "allow_concurrent_runs": false,
+    "reveal": "always",
+    "reveal_target": "dock",
+    "hide": "never",
+    "shell": "system",
+    "save": "all"
+  }
+]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build build-backend buildf runs runf dev clean test initdb killfs version lint ci setup-hooks
+.PHONY: help build build-backend buildf runs runf dev clean test test-integration test-integration-pg initdb killfs version lint ci setup-hooks
 
 # 版本信息
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "develop")
@@ -139,6 +139,29 @@ test:
 test-integration:
 	@echo "🧪 运行集成测试..."
 	CGO_ENABLED=0 go test -v ./internal/radiusd/... -run TestRadiusIntegration
+
+# 运行基于容器 PostgreSQL 的集成测试（真实数据库）
+# 自动拉起 docker-compose.test.yml 中的 Postgres，运行 //go:build integration 套件，最后清理。
+test-integration-pg:
+	@echo "🐘 启动 PostgreSQL 测试容器并运行集成测试..."
+	@set -e; \
+	COMPOSE="docker compose -p toughradius-it -f docker-compose.test.yml"; \
+	cleanup() { echo "🧹 清理测试容器..."; $$COMPOSE down -v >/dev/null 2>&1 || true; }; \
+	trap cleanup EXIT; \
+	$$COMPOSE up -d; \
+	echo "⏳ 等待 Postgres 健康检查..."; \
+	for i in $$(seq 1 30); do \
+		status=$$($$COMPOSE ps --format '{{.Health}}' 2>/dev/null || true); \
+		[ "$$status" = "healthy" ] && break; \
+		sleep 2; \
+	done; \
+	TEST_DATABASE_HOST=127.0.0.1 \
+	TEST_DATABASE_PORT=15432 \
+	TEST_DATABASE_USER=toughradius \
+	TEST_DATABASE_PASSWORD=toughradius \
+	TEST_DATABASE_NAME=postgres \
+	INTEGRATION_REQUIRED=1 \
+	CGO_ENABLED=0 go test -tags=integration -count=1 -v ./test/integration/...
 
 # 代码检查
 lint:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,27 @@
+# PostgreSQL service for running the container-backed integration test suite.
+#
+# Usage:
+#   docker compose -f docker-compose.test.yml up -d
+#   TEST_DATABASE_HOST=127.0.0.1 TEST_DATABASE_PORT=15432 \
+#   TEST_DATABASE_USER=toughradius TEST_DATABASE_PASSWORD=toughradius \
+#   TEST_DATABASE_NAME=postgres \
+#   go test -tags=integration ./test/integration/...
+#   docker compose -f docker-compose.test.yml down -v
+#
+# The `make test-integration-pg` target automates the full lifecycle.
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: toughradius
+      POSTGRES_PASSWORD: toughradius
+      POSTGRES_DB: postgres
+    ports:
+      - "15432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U toughradius -d postgres"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+    tmpfs:
+      - /var/lib/postgresql/data

--- a/test/integration/adminapi_test.go
+++ b/test/integration/adminapi_test.go
@@ -1,0 +1,143 @@
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/talkincode/toughradius/v9/internal/domain"
+	"github.com/talkincode/toughradius/v9/pkg/common"
+)
+
+// uniqueSuffix returns a per-test suffix so tests stay isolated on the shared
+// database without truncation or parallel-unsafe global resets.
+func uniqueSuffix() string {
+	return fmt.Sprintf("%d", time.Now().UnixNano())
+}
+
+func seedProfile(t *testing.T, name string) int64 {
+	t.Helper()
+	p := &domain.RadiusProfile{
+		ID:        common.UUIDint64(),
+		Name:      name,
+		Status:    common.ENABLED,
+		AddrPool:  "it-pool",
+		ActiveNum: 1,
+		UpRate:    1000,
+		DownRate:  2000,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	require.NoError(t, h.appCtx.DB().Create(p).Error)
+	return p.ID
+}
+
+// TestSystemBackupRestoreRoundTrip exercises the real /system/backup and
+// /system/restore HTTP endpoints against PostgreSQL and proves the security
+// behaviour we rely on: backups carry plaintext RADIUS passwords (unlike the
+// list API, which strips them) and restore reinstates a deleted user with the
+// password intact via an ON CONFLICT upsert on real Postgres.
+func TestSystemBackupRestoreRoundTrip(t *testing.T) {
+	c := newAPIClient(t)
+	suffix := uniqueSuffix()
+	profileID := seedProfile(t, "it-profile-"+suffix)
+
+	username := "it-backup-" + suffix
+	const password = "secret-Pw-123"
+	user := &domain.RadiusUser{
+		ID:         common.UUIDint64(),
+		ProfileId:  profileID,
+		Username:   username,
+		Password:   password,
+		Status:     common.ENABLED,
+		ExpireTime: time.Now().AddDate(1, 0, 0),
+		CreatedAt:  time.Now(),
+		UpdatedAt:  time.Now(),
+	}
+	require.NoError(t, h.appCtx.DB().Create(user).Error)
+
+	// 1) Download a backup over HTTP and confirm the plaintext password is present.
+	// The endpoint streams the bare SystemBackup JSON (no {"data":...} envelope).
+	status, backupBytes := c.get(t, "/api/v1/system/backup")
+	require.Equalf(t, http.StatusOK, status, "backup body: %s", string(backupBytes))
+
+	var backup struct {
+		Version string              `json:"version"`
+		Users   []domain.RadiusUser `json:"users"`
+	}
+	require.NoErrorf(t, json.Unmarshal(backupBytes, &backup), "backup not JSON: %s", string(backupBytes))
+	require.Equal(t, "9.0", backup.Version)
+	require.True(t, containsUserWithPassword(backup.Users, username, password),
+		"backup must contain %s with its plaintext password", username)
+
+	// 2) Delete the user directly, simulating data loss.
+	require.NoError(t, h.appCtx.DB().Where("username = ?", username).Delete(&domain.RadiusUser{}).Error)
+	var count int64
+	require.NoError(t, h.appCtx.DB().Model(&domain.RadiusUser{}).Where("username = ?", username).Count(&count).Error)
+	require.Equal(t, int64(0), count)
+
+	// 3) Restore the backup over HTTP (multipart upload of the bare backup JSON).
+	status, body := c.postMultipart(t, "/api/v1/system/restore", "backup.json", backupBytes)
+	require.Equalf(t, http.StatusOK, status, "restore body: %s", string(body))
+
+	// 4) The user is back with its password preserved.
+	var restored domain.RadiusUser
+	require.NoError(t, h.appCtx.DB().Where("username = ?", username).First(&restored).Error)
+	assert.Equal(t, password, restored.Password, "restore must preserve the plaintext password")
+}
+
+// TestSystemRestoreRejectsNonBackup ensures uploading a non-backup file (e.g. a
+// CSV meant for user import) is rejected with a clear error, mirroring the
+// real-world confusion between the restore and import features.
+func TestSystemRestoreRejectsNonBackup(t *testing.T) {
+	c := newAPIClient(t)
+	csv := csvRow("username", "password", "profile_id") + csvRow("x", "y", "1")
+	status, body := c.postMultipart(t, "/api/v1/system/restore", "users.csv", []byte(csv))
+	require.Equalf(t, http.StatusBadRequest, status, "expected 400, body: %s", string(body))
+	assert.Contains(t, string(body), "INVALID_BACKUP")
+}
+
+// TestUserImportCSV exercises the real /users/import endpoint with a multipart
+// CSV upload against PostgreSQL and verifies the row lands in the database.
+func TestUserImportCSV(t *testing.T) {
+	c := newAPIClient(t)
+	suffix := uniqueSuffix()
+	profileID := seedProfile(t, "it-import-profile-"+suffix)
+
+	username := "it-import-" + suffix
+	csv := csvRow("username", "password", "profile_id") +
+		csvRow(username, "import-Pw-123", fmt.Sprintf("%d", profileID))
+
+	status, body := c.postMultipart(t, "/api/v1/users/import", "users.csv", []byte(csv))
+	require.Equalf(t, http.StatusOK, status, "import body: %s", string(body))
+
+	var result struct {
+		Total   int `json:"total"`
+		Success int `json:"success"`
+		Failed  int `json:"failed"`
+	}
+	unwrapData(t, body, &result)
+	assert.Equal(t, 1, result.Total)
+	assert.Equalf(t, 1, result.Success, "import should succeed, body: %s", string(body))
+
+	var created domain.RadiusUser
+	require.NoError(t, h.appCtx.DB().Where("username = ?", username).First(&created).Error)
+	assert.Equal(t, "import-Pw-123", created.Password)
+	assert.Equal(t, profileID, created.ProfileId)
+}
+
+func containsUserWithPassword(users []domain.RadiusUser, username, password string) bool {
+	for _, u := range users {
+		if u.Username == username && u.Password == password {
+			return true
+		}
+	}
+	return false
+}

--- a/test/integration/client_test.go
+++ b/test/integration/client_test.go
@@ -1,0 +1,106 @@
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// apiClient is a thin HTTP client for the booted admin server that carries a
+// JWT obtained via the real /auth/login endpoint, so every request flows
+// through the production middleware chain (JWT auth, routing, binding).
+type apiClient struct {
+	base  string
+	token string
+	http  *http.Client
+}
+
+func newAPIClient(t *testing.T) *apiClient {
+	t.Helper()
+	c := &apiClient{base: h.webBaseURL, http: &http.Client{}}
+	c.login(t, h.adminUser, h.adminPass)
+	return c
+}
+
+func (c *apiClient) login(t *testing.T, username, password string) {
+	t.Helper()
+	body, _ := json.Marshal(map[string]string{"username": username, "password": password})
+	resp, err := c.http.Post(c.base+"/api/v1/auth/login", "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equalf(t, http.StatusOK, resp.StatusCode, "login should succeed")
+
+	var payload struct {
+		Data struct {
+			Token string `json:"token"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&payload))
+	require.NotEmpty(t, payload.Data.Token, "login must return a token")
+	c.token = payload.Data.Token
+}
+
+// getJSON performs an authenticated GET and returns the raw response body.
+func (c *apiClient) get(t *testing.T, path string) (int, []byte) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, c.base+path, nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	resp, err := c.http.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	data, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode, data
+}
+
+// postMultipart uploads a single file field ("upload") and returns the response.
+func (c *apiClient) postMultipart(t *testing.T, path, filename string, content []byte) (int, []byte) {
+	t.Helper()
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	fw, err := w.CreateFormFile("upload", filename)
+	require.NoError(t, err)
+	_, err = fw.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	req, err := http.NewRequest(http.MethodPost, c.base+path, &buf)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	resp, err := c.http.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	data, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode, data
+}
+
+// unwrapData decodes the {"data": ...} envelope into v.
+func unwrapData(t *testing.T, body []byte, v interface{}) {
+	t.Helper()
+	var env struct {
+		Data json.RawMessage `json:"data"`
+	}
+	require.NoErrorf(t, json.Unmarshal(body, &env), "response not JSON: %s", string(body))
+	require.NoError(t, json.Unmarshal(env.Data, v))
+}
+
+func csvRow(values ...string) string {
+	out := ""
+	for i, v := range values {
+		if i > 0 {
+			out += ","
+		}
+		out += v
+	}
+	return out + "\n"
+}

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -1,0 +1,348 @@
+//go:build integration
+
+// Package integration contains container-backed integration tests that exercise
+// ToughRADIUS against a real PostgreSQL database (the production default), which
+// the unit-test suite never covers because it uses in-memory SQLite.
+//
+// These tests are gated behind the `integration` build tag and require a running
+// PostgreSQL instance described by TEST_DATABASE_* environment variables. Use the
+// `make test-integration-pg` target or the provided docker-compose.test.yml to
+// provision one. When the environment is absent the suite skips locally, but
+// fails hard in CI (or when INTEGRATION_REQUIRED=1) so a misconfigured pipeline
+// can never report a false-green.
+package integration
+
+import (
+	"database/sql"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "github.com/jackc/pgx/v5/stdlib" // database/sql driver "pgx" for CREATE/DROP DATABASE
+
+	"github.com/talkincode/toughradius/v9/config"
+	"github.com/talkincode/toughradius/v9/internal/adminapi"
+	"github.com/talkincode/toughradius/v9/internal/app"
+	"github.com/talkincode/toughradius/v9/internal/domain"
+	"github.com/talkincode/toughradius/v9/internal/radiusd"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins"
+	parsers "github.com/talkincode/toughradius/v9/internal/radiusd/plugins/vendorparsers/parsers"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/registry"
+	"github.com/talkincode/toughradius/v9/internal/webserver"
+	"github.com/talkincode/toughradius/v9/pkg/common"
+)
+
+// harness holds the shared state for the whole integration run: one freshly
+// created PostgreSQL database, one booted admin HTTP server, and one running
+// RADIUS auth/acct server pair. Individual tests use unique identifiers to stay
+// isolated on the shared database rather than re-initialising the application.
+type harness struct {
+	cfg        *config.AppConfig
+	appCtx     *app.Application
+	radiusSvc  *radiusd.RadiusService
+	webBaseURL string
+	adminUser  string
+	adminPass  string
+	dbName     string
+	adminDSN   string // DSN to the server's maintenance ("postgres") database
+}
+
+var h *harness
+
+// pgEnv describes the PostgreSQL connection provided by the environment.
+type pgEnv struct {
+	host, user, password, adminDB string
+	port                          int
+}
+
+// readPGEnv loads TEST_DATABASE_* settings. It returns ok=false when the
+// environment is not configured; callers decide whether that is a skip or a
+// hard failure.
+func readPGEnv() (pgEnv, bool) {
+	host := os.Getenv("TEST_DATABASE_HOST")
+	portStr := os.Getenv("TEST_DATABASE_PORT")
+	user := os.Getenv("TEST_DATABASE_USER")
+	if host == "" || portStr == "" || user == "" {
+		return pgEnv{}, false
+	}
+	port, err := net.LookupPort("tcp", portStr)
+	if err != nil {
+		return pgEnv{}, false
+	}
+	adminDB := os.Getenv("TEST_DATABASE_NAME")
+	if adminDB == "" {
+		adminDB = "postgres"
+	}
+	return pgEnv{
+		host:     host,
+		port:     port,
+		user:     user,
+		password: os.Getenv("TEST_DATABASE_PASSWORD"),
+		adminDB:  adminDB,
+	}, true
+}
+
+// integrationRequired reports whether a missing test database should fail the
+// run instead of skipping it. This prevents false-green CI.
+func integrationRequired() bool {
+	return os.Getenv("CI") == "true" || os.Getenv("INTEGRATION_REQUIRED") == "1"
+}
+
+func TestMain(m *testing.M) {
+	env, ok := readPGEnv()
+	if !ok {
+		if integrationRequired() {
+			fmt.Fprintln(os.Stderr, "integration tests required but TEST_DATABASE_* is not configured")
+			os.Exit(1)
+		}
+		fmt.Fprintln(os.Stderr, "skipping integration tests: TEST_DATABASE_* not configured")
+		os.Exit(0)
+	}
+
+	code, err := runSuite(env, m)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "integration suite setup failed: %v\n", err)
+		os.Exit(1)
+	}
+	os.Exit(code)
+}
+
+// runSuite provisions a unique database, boots the servers, runs the tests, and
+// guarantees teardown (database drop + temp dir removal) regardless of outcome.
+func runSuite(env pgEnv, m *testing.M) (code int, err error) {
+	// Unique database name per run keeps concurrent runs and reruns isolated and
+	// makes teardown a single DROP DATABASE. The name pattern is also the only
+	// thing the test trusts before issuing destructive DROP statements.
+	dbName := fmt.Sprintf("toughradius_it_%d_%d", os.Getpid(), time.Now().UnixNano())
+	adminDSN := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=disable",
+		env.host, env.port, env.user, env.password, env.adminDB)
+
+	if err := createDatabase(adminDSN, dbName); err != nil {
+		return 1, fmt.Errorf("create database: %w", err)
+	}
+	defer func() {
+		if dropErr := dropDatabase(adminDSN, dbName); dropErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to drop test database %s: %v\n", dbName, dropErr)
+		}
+	}()
+
+	workdir, err := os.MkdirTemp("", "toughradius_it")
+	if err != nil {
+		return 1, fmt.Errorf("temp workdir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(workdir) }()
+	for _, d := range []string{"logs", "public", "private", "backup", "data", filepath.Join("data", "metrics")} {
+		if err := os.MkdirAll(filepath.Join(workdir, d), 0o755); err != nil {
+			return 1, fmt.Errorf("mkdir %s: %w", d, err)
+		}
+	}
+
+	webPort, err := freeTCPPort()
+	if err != nil {
+		return 1, err
+	}
+	webTLSPort, err := freeTCPPort()
+	if err != nil {
+		return 1, err
+	}
+	authPort, err := freeUDPPort()
+	if err != nil {
+		return 1, err
+	}
+	acctPort, err := freeUDPPort()
+	if err != nil {
+		return 1, err
+	}
+
+	cfg := &config.AppConfig{
+		System: config.SysConfig{
+			Appid:    "ToughRADIUS-IT",
+			Location: "Asia/Shanghai",
+			Workdir:  workdir,
+			Debug:    false,
+		},
+		Database: config.DBConfig{
+			Type:   "postgres",
+			Host:   env.host,
+			Port:   env.port,
+			User:   env.user,
+			Passwd: env.password,
+			Name:   dbName,
+		},
+		Web: config.WebConfig{
+			Host:    "127.0.0.1",
+			Port:    webPort,
+			TlsPort: webTLSPort,
+			Secret:  "integration-test-secret",
+		},
+		Radiusd: config.RadiusdConfig{
+			Enabled:  true,
+			Host:     "127.0.0.1",
+			AuthPort: authPort,
+			AcctPort: acctPort,
+			Debug:    false,
+		},
+		Logger: config.LogConfig{Mode: "development", FileEnable: false},
+	}
+
+	appCtx := app.NewApplication(cfg)
+	appCtx.Init(cfg) // connects to Postgres and migrates domain.Tables
+	defer appCtx.Release()
+
+	adminUser, adminPass := "it-admin", "it-password-123"
+	if err := seedAdminOperator(appCtx, adminUser, adminPass); err != nil {
+		return 1, fmt.Errorf("seed admin operator: %w", err)
+	}
+
+	// Boot the real admin HTTP server (full middleware chain: JWT, validator,
+	// appCtx injection, routing) so tests exercise the API as clients do.
+	webserver.Init(appCtx)
+	adminapi.Init(appCtx)
+	go func() { _ = webserver.Listen(appCtx) }()
+	webBase := fmt.Sprintf("http://127.0.0.1:%d", webPort)
+	if err := waitForHTTP(webBase+"/ready", 10*time.Second); err != nil {
+		return 1, fmt.Errorf("admin server did not become ready: %w", err)
+	}
+
+	// Boot the RADIUS auth/acct servers backed by the same Postgres database.
+	registry.ResetForTest()
+	registry.RegisterVendorParser(&parsers.DefaultParser{})
+	registry.RegisterVendorParser(&parsers.HuaweiParser{})
+	registry.RegisterVendorParser(&parsers.H3CParser{})
+	registry.RegisterVendorParser(&parsers.ZTEParser{})
+
+	radiusSvc := radiusd.NewRadiusService(appCtx)
+	defer radiusSvc.Release()
+	plugins.InitPlugins(appCtx, radiusSvc.SessionRepo, radiusSvc.AccountingRepo)
+	authSvc := radiusd.NewAuthService(radiusSvc)
+	acctSvc := radiusd.NewAcctService(radiusSvc)
+	go func() { _ = radiusd.ListenRadiusAuthServer(appCtx, authSvc) }()
+	go func() { _ = radiusd.ListenRadiusAcctServer(appCtx, acctSvc) }()
+	if err := waitForUDP(fmt.Sprintf("127.0.0.1:%d", authPort), 10*time.Second); err != nil {
+		return 1, fmt.Errorf("radius auth server did not become ready: %w", err)
+	}
+
+	h = &harness{
+		cfg:        cfg,
+		appCtx:     appCtx,
+		radiusSvc:  radiusSvc,
+		webBaseURL: webBase,
+		adminUser:  adminUser,
+		adminPass:  adminPass,
+		dbName:     dbName,
+		adminDSN:   adminDSN,
+	}
+
+	return m.Run(), nil
+}
+
+func seedAdminOperator(appCtx *app.Application, username, password string) error {
+	hashed, err := common.HashPassword(password)
+	if err != nil {
+		return err
+	}
+	var count int64
+	if err := appCtx.DB().Model(&domain.SysOpr{}).Where("username = ?", username).Count(&count).Error; err != nil {
+		return err
+	}
+	if count > 0 {
+		return nil
+	}
+	return appCtx.DB().Create(&domain.SysOpr{
+		ID:        common.UUIDint64(),
+		Username:  username,
+		Password:  hashed,
+		Level:     "super",
+		Status:    common.ENABLED,
+		Realname:  "Integration Admin",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}).Error
+}
+
+func createDatabase(adminDSN, name string) error {
+	db, err := sql.Open("pgx", adminDSN)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	if err := db.Ping(); err != nil {
+		return err
+	}
+	// name is generated internally (toughradius_it_<pid>_<nanos>); not user input.
+	_, err = db.Exec(fmt.Sprintf("CREATE DATABASE %q", name))
+	return err
+}
+
+func dropDatabase(adminDSN, name string) error {
+	db, err := sql.Open("pgx", adminDSN)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	// Terminate lingering connections before dropping.
+	_, _ = db.Exec("SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()", name)
+	_, err = db.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS %q", name))
+	return err
+}
+
+func freeTCPPort() (int, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = l.Close() }()
+	return l.Addr().(*net.TCPAddr).Port, nil
+}
+
+func freeUDPPort() (int, error) {
+	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	l, err := net.ListenUDP("udp", addr)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = l.Close() }()
+	return l.LocalAddr().(*net.UDPAddr).Port, nil
+}
+
+// waitForHTTP polls a URL until it returns any HTTP response or the timeout
+// elapses, replacing fixed sleeps with a bounded readiness check.
+func waitForHTTP(url string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	client := &http.Client{Timeout: time.Second}
+	var lastErr error
+	for time.Now().Before(deadline) {
+		resp, err := client.Get(url)
+		if err == nil {
+			_ = resp.Body.Close()
+			return nil
+		}
+		lastErr = err
+		time.Sleep(100 * time.Millisecond)
+	}
+	return lastErr
+}
+
+// waitForUDP confirms the RADIUS server socket is bound by dialing it; UDP dial
+// succeeds once the listener exists.
+func waitForUDP(addr string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("udp", addr, time.Second)
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+		lastErr = err
+		time.Sleep(100 * time.Millisecond)
+	}
+	return lastErr
+}

--- a/test/integration/migration_test.go
+++ b/test/integration/migration_test.go
@@ -1,0 +1,33 @@
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/talkincode/toughradius/v9/internal/domain"
+)
+
+// TestPostgresMigration asserts that the production schema migrates cleanly on a
+// real PostgreSQL server. It calls AutoMigrate directly (rather than the app's
+// MigrateDB, which swallows the error) so a migration regression fails loudly,
+// then verifies every declared table physically exists.
+func TestPostgresMigration(t *testing.T) {
+	db := h.appCtx.DB()
+
+	err := db.Migrator().AutoMigrate(domain.Tables...)
+	require.NoError(t, err, "AutoMigrate against PostgreSQL must succeed")
+
+	for _, model := range domain.Tables {
+		assert.Truef(t, db.Migrator().HasTable(model), "expected table for %T to exist", model)
+	}
+
+	// Spot-check a representative table's columns to catch silent column drift.
+	for _, col := range []string{"id", "username", "password", "profile_id", "status"} {
+		assert.Truef(t, db.Migrator().HasColumn(&domain.RadiusUser{}, col),
+			"radius_user.%s column should exist", col)
+	}
+}

--- a/test/integration/radius_test.go
+++ b/test/integration/radius_test.go
@@ -1,0 +1,86 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"layeh.com/radius"
+	"layeh.com/radius/rfc2865"
+
+	"github.com/talkincode/toughradius/v9/internal/domain"
+	"github.com/talkincode/toughradius/v9/pkg/common"
+)
+
+// TestRadiusPAPAuthentication drives the running RADIUS auth server (backed by
+// PostgreSQL) with a real PAP Access-Request and asserts Accept/Reject outcomes.
+// It is intentionally serial (no t.Parallel) because the RADIUS plugin registry
+// and rate limiter are process-global shared state.
+func TestRadiusPAPAuthentication(t *testing.T) {
+	const secret = "it-radius-secret"
+	suffix := uniqueSuffix()
+	nasIP := "10.200.0.1"
+	nasID := "it-nas-" + suffix
+
+	nas := &domain.NetNas{
+		ID:         common.UUIDint64(),
+		Identifier: nasID,
+		Ipaddr:     nasIP,
+		Secret:     secret,
+		VendorCode: "0",
+		Status:     common.ENABLED,
+	}
+	require.NoError(t, h.appCtx.DB().Create(nas).Error)
+
+	profileID := seedProfile(t, "it-radius-profile-"+suffix)
+	username := "it-radius-" + suffix
+	const password = "radius-Pw-123"
+	user := &domain.RadiusUser{
+		ID:         common.UUIDint64(),
+		ProfileId:  profileID,
+		Username:   username,
+		Password:   password,
+		Status:     common.ENABLED,
+		ExpireTime: time.Now().AddDate(1, 0, 0),
+		CreatedAt:  time.Now(),
+		UpdatedAt:  time.Now(),
+	}
+	require.NoError(t, h.appCtx.DB().Create(user).Error)
+
+	serverAddr := fmt.Sprintf("127.0.0.1:%d", h.cfg.Radiusd.AuthPort)
+
+	t.Run("accept valid credentials", func(t *testing.T) {
+		resp := exchange(t, serverAddr, secret, username, password, nasID, nasIP)
+		assert.Equalf(t, radius.CodeAccessAccept, resp.Code, "expected Access-Accept, got %v", resp.Code)
+		h.radiusSvc.ReleaseAuthRateLimit(username)
+	})
+
+	t.Run("reject wrong password", func(t *testing.T) {
+		resp := exchange(t, serverAddr, secret, username, "wrong-password", nasID, nasIP)
+		assert.Equalf(t, radius.CodeAccessReject, resp.Code, "expected Access-Reject, got %v", resp.Code)
+		h.radiusSvc.ReleaseAuthRateLimit(username)
+	})
+}
+
+// exchange sends a single PAP Access-Request with a bounded timeout so a stuck
+// server fails the test fast instead of hanging.
+func exchange(t *testing.T, serverAddr, secret, username, password, nasID, nasIP string) *radius.Packet {
+	t.Helper()
+	packet := radius.New(radius.CodeAccessRequest, []byte(secret))
+	_ = rfc2865.UserName_SetString(packet, username)
+	_ = rfc2865.UserPassword_SetString(packet, password)
+	_ = rfc2865.NASIdentifier_SetString(packet, nasID)
+	_ = rfc2865.NASIPAddress_Set(packet, net.ParseIP(nasIP))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	resp, err := radius.Exchange(ctx, packet, serverAddr)
+	require.NoError(t, err)
+	return resp
+}


### PR DESCRIPTION
## 背景

生产默认数据库是 **PostgreSQL**，但现有 75 个测试文件全部使用内存 SQLite。真实的 schema、迁移、SQL（`ON CONFLICT` upsert、JSON 列）从未被验证。本 PR 用「开发容器 + 容器化集成测试」补齐这一层。

## 内容

### 集成测试套件 `test/integration/`（`//go:build integration`）
在一个**新建的 PostgreSQL 数据库**上启动真实的 admin HTTP 服务（完整 JWT / 路由 / 中间件链）和 RADIUS auth/acct 服务，覆盖：

- **真实 Postgres 迁移**：直接断言 `AutoMigrate` 错误 + 表/列存在性。
- **系统备份/恢复 HTTP 往返**：验证明文 RADIUS 密码经「删除→恢复 upsert」后完整保留。
- **恢复拒绝非备份文件**：上传 CSV 返回 `INVALID_BACKUP`。
- **批量用户 CSV 导入 HTTP**。
- **RADIUS PAP 认证**：UDP 上的 Accept/Reject。

**健壮性**（采纳 rubber-duck 评审）：每次运行用唯一数据库并在结束后 DROP；就绪检测用轮询（无固定 sleep）；RADIUS 交换带超时 context；本地无 `TEST_DATABASE_*` 时跳过，但 CI / `INTEGRATION_REQUIRED=1` 下硬失败，杜绝假绿。

### 运行方式
- `docker-compose.test.yml` + `make test-integration-pg`：自动拉起 Postgres → 运行 → 清理。
- `.devcontainer/`：Go + Node + PostgreSQL compose 栈，`TEST_DATABASE_*` 接好，开箱即用。
- CI：新增 `integration` job，使用 `postgres:16` service。
- 附带 `.zed/tasks.json` 前后端一键 dev 任务与 `.gitignore` 本地 workdir 忽略。

## 约束
**无新增 Go 依赖**，**无生产代码改动**；build tag 使该套件不进入普通构建与 CI 的 `-short` 单测。

## 验证
本地对 `postgres:16` 实跑全部通过（5 测试 / 7 子测试），并验证 skip/fail-hard 守卫、容器自动清理、普通 `go build ./...` 不受影响。

> 注：`MigrateDB` 吞掉 `AutoMigrate` 错误是既有小问题，本 PR 在测试中直接断言规避，未改动生产代码，可后续单独修复。

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>