### PR TITLE
fix(radiusd): validate accounting request secret + per-NAS secret (FIX-006)

### DIFF
--- a/internal/radiusd/radius.go
+++ b/internal/radiusd/radius.go
@@ -43,6 +43,12 @@ import (
 const (
 	RadiusRejectDelayTimes = 7
 	RadiusAuthRateInterval = 1 // Original: 1 second rate limit
+
+	// unknownNasSecret is a placeholder secret returned for packets from an
+	// unrecognized NAS source IP. It is intentionally not a real credential; it
+	// only lets the packet reach the request handler so the unauthorized NAS can
+	// be logged and rejected with the correct metric.
+	unknownNasSecret = "__unknown_nas__" //nolint:gosec // G101: placeholder, not a real secret
 )
 
 type VendorRequest struct {
@@ -112,8 +118,21 @@ func NewRadiusService(appCtx app.AppContext) *RadiusService {
 	return s
 }
 
+// RADIUSSecret resolves the shared secret for an incoming UDP packet by looking
+// up the originating NAS by its source IP address. When the NAS is unknown a
+// non-empty placeholder is returned so the packet still reaches the request
+// handler, where the unauthorized NAS is logged and rejected with the proper
+// metric instead of being silently dropped by the server library.
 func (s *RadiusService) RADIUSSecret(ctx context.Context, remoteAddr net.Addr) ([]byte, error) {
-	return []byte("mysecret"), nil
+	ip := remoteAddr.String()
+	if host, _, err := net.SplitHostPort(ip); err == nil {
+		ip = host
+	}
+	nas, err := s.GetNas(ip, "")
+	if err != nil {
+		return []byte(unknownNasSecret), nil
+	}
+	return []byte(nas.Secret), nil
 }
 
 // GetNas looks up a NAS device, preferring IP before ID

--- a/internal/radiusd/radius_acct.go
+++ b/internal/radiusd/radius_acct.go
@@ -82,7 +82,15 @@ func (s *AcctService) ServeRADIUS(w radius.ResponseWriter, r *radius.Request) {
 
 	defer s.ReleaseAuthRateLimit(username)
 
-	// s.CheckRequestSecret(r.Packet, []byte(nas.Secret))
+	// Validate the Accounting-Request authenticator against the NAS shared secret.
+	// Unlike Access-Request (which carries a random authenticator), accounting
+	// packets are signed with a keyed Request Authenticator (RFC 2866). A mismatch
+	// means the request is forged or the NAS is misconfigured, so it must be
+	// dropped before any session state is mutated.
+	if err := s.CheckRequestSecret(r.Packet, []byte(nas.Secret)); err != nil {
+		s.logAcctError("verify_secret", nasrip, username, err)
+		return
+	}
 
 	vendorReq := s.ParseVendor(r, nas.VendorCode)
 

--- a/internal/radiusd/radius_acct_secret_test.go
+++ b/internal/radiusd/radius_acct_secret_test.go
@@ -1,0 +1,83 @@
+package radiusd
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/talkincode/toughradius/v9/internal/domain"
+	"github.com/talkincode/toughradius/v9/pkg/common"
+	"layeh.com/radius"
+	"layeh.com/radius/rfc2865"
+	"layeh.com/radius/rfc2866"
+)
+
+// buildAccountingRequest builds and re-parses an Accounting-Request packet so it
+// carries a valid keyed Request Authenticator computed with the given secret.
+func buildAccountingRequest(t *testing.T, secret []byte) *radius.Packet {
+	t.Helper()
+	p := radius.New(radius.CodeAccountingRequest, secret)
+	p.Identifier = 1
+	require.NoError(t, rfc2865.UserName_SetString(p, "testuser"))
+	require.NoError(t, rfc2866.AcctStatusType_Set(p, rfc2866.AcctStatusType_Value_Start))
+	wire, err := p.Encode()
+	require.NoError(t, err)
+	parsed, err := radius.Parse(wire, secret)
+	require.NoError(t, err)
+	return parsed
+}
+
+func TestCheckRequestSecretAccounting(t *testing.T) {
+	secret := []byte("correct-secret")
+	pkt := buildAccountingRequest(t, secret)
+
+	svc := &RadiusService{}
+
+	// Correct secret validates successfully.
+	require.NoError(t, svc.CheckRequestSecret(pkt, secret))
+
+	// Wrong secret is rejected: this is the forged-accounting protection.
+	err := svc.CheckRequestSecret(pkt, []byte("wrong-secret"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrSecretMismatch)
+
+	// Empty secret is rejected.
+	assert.ErrorIs(t, svc.CheckRequestSecret(pkt, nil), ErrSecretEmpty)
+}
+
+func TestRADIUSSecretResolvesPerNas(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping DB-backed test in short mode")
+	}
+	appCtx, _ := setupTestEnv(t)
+	defer appCtx.Release()
+
+	svc := NewRadiusService(appCtx)
+	defer svc.Release()
+
+	nas := &domain.NetNas{
+		ID:         1,
+		Identifier: "nas-1",
+		Ipaddr:     "10.9.9.9",
+		Secret:     "per-nas-secret",
+		VendorCode: "0",
+		Status:     common.ENABLED,
+	}
+	require.NoError(t, appCtx.DB().Create(nas).Error)
+
+	addr := &net.UDPAddr{IP: net.ParseIP("10.9.9.9"), Port: 5000}
+	secret, err := svc.RADIUSSecret(context.Background(), addr)
+	require.NoError(t, err)
+	assert.Equal(t, "per-nas-secret", string(secret))
+
+	// Unknown NAS returns a non-empty placeholder (so the handler can log it),
+	// never the hardcoded legacy "mysecret".
+	unknownAddr := &net.UDPAddr{IP: net.ParseIP("172.31.0.1"), Port: 5000}
+	placeholder, err := svc.RADIUSSecret(context.Background(), unknownAddr)
+	require.NoError(t, err)
+	assert.NotEmpty(t, placeholder)
+	assert.NotEqual(t, "mysecret", string(placeholder))
+	assert.NotEqual(t, "per-nas-secret", string(placeholder))
+}


### PR DESCRIPTION
## FIX-006 — Accounting shared-secret validation (P1)

### Problem
The accounting handler never validated the RADIUS shared secret (`CheckRequestSecret` was commented out). Because Accounting-Request packets carry a keyed Request Authenticator (RFC 2866), any host able to reach UDP/1813 that knows a NAS IP/identifier could inject forged accounting (inflate traffic counters, manipulate sessions). Separately, `RADIUSSecret` returned a hardcoded `"mysecret"`.

### Fix
- `internal/radiusd/radius_acct.go`: validate the Accounting-Request authenticator against the NAS shared secret before any session state is mutated; drop and meter mismatches via `logAcctError` (`MetricsRadiusAcctDrop`).
- `internal/radiusd/radius.go`: `RADIUSSecret` now resolves the real per-NAS secret by source IP. Unknown NAS returns a non-credential placeholder so the packet still reaches the handler and is logged/rejected with the proper metric (preserves existing behavior; the per-NAS secret set in the handler is always used for response signing).

### Why response signing is unaffected
The server response writer signs with the packet's own `Secret`, which the handler always resets to `nas.Secret`; the value returned by `RADIUSSecret` is only used for parsing and never for signing responses.

### Tests
- `radius_acct_secret_test.go`: `CheckRequestSecret` accepts the correct secret and rejects wrong/empty secrets (`ErrSecretMismatch`/`ErrSecretEmpty`); `RADIUSSecret` returns the per-NAS secret for a known NAS and a non-"mysecret" placeholder for an unknown one.

### Validation
- `go build ./...` ✓
- `go test ./internal/radiusd/...` ✓ (incl. integration accounting flow)
- `golangci-lint run ./internal/radiusd/...` → 0 issues

Part of the continuous remediation campaign (docs/fix-checklist.md).