### PR TITLE
fix(adminapi,webserver): login rate limiting + global body size limit (FIX-009)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/pgx/v5 v5.7.6 // indirect
+	github.com/jackc/pgx/v5 v5.7.6
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
@@ -73,5 +73,5 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/net v0.54.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
-	golang.org/x/time v0.14.0 // indirect
+	golang.org/x/time v0.14.0
 )

--- a/internal/adminapi/auth.go
+++ b/internal/adminapi/auth.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+	"golang.org/x/time/rate"
 	"gorm.io/gorm"
 
 	"github.com/talkincode/toughradius/v9/internal/domain"
@@ -24,8 +26,32 @@ type loginRequest struct {
 	Password string `json:"password"`
 }
 
+// loginRateLimiter throttles authentication attempts per client IP to slow down
+// brute-force / credential-stuffing attacks. It allows a short burst of attempts
+// and then refills slowly; exhausting the budget yields HTTP 429.
+func loginRateLimiter() echo.MiddlewareFunc {
+	store := middleware.NewRateLimiterMemoryStoreWithConfig(middleware.RateLimiterMemoryStoreConfig{
+		Rate:      rate.Every(3 * time.Second),
+		Burst:     5,
+		ExpiresIn: 3 * time.Minute,
+	})
+	return middleware.RateLimiterWithConfig(middleware.RateLimiterConfig{
+		Store: store,
+		IdentifierExtractor: func(c echo.Context) (string, error) {
+			return c.RealIP(), nil
+		},
+		ErrorHandler: func(c echo.Context, err error) error {
+			return fail(c, http.StatusForbidden, "RATE_LIMIT_ERROR", "Unable to evaluate rate limit", nil)
+		},
+		DenyHandler: func(c echo.Context, identifier string, err error) error {
+			return fail(c, http.StatusTooManyRequests, "RATE_LIMITED",
+				"Too many login attempts, please try again later", nil)
+		},
+	})
+}
+
 func registerAuthRoutes() {
-	webserver.ApiPOST("/auth/login", loginHandler)
+	webserver.ApiPOST("/auth/login", loginHandler, loginRateLimiter())
 	webserver.ApiGET("/auth/me", currentUserHandler)
 }
 

--- a/internal/adminapi/auth_ratelimit_test.go
+++ b/internal/adminapi/auth_ratelimit_test.go
@@ -1,0 +1,48 @@
+package adminapi
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestLoginRateLimiter verifies that repeated login attempts from the same client
+// IP are throttled with HTTP 429 once the burst budget is exhausted.
+func TestLoginRateLimiter(t *testing.T) {
+	e := echo.New()
+	e.POST("/login", func(c echo.Context) error {
+		return c.NoContent(http.StatusOK)
+	}, loginRateLimiter())
+
+	const clientIP = "203.0.113.7:40000"
+
+	// The burst budget (5) allows the first attempts through.
+	allowed := 0
+	for i := 0; i < 5; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/login", nil)
+		req.RemoteAddr = clientIP
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		if rec.Code == http.StatusOK {
+			allowed++
+		}
+	}
+	assert.Equal(t, 5, allowed, "burst attempts should be allowed")
+
+	// The next immediate attempt is denied.
+	req := httptest.NewRequest(http.MethodPost, "/login", nil)
+	req.RemoteAddr = clientIP
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusTooManyRequests, rec.Code, "exceeding the budget should be rate limited")
+
+	// A different client IP is unaffected.
+	req2 := httptest.NewRequest(http.MethodPost, "/login", nil)
+	req2.RemoteAddr = "198.51.100.9:40000"
+	rec2 := httptest.NewRecorder()
+	e.ServeHTTP(rec2, req2)
+	assert.Equal(t, http.StatusOK, rec2.Code, "a different IP should not be throttled")
+}

--- a/internal/webserver/bodylimit_test.go
+++ b/internal/webserver/bodylimit_test.go
@@ -1,0 +1,43 @@
+package webserver
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDefaultBodyLimitIsValid ensures the configured limit string is accepted by
+// the BodyLimit middleware (it panics on an invalid value).
+func TestDefaultBodyLimitIsValid(t *testing.T) {
+	require.NotPanics(t, func() {
+		_ = middleware.BodyLimit(DefaultBodyLimit)
+	})
+}
+
+// TestBodyLimitRejectsOversizedBody verifies that BodyLimit returns 413 for a
+// request body larger than the configured limit and allows smaller ones.
+func TestBodyLimitRejectsOversizedBody(t *testing.T) {
+	e := echo.New()
+	e.Use(middleware.BodyLimit("1K"))
+	e.POST("/x", func(c echo.Context) error {
+		return c.NoContent(http.StatusOK)
+	})
+
+	// Body under the limit is accepted.
+	small := httptest.NewRequest(http.MethodPost, "/x", bytes.NewReader(make([]byte, 512)))
+	recSmall := httptest.NewRecorder()
+	e.ServeHTTP(recSmall, small)
+	assert.Equal(t, http.StatusOK, recSmall.Code)
+
+	// Body over the limit is rejected.
+	big := httptest.NewRequest(http.MethodPost, "/x", bytes.NewReader(make([]byte, 2048)))
+	recBig := httptest.NewRecorder()
+	e.ServeHTTP(recBig, big)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, recBig.Code)
+}

--- a/internal/webserver/server.go
+++ b/internal/webserver/server.go
@@ -33,6 +33,11 @@ import (
 
 const apiBasePath = "/api/v1"
 
+// DefaultBodyLimit caps the size of any single request body to bound memory use
+// and reject oversized uploads (including the system restore endpoint). It is
+// generous enough for normal admin API JSON and configuration-table backups.
+const DefaultBodyLimit = "16M"
+
 var JwtSkipPrefix = []string{
 	"/ready",
 	"/realip",
@@ -63,6 +68,9 @@ func NewAdminServer(appCtx app.AppContext) *AdminServer {
 	s := &AdminServer{appCtx: appCtx}
 	s.root = echo.New()
 	s.root.Pre(middleware.RemoveTrailingSlash())
+	// Bound request body size globally to mitigate memory-exhaustion via oversized
+	// payloads (e.g. the system restore upload).
+	s.root.Use(middleware.BodyLimit(DefaultBodyLimit))
 	s.root.Use(middleware.GzipWithConfig(middleware.GzipConfig{
 		Skipper: func(c echo.Context) bool {
 			return strings.HasPrefix(c.Path(), "/metrics")


### PR DESCRIPTION
## FIX-009 — Login rate limit & request body limit (P1)

### Problem
The admin login endpoint had no rate limiting (open to brute-force / credential stuffing), and there was no global request body size limit (oversized payloads, including the system restore upload, could exhaust memory).

### Fix
- `internal/adminapi/auth.go`: `loginRateLimiter()` — a per-client-IP limiter (burst 5, refill ~1 per 3s, 3-minute window) applied to `POST /auth/login`. Exceeding the budget returns HTTP 429 `RATE_LIMITED`.
- `internal/webserver/server.go`: global `middleware.BodyLimit(DefaultBodyLimit)` (16M) on the admin server, bounding every request body and capping the restore upload.

### Tests
- `auth_ratelimit_test.go`: burst attempts allowed, the next is 429, a different IP is unaffected.
- `bodylimit_test.go`: oversized body → 413, small body → 200, and the configured limit string is valid.

### Notes
- `go mod tidy` promoted `golang.org/x/time` to a direct dependency (now used directly) and corrected a pre-existing `pgx/v5` indirect mismatch.

### Validation
- `go build ./...` ✓
- `go test ./internal/adminapi/... ./internal/webserver/...` ✓
- `golangci-lint run` (both packages) → 0 issues

Part of the continuous remediation campaign (docs/fix-checklist.md).