### PR TITLE
fix(radiusd): EAP state TTL expiry + remove dead EapStateCache (FIX-007)

### DIFF
--- a/internal/radiusd/plugins/eap/statemanager/memory_state_manager.go
+++ b/internal/radiusd/plugins/eap/statemanager/memory_state_manager.go
@@ -1,70 +1,149 @@
 package statemanager
 
 import (
-	"errors"
-	"sync"
+"errors"
+"sync"
+"time"
 
-	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap"
+"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap"
 )
 
-// MemoryStateManager is an in-memory EAP state manager
+const (
+// DefaultStateTTL is how long an EAP state is retained before it is
+// considered stale. EAP handshakes normally complete within seconds; this
+// generous window tolerates slow clients while ensuring that abandoned
+// (never-completed) handshakes cannot leak memory indefinitely.
+DefaultStateTTL = 5 * time.Minute
+
+// defaultCleanupInterval is how often the background janitor sweeps expired
+// states out of the map.
+defaultCleanupInterval = time.Minute
+)
+
+// stateEntry wraps a stored EAP state with its expiry deadline.
+type stateEntry struct {
+state     *eap.EAPState
+expiresAt time.Time
+}
+
+// MemoryStateManager is an in-memory EAP state manager with TTL-based expiry.
+//
+// Each stored state has an absolute expiry deadline. Expired states are removed
+// lazily on read and proactively by a background janitor, so an EAP handshake
+// that is started but never finished cannot accumulate unbounded memory.
 type MemoryStateManager struct {
-	states map[string]*eap.EAPState
-	mu     sync.RWMutex
+states map[string]*stateEntry
+mu     sync.RWMutex
+ttl    time.Duration
+
+stopOnce sync.Once
+stopCh   chan struct{}
 }
 
-// NewMemoryStateManager creates a new in-memory state manager
+// NewMemoryStateManager creates a new in-memory state manager using the default
+// TTL and cleanup interval, and starts its background janitor.
 func NewMemoryStateManager() *MemoryStateManager {
-	return &MemoryStateManager{
-		states: make(map[string]*eap.EAPState),
-	}
+return NewMemoryStateManagerWithTTL(DefaultStateTTL, defaultCleanupInterval)
 }
 
-// GetState get EAP Status
+// NewMemoryStateManagerWithTTL creates a state manager with a custom state TTL
+// and janitor interval. A non-positive cleanupInterval disables the background
+// janitor (expiry then relies solely on lazy removal during reads).
+func NewMemoryStateManagerWithTTL(ttl, cleanupInterval time.Duration) *MemoryStateManager {
+m := &MemoryStateManager{
+states: make(map[string]*stateEntry),
+ttl:    ttl,
+stopCh: make(chan struct{}),
+}
+if cleanupInterval > 0 {
+go m.janitor(cleanupInterval)
+}
+return m
+}
+
+// janitor periodically removes expired states until the manager is closed.
+func (m *MemoryStateManager) janitor(interval time.Duration) {
+ticker := time.NewTicker(interval)
+defer ticker.Stop()
+for {
+select {
+case <-ticker.C:
+m.sweepExpired()
+case <-m.stopCh:
+return
+}
+}
+}
+
+// sweepExpired removes all states whose deadline has passed.
+func (m *MemoryStateManager) sweepExpired() {
+now := time.Now()
+m.mu.Lock()
+defer m.mu.Unlock()
+for id, entry := range m.states {
+if now.After(entry.expiresAt) {
+delete(m.states, id)
+}
+}
+}
+
+// Close stops the background janitor. It is safe to call multiple times.
+func (m *MemoryStateManager) Close() {
+m.stopOnce.Do(func() { close(m.stopCh) })
+}
+
+// GetState returns the EAP state for the given ID. Expired states are treated as
+// absent and removed.
 func (m *MemoryStateManager) GetState(stateID string) (*eap.EAPState, error) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
+m.mu.Lock()
+defer m.mu.Unlock()
 
-	state, ok := m.states[stateID]
-	if !ok {
-		return nil, errors.New("state not found")
-	}
-
-	// Returns a copy to avoid concurrent modification
-	stateCopy := *state
-	if state.Data != nil {
-		stateCopy.Data = make(map[string]interface{})
-		for k, v := range state.Data {
-			stateCopy.Data[k] = v
-		}
-	}
-
-	return &stateCopy, nil
+entry, ok := m.states[stateID]
+if !ok {
+return nil, errors.New("state not found")
+}
+if time.Now().After(entry.expiresAt) {
+delete(m.states, stateID)
+return nil, errors.New("state not found")
 }
 
-// SetState stores the EAP status
+// Return a copy to avoid concurrent modification.
+stateCopy := *entry.state
+if entry.state.Data != nil {
+stateCopy.Data = make(map[string]interface{})
+for k, v := range entry.state.Data {
+stateCopy.Data[k] = v
+}
+}
+
+return &stateCopy, nil
+}
+
+// SetState stores the EAP state and (re)sets its expiry deadline.
 func (m *MemoryStateManager) SetState(stateID string, state *eap.EAPState) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	// Store a copy to avoid external modification
-	stateCopy := *state
-	if state.Data != nil {
-		stateCopy.Data = make(map[string]interface{})
-		for k, v := range state.Data {
-			stateCopy.Data[k] = v
-		}
-	}
-
-	m.states[stateID] = &stateCopy
-	return nil
+// Store a copy to avoid external modification.
+stateCopy := *state
+if state.Data != nil {
+stateCopy.Data = make(map[string]interface{})
+for k, v := range state.Data {
+stateCopy.Data[k] = v
+}
 }
 
-// DeleteState Delete EAP Status
-func (m *MemoryStateManager) DeleteState(stateID string) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+m.mu.Lock()
+defer m.mu.Unlock()
+m.states[stateID] = &stateEntry{
+state:     &stateCopy,
+expiresAt: time.Now().Add(m.ttl),
+}
+return nil
+}
 
-	delete(m.states, stateID)
-	return nil
+// DeleteState removes the EAP state for the given ID.
+func (m *MemoryStateManager) DeleteState(stateID string) error {
+m.mu.Lock()
+defer m.mu.Unlock()
+
+delete(m.states, stateID)
+return nil
 }

--- a/internal/radiusd/plugins/eap/statemanager/memory_state_manager_test.go
+++ b/internal/radiusd/plugins/eap/statemanager/memory_state_manager_test.go
@@ -3,6 +3,7 @@ package statemanager
 import (
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -11,12 +12,14 @@ import (
 
 func TestNewMemoryStateManager(t *testing.T) {
 	mgr := NewMemoryStateManager()
+	defer mgr.Close()
 	assert.NotNil(t, mgr)
 	assert.NotNil(t, mgr.states)
 }
 
 func TestMemoryStateManager_SetState(t *testing.T) {
 	mgr := NewMemoryStateManager()
+	defer mgr.Close()
 
 	state := &eap.EAPState{
 		StateID:  "state-123",
@@ -39,6 +42,7 @@ func TestMemoryStateManager_SetState(t *testing.T) {
 
 func TestMemoryStateManager_SetState_WithNilData(t *testing.T) {
 	mgr := NewMemoryStateManager()
+	defer mgr.Close()
 
 	state := &eap.EAPState{
 		StateID:  "state-123",
@@ -57,6 +61,7 @@ func TestMemoryStateManager_SetState_WithNilData(t *testing.T) {
 
 func TestMemoryStateManager_GetState_NotFound(t *testing.T) {
 	mgr := NewMemoryStateManager()
+	defer mgr.Close()
 
 	state, err := mgr.GetState("nonexistent")
 	assert.Error(t, err)
@@ -66,6 +71,7 @@ func TestMemoryStateManager_GetState_NotFound(t *testing.T) {
 
 func TestMemoryStateManager_GetState_ReturnsCopy(t *testing.T) {
 	mgr := NewMemoryStateManager()
+	defer mgr.Close()
 
 	originalData := map[string]interface{}{
 		"key1": "value1",
@@ -92,6 +98,7 @@ func TestMemoryStateManager_GetState_ReturnsCopy(t *testing.T) {
 
 func TestMemoryStateManager_SetState_StoresCopy(t *testing.T) {
 	mgr := NewMemoryStateManager()
+	defer mgr.Close()
 
 	data := map[string]interface{}{
 		"key1": "value1",
@@ -116,6 +123,7 @@ func TestMemoryStateManager_SetState_StoresCopy(t *testing.T) {
 
 func TestMemoryStateManager_DeleteState(t *testing.T) {
 	mgr := NewMemoryStateManager()
+	defer mgr.Close()
 
 	state := &eap.EAPState{
 		StateID: "state-123",
@@ -132,6 +140,7 @@ func TestMemoryStateManager_DeleteState(t *testing.T) {
 
 func TestMemoryStateManager_DeleteState_NonExistent(t *testing.T) {
 	mgr := NewMemoryStateManager()
+	defer mgr.Close()
 
 	err := mgr.DeleteState("nonexistent")
 	assert.NoError(t, err)
@@ -139,6 +148,7 @@ func TestMemoryStateManager_DeleteState_NonExistent(t *testing.T) {
 
 func TestMemoryStateManager_OverwriteState(t *testing.T) {
 	mgr := NewMemoryStateManager()
+	defer mgr.Close()
 
 	state1 := &eap.EAPState{
 		StateID:  "state-1",
@@ -163,6 +173,7 @@ func TestMemoryStateManager_OverwriteState(t *testing.T) {
 
 func TestMemoryStateManager_ConcurrentAccess(t *testing.T) {
 	mgr := NewMemoryStateManager()
+	defer mgr.Close()
 	var wg sync.WaitGroup
 
 	for i := 0; i < 100; i++ {
@@ -200,6 +211,7 @@ func TestMemoryStateManager_ConcurrentAccess(t *testing.T) {
 
 func TestMemoryStateManager_MultipleStates(t *testing.T) {
 	mgr := NewMemoryStateManager()
+	defer mgr.Close()
 
 	states := map[string]*eap.EAPState{
 		"state-1": {StateID: "id-1", Username: "user1"},
@@ -233,4 +245,43 @@ func TestMemoryStateManager_MultipleStates(t *testing.T) {
 func TestMemoryStateManager_ImplementsInterface(t *testing.T) {
 	// Verify MemoryStateManager implements EAPStateManager
 	var _ eap.EAPStateManager = (*MemoryStateManager)(nil)
+}
+
+func TestMemoryStateManager_ExpiresAfterTTL(t *testing.T) {
+mgr := NewMemoryStateManagerWithTTL(20*time.Millisecond, 0)
+defer mgr.Close()
+
+require.NoError(t, mgr.SetState("s1", &eap.EAPState{StateID: "s1", Username: "u"}))
+
+// Before expiry the state is retrievable.
+got, err := mgr.GetState("s1")
+require.NoError(t, err)
+assert.Equal(t, "u", got.Username)
+
+// After the TTL elapses the state is treated as absent and removed lazily.
+time.Sleep(40 * time.Millisecond)
+_, err = mgr.GetState("s1")
+require.Error(t, err)
+assert.Contains(t, err.Error(), "not found")
+
+mgr.mu.RLock()
+_, exists := mgr.states["s1"]
+mgr.mu.RUnlock()
+assert.False(t, exists, "expired state should be removed on read")
+}
+
+func TestMemoryStateManager_JanitorSweepsExpired(t *testing.T) {
+mgr := NewMemoryStateManagerWithTTL(15*time.Millisecond, 10*time.Millisecond)
+defer mgr.Close()
+
+require.NoError(t, mgr.SetState("s1", &eap.EAPState{StateID: "s1"}))
+require.NoError(t, mgr.SetState("s2", &eap.EAPState{StateID: "s2"}))
+
+// Wait long enough for the janitor to run at least once after expiry.
+assert.Eventually(t, func() bool {
+mgr.mu.RLock()
+n := len(mgr.states)
+mgr.mu.RUnlock()
+return n == 0
+}, time.Second, 5*time.Millisecond, "janitor should reclaim expired states")
 }

--- a/internal/radiusd/radius.go
+++ b/internal/radiusd/radius.go
@@ -62,21 +62,11 @@ type AuthRateUser struct {
 	Starttime time.Time
 }
 
-type EapState struct {
-	Username  string
-	Challenge []byte
-	StateID   string
-	EapMethad string
-	Success   bool
-}
-
 type RadiusService struct {
 	appCtx        app.AppContext // Use interface instead of concrete type
 	AuthRateCache map[string]AuthRateUser
-	EapStateCache map[string]EapState
 	TaskPool      *ants.Pool
 	arclock       sync.Mutex
-	eaplock       sync.Mutex
 	nasCache      *cachepkg.TTLCache[*domain.NetNas]
 	userCache     *cachepkg.TTLCache[*domain.RadiusUser]
 
@@ -100,7 +90,6 @@ func NewRadiusService(appCtx app.AppContext) *RadiusService {
 	s := &RadiusService{
 		appCtx:        appCtx,
 		AuthRateCache: make(map[string]AuthRateUser),
-		EapStateCache: make(map[string]EapState),
 		arclock:       sync.Mutex{},
 		TaskPool:      pool,
 		nasCache:      cachepkg.NewTTLCache[*domain.NetNas](time.Minute, 512),
@@ -441,37 +430,6 @@ func (s *RadiusService) CheckRequestSecret(r *radius.Packet, secret []byte) erro
 		return ErrSecretMismatch
 	}
 	return nil
-}
-
-// State add
-func (s *RadiusService) AddEapState(stateid, username string, challenge []byte, eapMethad string) {
-	s.eaplock.Lock()
-	defer s.eaplock.Unlock()
-	s.EapStateCache[stateid] = EapState{
-		Username:  username,
-		StateID:   stateid,
-		Challenge: challenge,
-		EapMethad: eapMethad,
-		Success:   false,
-	}
-}
-
-// State get
-func (s *RadiusService) GetEapState(stateid string) (state *EapState, err error) {
-	s.eaplock.Lock()
-	defer s.eaplock.Unlock()
-	val, ok := s.EapStateCache[stateid]
-	if ok {
-		return &val, nil
-	}
-	return nil, errors.New("state not found")
-}
-
-// State delete
-func (s *RadiusService) DeleteEapState(stateid string) {
-	s.eaplock.Lock()
-	defer s.eaplock.Unlock()
-	delete(s.EapStateCache, stateid)
 }
 
 func (s *AuthService) GetLocalPassword(user *domain.RadiusUser, isMacAuth bool) (string, error) {

--- a/internal/radiusd/radius_test.go
+++ b/internal/radiusd/radius_test.go
@@ -1,7 +1,6 @@
 package radiusd
 
 import (
-	"bytes"
 	"strconv"
 	"sync"
 	"testing"
@@ -153,99 +152,6 @@ func TestCheckAuthRateLimitConcurrent(t *testing.T) {
 	t.Logf("Concurrent test: %d success, %d failed", successCount, failCount)
 }
 
-func TestEAPStateManagement(t *testing.T) {
-	service := &RadiusService{
-		EapStateCache: make(map[string]EapState),
-		eaplock:       sync.Mutex{},
-	}
-
-	// Add EAP Status
-	stateID := "test-state-id"
-	username := "testuser"
-	challenge := []byte("challenge-data")
-	eapMethod := "eap-md5"
-
-	service.AddEapState(stateID, username, challenge, eapMethod)
-
-	// get EAP Status
-	state, err := service.GetEapState(stateID)
-	if err != nil {
-		t.Fatalf("failed to get EAP state: %v", err)
-	}
-
-	if state.Username != username {
-		t.Errorf("expected username %s, got %s", username, state.Username)
-	}
-
-	if !bytes.Equal(state.Challenge, challenge) {
-		t.Errorf("challenge data mismatch")
-	}
-
-	if state.EapMethad != eapMethod {
-		t.Errorf("expected method %s, got %s", eapMethod, state.EapMethad)
-	}
-
-	if state.Success {
-		t.Error("initial state should have Success=false")
-	}
-
-	// Delete EAP Status
-	service.DeleteEapState(stateID)
-
-	// Validatedeleted
-	_, err = service.GetEapState(stateID)
-	if err == nil {
-		t.Error("expected error when getting deleted state")
-	}
-}
-
-func TestGetEapStateNotFound(t *testing.T) {
-	service := &RadiusService{
-		EapStateCache: make(map[string]EapState),
-		eaplock:       sync.Mutex{},
-	}
-
-	_, err := service.GetEapState("nonexistent")
-	if err == nil {
-		t.Error("expected error for nonexistent state")
-	}
-
-	if err.Error() != "state not found" {
-		t.Errorf("expected 'state not found' error, got: %v", err)
-	}
-}
-
-func TestEAPStateConcurrentAccess(t *testing.T) {
-	service := &RadiusService{
-		EapStateCache: make(map[string]EapState),
-		eaplock:       sync.Mutex{},
-	}
-
-	var wg sync.WaitGroup
-	stateCount := 100
-
-	// Concurrent add states
-	for i := 0; i < stateCount; i++ {
-		wg.Add(1)
-		go func(id int) {
-			defer wg.Done()
-			stateID := "state-" + strconv.Itoa(id)
-			service.AddEapState(stateID, "user", []byte("challenge"), "eap-md5")
-		}(i)
-	}
-
-	wg.Wait()
-
-	// ValidateAll states added
-	service.eaplock.Lock()
-	count := len(service.EapStateCache)
-	service.eaplock.Unlock()
-
-	if count != stateCount {
-		t.Errorf("expected %d states, got %d", stateCount, count)
-	}
-}
-
 func TestAuthRateCacheConcurrentAccess(t *testing.T) {
 	service := &RadiusService{
 		AuthRateCache: make(map[string]AuthRateUser),
@@ -277,35 +183,6 @@ func TestAuthRateCacheConcurrentAccess(t *testing.T) {
 	}
 }
 
-func TestEAPStateUpdate(t *testing.T) {
-	service := &RadiusService{
-		EapStateCache: make(map[string]EapState),
-		eaplock:       sync.Mutex{},
-	}
-
-	stateID := "test-state"
-
-	// Add the initial status
-	service.AddEapState(stateID, "user1", []byte("challenge1"), "eap-md5")
-
-	// Update state（by overwriting）
-	service.AddEapState(stateID, "user2", []byte("challenge2"), "eap-mschapv2")
-
-	// ValidateStatusupdated
-	state, err := service.GetEapState(stateID)
-	if err != nil {
-		t.Fatalf("failed to get state: %v", err)
-	}
-
-	if state.Username != "user2" {
-		t.Errorf("expected username user2, got %s", state.Username)
-	}
-
-	if state.EapMethad != "eap-mschapv2" {
-		t.Errorf("expected method eap-mschapv2, got %s", state.EapMethad)
-	}
-}
-
 func TestReleaseAuthRateLimitNonexistent(t *testing.T) {
 	service := &RadiusService{
 		AuthRateCache: make(map[string]AuthRateUser),
@@ -322,55 +199,6 @@ func TestReleaseAuthRateLimitNonexistent(t *testing.T) {
 
 	if count != 0 {
 		t.Errorf("expected empty cache, got %d entries", count)
-	}
-}
-
-func TestDeleteEapStateNonexistent(t *testing.T) {
-	service := &RadiusService{
-		EapStateCache: make(map[string]EapState),
-		eaplock:       sync.Mutex{},
-	}
-
-	// DeleteNon-existent state should not panic
-	service.DeleteEapState("nonexistent-state")
-
-	// Validate the cache is empty
-	service.eaplock.Lock()
-	count := len(service.EapStateCache)
-	service.eaplock.Unlock()
-
-	if count != 0 {
-		t.Errorf("expected empty cache, got %d entries", count)
-	}
-}
-
-func TestMultipleEAPStates(t *testing.T) {
-	service := &RadiusService{
-		EapStateCache: make(map[string]EapState),
-		eaplock:       sync.Mutex{},
-	}
-
-	// Add multiple different EAP Status
-	states := map[string]string{
-		"state1": "user1",
-		"state2": "user2",
-		"state3": "user3",
-	}
-
-	for stateID, username := range states {
-		service.AddEapState(stateID, username, []byte("challenge"), "eap-md5")
-	}
-
-	// ValidateAll states exist
-	for stateID, expectedUser := range states {
-		state, err := service.GetEapState(stateID)
-		if err != nil {
-			t.Errorf("failed to get state %s: %v", stateID, err)
-			continue
-		}
-		if state.Username != expectedUser {
-			t.Errorf("state %s: expected user %s, got %s", stateID, expectedUser, state.Username)
-		}
 	}
 }
 


### PR DESCRIPTION
## FIX-007 — EAP state TTL + dead code removal (P1)

### Problem
1. `MemoryStateManager` (the real EAP state store) never expired entries — an EAP handshake that is started but never completed left its state in the map forever, an unbounded memory-growth / DoS vector.
2. `RadiusService` carried a parallel, unused `EapStateCache` (`AddEapState`/`GetEapState`/`DeleteEapState`) — dead code with its own tests.

### Fix
- `internal/radiusd/plugins/eap/statemanager/memory_state_manager.go`: each state now has an absolute expiry deadline (default TTL 5m). Expired states are removed lazily on `GetState` and proactively by a background janitor (`Close()` stops it). New `NewMemoryStateManagerWithTTL(ttl, interval)` constructor for configurable/short-TTL use.
- `internal/radiusd/radius.go`: removed the unused `EapStateCache` field, `eaplock`, the `EapState` type, and the three dead methods.
- `internal/radiusd/radius_test.go`: removed the dead tests that exercised the removed cache.

### Tests
- `memory_state_manager_test.go`: existing tests now `defer mgr.Close()`; added `ExpiresAfterTTL` (state gone after TTL, removed on read) and `JanitorSweepsExpired` (background sweep reclaims entries).

### Validation
- `go build ./...` ✓
- `go test ./internal/radiusd/... ./internal/radiusd/plugins/eap/...` ✓
- `golangci-lint run ./internal/radiusd/...` → 0 issues

Part of the continuous remediation campaign (docs/fix-checklist.md).