### PR TITLE
fix(webserver): security headers + configurable CORS (FIX-010)

### DIFF
--- a/internal/webserver/security_test.go
+++ b/internal/webserver/security_test.go
@@ -1,0 +1,67 @@
+package webserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSecurityHeadersApplied verifies the baseline security headers are set on
+// responses.
+func TestSecurityHeadersApplied(t *testing.T) {
+	e := echo.New()
+	e.Use(securityHeaders())
+	e.GET("/x", func(c echo.Context) error { return c.NoContent(http.StatusOK) })
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "SAMEORIGIN", rec.Header().Get(echo.HeaderXFrameOptions))
+	assert.Equal(t, "nosniff", rec.Header().Get(echo.HeaderXContentTypeOptions))
+	assert.Equal(t, "1; mode=block", rec.Header().Get(echo.HeaderXXSSProtection))
+}
+
+// TestCorsAllowedOriginsParsing verifies env-driven CORS configuration parsing.
+func TestCorsAllowedOriginsParsing(t *testing.T) {
+	t.Setenv(corsEnvVar, "")
+	assert.Nil(t, corsAllowedOrigins(), "unset/empty yields no origins (CORS disabled)")
+
+	t.Setenv(corsEnvVar, " https://a.example.com , https://b.example.com ,")
+	assert.Equal(t,
+		[]string{"https://a.example.com", "https://b.example.com"},
+		corsAllowedOrigins(),
+		"origins should be split and trimmed, empties dropped")
+}
+
+// TestCorsHonorsConfiguredOrigins verifies that, when configured, a preflight
+// from an allowed origin is granted and a disallowed origin is not.
+func TestCorsHonorsConfiguredOrigins(t *testing.T) {
+	e := echo.New()
+	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
+		AllowOrigins:     []string{"https://allowed.example.com"},
+		AllowCredentials: true,
+	}))
+	e.GET("/x", func(c echo.Context) error { return c.NoContent(http.StatusOK) })
+
+	// Allowed origin echoed back.
+	reqOK := httptest.NewRequest(http.MethodOptions, "/x", nil)
+	reqOK.Header.Set(echo.HeaderOrigin, "https://allowed.example.com")
+	reqOK.Header.Set(echo.HeaderAccessControlRequestMethod, http.MethodGet)
+	recOK := httptest.NewRecorder()
+	e.ServeHTTP(recOK, reqOK)
+	assert.Equal(t, "https://allowed.example.com", recOK.Header().Get(echo.HeaderAccessControlAllowOrigin))
+
+	// Disallowed origin is not granted.
+	reqBad := httptest.NewRequest(http.MethodOptions, "/x", nil)
+	reqBad.Header.Set(echo.HeaderOrigin, "https://evil.example.com")
+	reqBad.Header.Set(echo.HeaderAccessControlRequestMethod, http.MethodGet)
+	recBad := httptest.NewRecorder()
+	e.ServeHTTP(recBad, reqBad)
+	assert.NotEqual(t, "https://evil.example.com", recBad.Header().Get(echo.HeaderAccessControlAllowOrigin))
+}

--- a/internal/webserver/server.go
+++ b/internal/webserver/server.go
@@ -38,6 +38,40 @@ const apiBasePath = "/api/v1"
 // generous enough for normal admin API JSON and configuration-table backups.
 const DefaultBodyLimit = "16M"
 
+// corsEnvVar is the environment variable holding a comma-separated list of
+// origins allowed for cross-origin requests to the admin API.
+const corsEnvVar = "TOUGHRADIUS_WEB_CORS_ORIGINS"
+
+// securityHeaders returns middleware that sets baseline security response
+// headers: X-Frame-Options (clickjacking), X-Content-Type-Options (MIME
+// sniffing), and X-XSS-Protection. HSTS is intentionally left disabled so plain
+// HTTP deployments are not broken; it should be enabled by a TLS-terminating
+// proxy when applicable.
+func securityHeaders() echo.MiddlewareFunc {
+	return middleware.SecureWithConfig(middleware.SecureConfig{
+		XFrameOptions:      "SAMEORIGIN",
+		ContentTypeNosniff: "nosniff",
+		XSSProtection:      "1; mode=block",
+	})
+}
+
+// corsAllowedOrigins parses the configured CORS allow-list. An empty/unset value
+// yields nil, meaning CORS is not enabled (same-origin only).
+func corsAllowedOrigins() []string {
+	raw := strings.TrimSpace(os.Getenv(corsEnvVar))
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	origins := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if o := strings.TrimSpace(p); o != "" {
+			origins = append(origins, o)
+		}
+	}
+	return origins
+}
+
 var JwtSkipPrefix = []string{
 	"/ready",
 	"/realip",
@@ -77,6 +111,26 @@ func NewAdminServer(appCtx app.AppContext) *AdminServer {
 		},
 		Level: 1,
 	}))
+
+	// Security response headers (clickjacking, MIME sniffing, reflected XSS).
+	s.root.Use(securityHeaders())
+
+	// CORS is disabled by default (the admin UI is served same-origin). When
+	// cross-origin access is required it can be enabled by listing the allowed
+	// origins in TOUGHRADIUS_WEB_CORS_ORIGINS (comma-separated).
+	if origins := corsAllowedOrigins(); len(origins) > 0 {
+		s.root.Use(middleware.CORSWithConfig(middleware.CORSConfig{
+			AllowOrigins: origins,
+			AllowMethods: []string{
+				http.MethodGet, http.MethodHead, http.MethodPost,
+				http.MethodPut, http.MethodPatch, http.MethodDelete, http.MethodOptions,
+			},
+			AllowHeaders: []string{
+				echo.HeaderOrigin, echo.HeaderContentType, echo.HeaderAuthorization,
+			},
+			AllowCredentials: true,
+		}))
+	}
 
 	// Register the custom validator
 	s.root.Validator = customValidator.NewValidator()


### PR DESCRIPTION
## FIX-010 — Security middleware (P1)

### Problem
The admin server set no security response headers and had no CORS policy.

### Fix
- `internal/webserver/server.go`:
  - `securityHeaders()` middleware (always on): `X-Frame-Options: SAMEORIGIN`, `X-Content-Type-Options: nosniff`, `X-XSS-Protection: 1; mode=block`. HSTS is intentionally left to a TLS-terminating proxy so plain-HTTP deployments aren't broken.
  - Opt-in CORS via `TOUGHRADIUS_WEB_CORS_ORIGINS` (comma-separated). Disabled by default — the admin UI is served same-origin, so we avoid a permissive `*` default.

### Tests
- `security_test.go`: headers present on responses; origin list parsing (trim/empty-drop, unset → disabled); configured CORS grants allowed origin and rejects others.

### Validation
- `go build ./...` ✓
- `go test ./internal/webserver/...` ✓
- `golangci-lint run ./internal/webserver/...` → 0 issues

Part of the continuous remediation campaign (docs/fix-checklist.md).