### PR TITLE
fix(adminapi): whitelist sort fields to prevent SQL injection (FIX-001)

### DIFF
--- a/internal/adminapi/nas.go
+++ b/internal/adminapi/nas.go
@@ -42,6 +42,25 @@ type nasUpdatePayload struct {
 	Remark     string `json:"remark" validate:"omitempty,max=500"`
 }
 
+// allowedNasSortFields defines the whitelist of sortable columns for the NAS
+// device list. It prevents SQL injection through the sort parameter, which is
+// otherwise interpolated directly into the ORDER BY clause.
+var allowedNasSortFields = map[string]bool{
+	"id":          true,
+	"node_id":     true,
+	"name":        true,
+	"identifier":  true,
+	"hostname":    true,
+	"ipaddr":      true,
+	"coa_port":    true,
+	"model":       true,
+	"vendor_code": true,
+	"status":      true,
+	"tags":        true,
+	"created_at":  true,
+	"updated_at":  true,
+}
+
 // ListNAS retrieves the NAS device list
 // @Summary get the NAS device list
 // @Tags NAS
@@ -67,7 +86,7 @@ func ListNAS(c echo.Context) error {
 
 	sortField := c.QueryParam("sort")
 	order := c.QueryParam("order")
-	if sortField == "" {
+	if sortField == "" || !allowedNasSortFields[sortField] {
 		sortField = "id"
 	}
 	if order != "ASC" && order != "DESC" {

--- a/internal/adminapi/nas_test.go
+++ b/internal/adminapi/nas_test.go
@@ -115,6 +115,12 @@ func TestListNAS(t *testing.T) {
 				assert.Equal(t, "nas1", nasData["name"])
 			},
 		},
+		{
+			name:           "Malicious sort field is ignored (SQLi guard)",
+			queryParams:    "?sort=id%29%3BDROP+TABLE+net_nas%3B--&order=ASC",
+			expectedStatus: http.StatusOK,
+			expectedCount:  3,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/adminapi/profiles.go
+++ b/internal/adminapi/profiles.go
@@ -10,6 +10,26 @@ import (
 	"github.com/talkincode/toughradius/v9/internal/webserver"
 )
 
+// allowedProfileSortFields defines the whitelist of sortable columns for the
+// RADIUS profile list. It prevents SQL injection through the sort parameter,
+// which is otherwise interpolated directly into the ORDER BY clause.
+var allowedProfileSortFields = map[string]bool{
+	"id":               true,
+	"node_id":          true,
+	"name":             true,
+	"status":           true,
+	"addr_pool":        true,
+	"active_num":       true,
+	"up_rate":          true,
+	"down_rate":        true,
+	"domain":           true,
+	"ipv6_prefix_pool": true,
+	"bind_mac":         true,
+	"bind_vlan":        true,
+	"created_at":       true,
+	"updated_at":       true,
+}
+
 // ListProfiles retrieves the RADIUS profile list
 // @Summary get the RADIUS profile list
 // @Tags RadiusProfile
@@ -33,7 +53,7 @@ func ListProfiles(c echo.Context) error {
 
 	sortField := c.QueryParam("sort")
 	order := c.QueryParam("order")
-	if sortField == "" {
+	if sortField == "" || !allowedProfileSortFields[sortField] {
 		sortField = "id"
 	}
 	if order != "ASC" && order != "DESC" {

--- a/internal/adminapi/profiles_test.go
+++ b/internal/adminapi/profiles_test.go
@@ -135,6 +135,12 @@ func TestListProfiles(t *testing.T) {
 				assert.Equal(t, "profile1", profiles[0].Name)
 			},
 		},
+		{
+			name:           "Malicious sort field is ignored (SQLi guard)",
+			queryParams:    "?sort=id%29%3BDROP+TABLE+radius_profile%3B--&order=ASC",
+			expectedStatus: http.StatusOK,
+			expectedCount:  3,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## FIX-001 (P0)

The `ListProfiles` and `ListNAS` handlers built their `ORDER BY` clause by string-concatenating the raw `sort` query parameter (`query.Order(sortField + " " + order)`), enabling SQL injection. The user-list endpoint already guarded this with a whitelist; the two endpoints here did not.

### Changes
- Add `allowedProfileSortFields` / `allowedNasSortFields` whitelists (valid columns only; sensitive columns like `secret` excluded).
- Non-whitelisted `sort` values now fall back to `id`.
- Regression tests assert a malicious URL-encoded `sort` payload returns 200 and is ignored.

### Validation
- `go build ./...` OK
- `go test ./internal/adminapi/ -run 'TestListProfiles|TestListNAS'` OK
- `golangci-lint run ./internal/adminapi/...` 0 issues

Ref: docs/fix-checklist.md FIX-001