### PR TITLE
fix(adminapi): stop leaking raw DB/internal errors to clients (FIX-011)

### DIFF
--- a/internal/adminapi/responses.go
+++ b/internal/adminapi/responses.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
+	"go.uber.org/zap"
 )
 
 // Meta describes pagination information
@@ -45,6 +46,19 @@ func paged(c echo.Context, data interface{}, total int64, page, pageSize int) er
 func fail(c echo.Context, status int, code, message string, details interface{}) error {
 	if status == 0 {
 		status = http.StatusBadRequest
+	}
+	// Never expose internal error details (e.g. raw database errors that contain
+	// table/column names) to clients on server-side failures. Log them for
+	// operators and return only the generic code and message.
+	if status >= http.StatusInternalServerError && details != nil {
+		zap.L().Error("adminapi internal error",
+			zap.String("namespace", "adminapi"),
+			zap.Int("status", status),
+			zap.String("code", code),
+			zap.String("path", c.Path()),
+			zap.Any("details", details),
+		)
+		details = nil
 	}
 	return c.JSON(status, ErrorResponse{
 		Error:   code,

--- a/internal/adminapi/responses_test.go
+++ b/internal/adminapi/responses_test.go
@@ -1,0 +1,57 @@
+package adminapi
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestFailSanitizesInternalDetails verifies that server-side (>=500) failures
+// never leak raw error details (such as database errors that expose table and
+// column names) to the client. The generic code/message must still be present.
+func TestFailSanitizesInternalDetails(t *testing.T) {
+	e := echo.New()
+	dbErr := errors.New(`pq: column "secret_token" of relation "rad_account" does not exist`)
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := fail(c, http.StatusInternalServerError, "DATABASE_ERROR", "Failed to query data", dbErr.Error())
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	body := rec.Body.String()
+	assert.NotContains(t, body, "secret_token", "raw column name must not leak to client")
+	assert.NotContains(t, body, "rad_account", "raw table name must not leak to client")
+
+	var resp ErrorResponse
+	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "DATABASE_ERROR", resp.Error)
+	assert.Equal(t, "Failed to query data", resp.Message)
+	assert.Nil(t, resp.Details, "internal details must be stripped from the response")
+}
+
+// TestFailPreservesClientDetails verifies that client-side (4xx) failures keep
+// their details, which are intended to help the caller correct the request.
+func TestFailPreservesClientDetails(t *testing.T) {
+	e := echo.New()
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := fail(c, http.StatusBadRequest, "VALIDATION_ERROR", "Invalid input", "field 'name' is required")
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	body := rec.Body.String()
+	assert.True(t, strings.Contains(body, "field 'name' is required"),
+		"client-facing validation details should be preserved")
+}


### PR DESCRIPTION
## FIX-011 — Stop leaking raw database/internal errors to API clients

### Problem
Server-side failures returned the raw error text as the response `details` field. Many are database errors that expose internal schema (table/column names) to clients.

### Fix
Sanitize centrally in `fail()`:
- For `status >= 500`: log the detailed error via zap (`namespace=adminapi`) for operators and **strip it from the client response**, returning only the generic error code + message.
- Client-side (4xx) details (e.g. validation messages) are **preserved**.

This single-point fix covers all ~55 leaking 5xx call sites across auth/nas/nodes/operators/profiles/sessions/settings/system_backup without churning every handler.

### Tests
`internal/adminapi/responses_test.go`:
- `TestFailSanitizesInternalDetails` — asserts table/column names do not leak and `details` is nil on 500.
- `TestFailPreservesClientDetails` — asserts 4xx validation details are retained.

### Validation
- `go build ./...` ✅
- `go test ./internal/adminapi/` ✅
- `golangci-lint run ./internal/adminapi/...` ✅ (0 issues)

Refs docs/fix-checklist.md FIX-011.