### PR TITLE
fix(radiusd/eap): remove EAP-OTP hardcoded-password auth bypass (FIX-004)

### DIFF
--- a/internal/radiusd/plugins/eap/errors.go
+++ b/internal/radiusd/plugins/eap/errors.go
@@ -9,4 +9,5 @@ var (
 	ErrPasswordMismatch     = errors.New("password mismatch")
 	ErrUnsupportedEAPType   = errors.New("unsupported EAP type")
 	ErrAuthenticationFailed = errors.New("authentication failed")
+	ErrOTPNotConfigured     = errors.New("EAP-OTP validation is not configured")
 )

--- a/internal/radiusd/plugins/eap/handlers/handlers_test.go
+++ b/internal/radiusd/plugins/eap/handlers/handlers_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap"
+	"layeh.com/radius"
+	"layeh.com/radius/rfc2865"
 )
 
 // Mock state manager for testing
@@ -194,6 +196,29 @@ func TestOTPHandler_CanHandle(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+// TestOTPHandler_HandleResponse_NeverAuthenticates ensures the OTP handler no
+// longer authenticates against the previously hardcoded "123456" password and
+// instead reports that OTP validation is not configured.
+func TestOTPHandler_HandleResponse_NeverAuthenticates(t *testing.T) {
+	h := NewOTPHandler()
+
+	packet := radius.New(radius.CodeAccessRequest, []byte("secret"))
+	require.NoError(t, rfc2865.State_SetString(packet, "state-otp-1"))
+
+	sm := newMockStateManagerForTest()
+	require.NoError(t, sm.SetState("state-otp-1", &eap.EAPState{StateID: "state-otp-1", Method: "eap-otp"}))
+
+	ctx := &eap.EAPContext{
+		Request:      &radius.Request{Packet: packet},
+		StateManager: sm,
+		EAPMessage:   &eap.EAPMessage{Type: eap.TypeOTP, Data: []byte("123456")},
+	}
+
+	success, err := h.HandleResponse(ctx)
+	assert.False(t, success, "the former fixed password must not authenticate")
+	assert.ErrorIs(t, err, eap.ErrOTPNotConfigured)
 }
 
 func TestOTPHandler_buildChallengeRequest(t *testing.T) {

--- a/internal/radiusd/plugins/eap/handlers/otp_handler.go
+++ b/internal/radiusd/plugins/eap/handlers/otp_handler.go
@@ -83,28 +83,16 @@ func (h *OTPHandler) HandleResponse(ctx *eap.EAPContext) (bool, error) {
 		return false, eap.ErrStateNotFound
 	}
 
-	state, err := ctx.StateManager.GetState(stateID)
-	if err != nil {
+	if _, err := ctx.StateManager.GetState(stateID); err != nil {
 		return false, err
 	}
 
-	// Get the OTP password (simplified here; a real implementation should call an OTP validation service)
-	// TODO: Integrate with a real OTP validation logic
-	expectedOTP := "123456" // Sample fixed value; in reality retrieve from the validation service
-
-	// Extract the user's entered OTP from the EAP data
-	userOTP := string(ctx.EAPMessage.Data)
-
-	// Validate OTP
-	if userOTP != expectedOTP {
-		return false, eap.ErrPasswordMismatch
-	}
-
-	// Mark authentication as successful
-	state.Success = true
-	_ = ctx.StateManager.SetState(stateID, state) //nolint:errcheck
-
-	return true, nil
+	// EAP-OTP has no real validation backend yet. Never authenticate against a
+	// hardcoded/sample password (the previous implementation accepted a fixed
+	// "123456", which was an authentication bypass). Reject until a real OTP
+	// validation service is integrated. This handler is also not registered by
+	// default (see internal/radiusd/plugins/init.go).
+	return false, eap.ErrOTPNotConfigured
 }
 
 // buildChallengeRequest constructs the OTP Challenge Request

--- a/internal/radiusd/plugins/init.go
+++ b/internal/radiusd/plugins/init.go
@@ -58,7 +58,9 @@ func InitPlugins(appCtx app.ConfigManagerProvider, sessionRepo repository.Sessio
 
 	// Register EAP handlers
 	registry.RegisterEAPHandler(eaphandlers.NewMD5Handler())
-	registry.RegisterEAPHandler(eaphandlers.NewOTPHandler())
+	// EAP-OTP is intentionally not registered: its handler has no real OTP
+	// validation backend yet. Registering it would expose an unauthenticated
+	// EAP method. Re-enable only once a real validation service is wired in.
 	registry.RegisterEAPHandler(eaphandlers.NewMSCHAPv2Handler())
 
 	// Vendor parsers under vendor/parsers register themselves via init()

--- a/internal/radiusd/plugins/init_test.go
+++ b/internal/radiusd/plugins/init_test.go
@@ -91,7 +91,7 @@ func TestInitPlugins_EAPHandlers(t *testing.T) {
 	eapHandlers := registry.GetAllEAPHandlers()
 
 	assert.NotNil(t, eapHandlers[4], "EAP-MD5 should be registered")
-	assert.NotNil(t, eapHandlers[5], "EAP-OTP should be registered")
+	assert.Nil(t, eapHandlers[5], "EAP-OTP must not be registered (stub handler has no real validation backend)")
 	assert.NotNil(t, eapHandlers[26], "EAP-MSCHAPv2 should be registered")
 }
 


### PR DESCRIPTION
## FIX-004 (P0)

The EAP-OTP handler accepted any response equal to the hardcoded `"123456"` and was registered by default — an authentication bypass.

### Changes
- `HandleResponse` no longer compares against a fixed password; it returns the new `ErrOTPNotConfigured` until a real OTP backend is integrated.
- The stub handler is no longer registered in `InitPlugins`.

### Tests
- `TestOTPHandler_HandleResponse_NeverAuthenticates` — the former fixed password does not authenticate.
- `TestInitPlugins_EAPHandlers` updated to assert EAP-OTP is not registered.

### Validation
- `go build ./...`, `go test ./internal/radiusd/plugins/...` OK
- `golangci-lint run ./internal/radiusd/plugins/...` 0 issues

Ref: docs/fix-checklist.md FIX-004