### PR TITLE
fix(radiusd): persist both VLAN IDs correctly in UpdateBind (FIX-005)

### DIFF
--- a/internal/radiusd/radius.go
+++ b/internal/radiusd/radius.go
@@ -468,11 +468,11 @@ func (s *AuthService) UpdateBind(user *domain.RadiusUser, vendorReq *VendorReque
 	}
 	reqvid1 := int(vendorReq.Vlanid1)
 	reqvid2 := int(vendorReq.Vlanid2)
-	if user.Vlanid1 != reqvid1 {
-		s.UpdateUserVlanid2(user.Username, reqvid1)
-	}
-	if user.Vlanid2 != reqvid2 {
-		s.UpdateUserVlanid2(user.Username, reqvid2)
+	// UpdateVlanId writes both vlanid columns at once, so persist them together
+	// when either differs. Updating them via the single-field helpers would zero
+	// out the other column (and the old code also wrote vlanid1 into vlanid2).
+	if user.Vlanid1 != reqvid1 || user.Vlanid2 != reqvid2 {
+		_ = s.UserRepo.UpdateVlanId(context.Background(), user.Username, reqvid1, reqvid2)
 	}
 }
 

--- a/internal/radiusd/radius_updatebind_test.go
+++ b/internal/radiusd/radius_updatebind_test.go
@@ -1,0 +1,57 @@
+package radiusd
+
+import (
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/talkincode/toughradius/v9/internal/domain"
+	repogorm "github.com/talkincode/toughradius/v9/internal/radiusd/repository/gorm"
+)
+
+func newUpdateBindTestService(t *testing.T) (*AuthService, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&domain.RadiusUser{}))
+	svc := &AuthService{RadiusService: &RadiusService{
+		UserRepo: repogorm.NewGormUserRepository(db),
+	}}
+	return svc, db
+}
+
+// TestUpdateBindPersistsBothVlanIds verifies that UpdateBind writes the request
+// VLAN IDs to the matching columns (vlanid1 -> vlanid1, vlanid2 -> vlanid2).
+func TestUpdateBindPersistsBothVlanIds(t *testing.T) {
+	svc, db := newUpdateBindTestService(t)
+
+	user := &domain.RadiusUser{Username: "u1", Vlanid1: 10, Vlanid2: 20, MacAddr: "aa:bb"}
+	require.NoError(t, db.Create(user).Error)
+
+	svc.UpdateBind(user, &VendorRequest{Vlanid1: 100, Vlanid2: 200, MacAddr: "cc:dd"})
+
+	var got domain.RadiusUser
+	require.NoError(t, db.Where("username = ?", "u1").First(&got).Error)
+	require.Equal(t, 100, got.Vlanid1)
+	require.Equal(t, 200, got.Vlanid2)
+	require.Equal(t, "cc:dd", got.MacAddr)
+}
+
+// TestUpdateBindVlanid1ChangeKeepsVlanid2 is the regression for the original bug
+// where a vlanid1 change was written into vlanid2 (and vlanid1 was never saved).
+func TestUpdateBindVlanid1ChangeKeepsVlanid2(t *testing.T) {
+	svc, db := newUpdateBindTestService(t)
+
+	user := &domain.RadiusUser{Username: "u2", Vlanid1: 10, Vlanid2: 20}
+	require.NoError(t, db.Create(user).Error)
+
+	// Only vlanid1 differs from the stored value.
+	svc.UpdateBind(user, &VendorRequest{Vlanid1: 99, Vlanid2: 20})
+
+	var got domain.RadiusUser
+	require.NoError(t, db.Where("username = ?", "u2").First(&got).Error)
+	require.Equal(t, 99, got.Vlanid1, "vlanid1 must be persisted to vlanid1")
+	require.Equal(t, 20, got.Vlanid2, "vlanid2 must be preserved")
+}


### PR DESCRIPTION
## FIX-005 (P0)

`AuthService.UpdateBind` had a real data-persistence bug:
- A changed `vlanid1` was written via `UpdateUserVlanid2(..., reqvid1)` — i.e. into `vlanid2`.
- `UpdateUserVlanid1/2` both call `UpdateVlanId`, which writes **both** columns, so each helper zeroes the other column.

Net effect: `vlanid1` was never persisted and `vlanid2` could be clobbered.

### Fix
Persist both VLAN IDs in a single `UserRepo.UpdateVlanId` call when either differs.

### Tests
- `TestUpdateBindPersistsBothVlanIds` — both IDs land in the right columns.
- `TestUpdateBindVlanid1ChangeKeepsVlanid2` — regression: vlanid1-only change persists to vlanid1 and preserves vlanid2.

### Validation
- `go build ./...`, `go test ./internal/radiusd/ -short` OK
- `golangci-lint run ./internal/radiusd/` 0 issues

Ref: docs/fix-checklist.md FIX-005