### PR TITLE
fix(radiusd): bound accounting goroutines under overload (FIX-008)

### DIFF
--- a/internal/radiusd/radius.go
+++ b/internal/radiusd/radius.go
@@ -82,7 +82,12 @@ func NewRadiusService(appCtx app.AppContext) *RadiusService {
 	if err != nil {
 		poolsize = 1024
 	}
-	pool, err := ants.NewPool(poolsize)
+	// Nonblocking: when all workers are busy, Submit returns ErrPoolOverload
+	// immediately instead of blocking the caller. Accounting overflow is then
+	// dropped and metered (see AcctService.submitAcctTask), which bounds the
+	// number of goroutines under load rather than letting blocked submitters
+	// accumulate without limit.
+	pool, err := ants.NewPool(poolsize, ants.WithNonblocking(true))
 	common.Must(err)
 
 	// Initialize all repositories using injected context

--- a/internal/radiusd/radius_acct.go
+++ b/internal/radiusd/radius_acct.go
@@ -121,14 +121,26 @@ func (s *AcctService) ServeRADIUS(w radius.ResponseWriter, r *radius.Request) {
 		}
 	}
 
+	s.submitAcctTask(task, username)
+}
+
+// submitAcctTask schedules an accounting task on the bounded worker pool.
+//
+// When the pool is saturated the task is dropped (and recorded as an accounting
+// drop) rather than spawning a goroutine per request. Spawning an unbounded
+// goroutine on overload would let a flood of accounting traffic exhaust memory;
+// dropping preserves back-pressure. Returns true if the task was accepted.
+func (s *AcctService) submitAcctTask(task func(), username string) bool {
 	if err := s.TaskPool.Submit(task); err != nil {
-		zap.L().Warn("accounting task pool saturated, running fallback goroutine",
+		zap.L().Warn("accounting task pool saturated, dropping accounting update",
 			zap.String("namespace", "radius"),
+			zap.String("username", username),
 			zap.String("metrics", app.MetricsRadiusAcctDrop),
 			zap.Error(err),
 		)
-		go task()
+		return false
 	}
+	return true
 }
 
 // logAcctError logs accounting errors with appropriate metrics.

--- a/internal/radiusd/radius_acct_overload_test.go
+++ b/internal/radiusd/radius_acct_overload_test.go
@@ -1,0 +1,47 @@
+package radiusd
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/panjf2000/ants/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSubmitAcctTaskDropsOnOverload verifies that when the worker pool is
+// saturated, an accounting task is dropped instead of spawning an unbounded
+// goroutine, keeping goroutine usage bounded under overload.
+func TestSubmitAcctTaskDropsOnOverload(t *testing.T) {
+	pool, err := ants.NewPool(1, ants.WithNonblocking(true))
+	require.NoError(t, err)
+	defer pool.Release()
+
+	acct := &AcctService{RadiusService: &RadiusService{TaskPool: pool}}
+
+	started := make(chan struct{})
+	block := make(chan struct{})
+
+	// Occupy the only worker with a blocking task.
+	require.True(t, acct.submitAcctTask(func() {
+		close(started)
+		<-block
+	}, "busy"))
+	<-started
+
+	// With the single worker busy, the next task must be dropped (back-pressure),
+	// not executed on a freshly spawned goroutine.
+	var ran int32
+	accepted := acct.submitAcctTask(func() {
+		atomic.AddInt32(&ran, 1)
+	}, "overflow")
+
+	assert.False(t, accepted, "task should be dropped when pool is saturated")
+
+	// Give any (incorrectly) spawned goroutine a chance to run before asserting.
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&ran), "dropped task must not execute")
+
+	close(block)
+}


### PR DESCRIPTION
## FIX-008 — Bounded accounting goroutines (P1)

### Problem
The accounting worker pool was created with `ants.NewPool(poolsize)`, whose default `Submit` **blocks** when all workers are busy (unbounded blocking submitters). Because the RADIUS server spawns a goroutine per packet, a sustained accounting flood made these blocked submitters accumulate without limit. The existing `go task()` fallback only ran on `ErrPoolOverload`, which the blocking pool effectively never returned — so it was dead code that, if reached, would itself spawn unbounded goroutines.

### Fix
- `internal/radiusd/radius.go`: create the pool with `ants.WithNonblocking(true)` so `Submit` returns `ErrPoolOverload` immediately when saturated.
- `internal/radiusd/radius_acct.go`: extract `submitAcctTask`, which on overload **drops** the accounting update and records `MetricsRadiusAcctDrop` instead of spawning a goroutine. Goroutine usage is now bounded by the pool size while back-pressure is preserved.

### Tests
- `radius_acct_overload_test.go`: with a saturated single-worker non-blocking pool, an overflow task is dropped (not executed), proving bounded behavior.

### Validation
- `go build ./...` ✓
- `go test ./internal/radiusd/...` ✓ (incl. integration accounting flow)
- `golangci-lint run ./internal/radiusd/...` → 0 issues

Part of the continuous remediation campaign (docs/fix-checklist.md).