### PR TITLE
fix(ci): restore dropped build job header (CI workflow rejected)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
           INTEGRATION_REQUIRED: '1'
         run: go test -tags=integration -count=1 -v ./test/integration/...
 
-
+  build:
     name: Build
     runs-on: ubuntu-latest
     needs: [lint, test]


### PR DESCRIPTION
## Problem

PR #256 (integration testing) accidentally dropped the `build:` job key when inserting the new `integration` job. The Build job's keys (`name`, `runs-on`, `timeout-minutes`, `steps`, …) were absorbed into the `integration` job, producing duplicate-map-keys. GitHub Actions rejects the **entire** `CI` workflow at parse time — no jobs run (`total_count: 0`, "This run likely failed because of a workflow file issue").

This is currently broken on `main`, so CI no longer runs for any push/PR.

## Fix

Restore the `build:` job header so all five jobs parse independently.

## Verification

- `actionlint` — duplicate-key syntax error gone.
- `yaml.safe_load` — jobs parse as `['lint', 'test', 'integration', 'build', 'security']`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>