### PR TITLE
fix(adminapi): enforce role-based authorization on sensitive routes (FIX-002)

### DIFF
--- a/internal/adminapi/authz.go
+++ b/internal/adminapi/authz.go
@@ -1,0 +1,47 @@
+package adminapi
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+// Operator privilege levels, ordered from most to least privileged.
+const (
+	LevelSuper    = "super"
+	LevelAdmin    = "admin"
+	LevelOperator = "operator"
+)
+
+// RequireLevel returns middleware that authorizes a request only when the
+// authenticated operator's level is one of the allowed levels.
+//
+// It must be chained after the JWT middleware so the operator can be resolved
+// from the request context. Requests from operators whose level is not allowed
+// receive HTTP 403; requests without a resolvable operator receive HTTP 401.
+func RequireLevel(levels ...string) echo.MiddlewareFunc {
+	allowed := make(map[string]bool, len(levels))
+	for _, l := range levels {
+		allowed[l] = true
+	}
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			operator, err := resolveOperatorFromContext(c)
+			if err != nil {
+				return fail(c, http.StatusUnauthorized, "UNAUTHORIZED", "Authentication required", nil)
+			}
+			if !allowed[operator.Level] {
+				return fail(c, http.StatusForbidden, "PERMISSION_DENIED",
+					"Insufficient privileges for this operation", nil)
+			}
+			return next(c)
+		}
+	}
+}
+
+// requireAdmin restricts an endpoint to admin and super operators. It is used to
+// guard configuration writes and system backup/restore, which are not safe for
+// regular operator-level accounts.
+func requireAdmin() echo.MiddlewareFunc {
+	return RequireLevel(LevelSuper, LevelAdmin)
+}

--- a/internal/adminapi/authz_test.go
+++ b/internal/adminapi/authz_test.go
@@ -1,0 +1,114 @@
+package adminapi
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/talkincode/toughradius/v9/internal/domain"
+)
+
+// authzNext is a sentinel handler used to detect whether the middleware allowed
+// the request to proceed to the wrapped handler.
+func authzNext(c echo.Context) error {
+	return c.String(http.StatusOK, "ok")
+}
+
+func TestRequireLevel(t *testing.T) {
+	tests := []struct {
+		name           string
+		operator       *domain.SysOpr
+		allowedLevels  []string
+		expectedStatus int
+		expectNext     bool
+	}{
+		{
+			name:           "admin allowed for requireAdmin",
+			operator:       &domain.SysOpr{Level: LevelAdmin},
+			allowedLevels:  []string{LevelSuper, LevelAdmin},
+			expectedStatus: http.StatusOK,
+			expectNext:     true,
+		},
+		{
+			name:           "super allowed for requireAdmin",
+			operator:       &domain.SysOpr{Level: LevelSuper},
+			allowedLevels:  []string{LevelSuper, LevelAdmin},
+			expectedStatus: http.StatusOK,
+			expectNext:     true,
+		},
+		{
+			name:           "operator denied for requireAdmin",
+			operator:       &domain.SysOpr{Level: LevelOperator},
+			allowedLevels:  []string{LevelSuper, LevelAdmin},
+			expectedStatus: http.StatusForbidden,
+			expectNext:     false,
+		},
+		{
+			name:           "unknown level denied",
+			operator:       &domain.SysOpr{Level: "guest"},
+			allowedLevels:  []string{LevelSuper, LevelAdmin},
+			expectedStatus: http.StatusForbidden,
+			expectNext:     false,
+		},
+		{
+			name:           "missing operator unauthorized",
+			operator:       nil,
+			allowedLevels:  []string{LevelSuper, LevelAdmin},
+			expectedStatus: http.StatusUnauthorized,
+			expectNext:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/system/settings", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			if tt.operator != nil {
+				c.Set("current_operator", tt.operator)
+			}
+
+			called := false
+			handler := RequireLevel(tt.allowedLevels...)(func(c echo.Context) error {
+				called = true
+				return authzNext(c)
+			})
+
+			err := handler(c)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedStatus, rec.Code)
+			assert.Equal(t, tt.expectNext, called)
+		})
+	}
+}
+
+func TestRequireAdminMatchesSuperAndAdmin(t *testing.T) {
+	mw := requireAdmin()
+
+	for _, level := range []string{LevelSuper, LevelAdmin} {
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/network/nas", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.Set("current_operator", &domain.SysOpr{Level: level})
+
+		err := mw(authzNext)(c)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code, "level %s should be allowed", level)
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/network/nas", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("current_operator", &domain.SysOpr{Level: LevelOperator})
+
+	err := mw(authzNext)(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusForbidden, rec.Code, "operator level should be denied")
+}

--- a/internal/adminapi/nas.go
+++ b/internal/adminapi/nas.go
@@ -317,7 +317,7 @@ func DeleteNAS(c echo.Context) error {
 func registerNASRoutes() {
 	webserver.ApiGET("/network/nas", ListNAS)
 	webserver.ApiGET("/network/nas/:id", GetNAS)
-	webserver.ApiPOST("/network/nas", CreateNAS)
-	webserver.ApiPUT("/network/nas/:id", UpdateNAS)
-	webserver.ApiDELETE("/network/nas/:id", DeleteNAS)
+	webserver.ApiPOST("/network/nas", CreateNAS, requireAdmin())
+	webserver.ApiPUT("/network/nas/:id", UpdateNAS, requireAdmin())
+	webserver.ApiDELETE("/network/nas/:id", DeleteNAS, requireAdmin())
 }

--- a/internal/adminapi/nodes.go
+++ b/internal/adminapi/nodes.go
@@ -30,9 +30,9 @@ type nodeUpdatePayload struct {
 func registerNodesRoutes() {
 	webserver.ApiGET("/network/nodes", listNodes)
 	webserver.ApiGET("/network/nodes/:id", getNode)
-	webserver.ApiPOST("/network/nodes", createNode)
-	webserver.ApiPUT("/network/nodes/:id", updateNode)
-	webserver.ApiDELETE("/network/nodes/:id", deleteNode)
+	webserver.ApiPOST("/network/nodes", createNode, requireAdmin())
+	webserver.ApiPUT("/network/nodes/:id", updateNode, requireAdmin())
+	webserver.ApiDELETE("/network/nodes/:id", deleteNode, requireAdmin())
 }
 
 // listNodes retrieves the network node list

--- a/internal/adminapi/profiles.go
+++ b/internal/adminapi/profiles.go
@@ -450,7 +450,7 @@ func DeleteProfile(c echo.Context) error {
 func registerProfileRoutes() {
 	webserver.ApiGET("/radius-profiles", ListProfiles)
 	webserver.ApiGET("/radius-profiles/:id", GetProfile)
-	webserver.ApiPOST("/radius-profiles", CreateProfile)
-	webserver.ApiPUT("/radius-profiles/:id", UpdateProfile)
-	webserver.ApiDELETE("/radius-profiles/:id", DeleteProfile)
+	webserver.ApiPOST("/radius-profiles", CreateProfile, requireAdmin())
+	webserver.ApiPUT("/radius-profiles/:id", UpdateProfile, requireAdmin())
+	webserver.ApiDELETE("/radius-profiles/:id", DeleteProfile, requireAdmin())
 }

--- a/internal/adminapi/settings.go
+++ b/internal/adminapi/settings.go
@@ -30,10 +30,10 @@ func registerSettingsRoutes() {
 	webserver.ApiGET("/system/settings", listSettings)
 	webserver.ApiGET("/system/settings/:id", getSettings)
 	webserver.ApiGET("/system/config/schemas", getConfigSchemas)
-	webserver.ApiPOST("/system/settings", createSettings)
-	webserver.ApiPUT("/system/settings/:id", updateSettings)
-	webserver.ApiDELETE("/system/settings/:id", deleteSettings)
-	webserver.ApiPOST("/system/config/reload", reloadConfig)
+	webserver.ApiPOST("/system/settings", createSettings, requireAdmin())
+	webserver.ApiPUT("/system/settings/:id", updateSettings, requireAdmin())
+	webserver.ApiDELETE("/system/settings/:id", deleteSettings, requireAdmin())
+	webserver.ApiPOST("/system/config/reload", reloadConfig, requireAdmin())
 }
 
 // listSettings retrieves the system settings list

--- a/internal/adminapi/system_backup.go
+++ b/internal/adminapi/system_backup.go
@@ -33,8 +33,8 @@ type SystemBackup struct {
 }
 
 func registerSystemBackupRoutes() {
-	webserver.ApiGET("/system/backup", backupSystem)
-	webserver.ApiPOST("/system/restore", restoreSystem)
+	webserver.ApiGET("/system/backup", backupSystem, requireAdmin())
+	webserver.ApiPOST("/system/restore", restoreSystem, requireAdmin())
 }
 
 // backupSystem exports the core configuration tables as a downloadable JSON file.


### PR DESCRIPTION
## FIX-002 — Role-based authorization (P0)

### Problem
Every authenticated operator had full write access to all admin APIs regardless of privilege level (`super`/`admin`/`operator`). An `operator`-level account could modify NAS, profiles, nodes, settings, and trigger system backup/restore (which exports plaintext credentials and can overwrite the operators table).

### Fix
- New `internal/adminapi/authz.go` with `RequireLevel(levels ...string)` echo middleware and a `requireAdmin()` convenience (= super+admin). Returns 401 when no operator resolves, 403 when level not allowed.
- Applied `requireAdmin()` to sensitive write/sensitive routes:
  - `system/backup` (GET), `system/restore` (POST)
  - settings writes: `POST/PUT/DELETE /system/settings`, `POST /system/config/reload`
  - NAS writes: `POST/PUT/DELETE /network/nas`
  - profile writes: `POST/PUT/DELETE /radius-profiles`
  - node writes: `POST/PUT/DELETE /network/nodes`
- Read-only GETs and operator/user management (already level-gated inline) left unchanged to preserve the operator workflow.

### Tests
- `authz_test.go`: table-driven coverage of allow (super/admin), deny (operator/unknown → 403), and missing-operator (401).

### Validation
- `go build ./...` ✓
- `go test ./internal/adminapi/...` ✓
- `golangci-lint run ./internal/adminapi/...` → 0 issues

Part of the continuous remediation campaign (docs/fix-checklist.md).