### PR TITLE
fix(webserver): remove global JWT auth bypass via TOUGHRADIUS_DEVMODE (FIX-003)

### DIFF
--- a/internal/webserver/server.go
+++ b/internal/webserver/server.go
@@ -301,10 +301,6 @@ func ServerRecover(debug bool) echo.MiddlewareFunc {
 // skipFunc filters web requests in middleware
 func jwtSkipFunc() func(c echo.Context) bool {
 	return func(c echo.Context) bool {
-		if os.Getenv("TOUGHRADIUS_DEVMODE") == "true" {
-			return true
-		}
-
 		for _, prefix := range JwtSkipPrefix {
 			if strings.HasPrefix(c.Path(), prefix) {
 				return true

--- a/internal/webserver/server_test.go
+++ b/internal/webserver/server_test.go
@@ -1,0 +1,37 @@
+package webserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestJwtSkipFuncDoesNotBypassWithDevmode ensures the JWT skipper only skips
+// the explicitly public routes and never disables auth globally, including when
+// the removed TOUGHRADIUS_DEVMODE environment variable is set.
+func TestJwtSkipFuncDoesNotBypassWithDevmode(t *testing.T) {
+	e := echo.New()
+	skip := jwtSkipFunc()
+
+	newCtx := func(path string) echo.Context {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetPath(path)
+		return c
+	}
+
+	// Public routes are skipped.
+	assert.True(t, skip(newCtx("/ready")))
+	assert.True(t, skip(newCtx(apiBasePath+"/auth/login")))
+
+	// Protected routes are never skipped.
+	assert.False(t, skip(newCtx(apiBasePath+"/users")))
+
+	// Setting the former bypass env var must not disable auth.
+	t.Setenv("TOUGHRADIUS_DEVMODE", "true")
+	assert.False(t, skip(newCtx(apiBasePath+"/users")))
+}


### PR DESCRIPTION
## FIX-003 (P0)

`jwtSkipFunc` returned `true` for **all** requests when `TOUGHRADIUS_DEVMODE=true`, fully disabling auth on the admin API. A stray env var in production would expose every endpoint.

The flag was referenced nowhere else. Removed the bypass so only the explicit `JwtSkipPrefix` public routes (login/ready/etc.) are skipped.

### Tests
- `TestJwtSkipFuncDoesNotBypassWithDevmode` — protected routes never skipped, even with the env var set; public routes still skipped.

### Validation
- `go build ./...`, `go test ./internal/webserver/` OK
- `golangci-lint run ./internal/webserver/` 0 issues

Ref: docs/fix-checklist.md FIX-003