### PR TITLE
fix(adminapi): invalidate tokens for disabled accounts (FIX-012)

### DIFF
--- a/internal/adminapi/auth.go
+++ b/internal/adminapi/auth.go
@@ -158,6 +158,11 @@ func resolveOperatorFromContext(c echo.Context) (*domain.SysOpr, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Reject tokens issued to accounts that have since been disabled so that
+	// revoking an operator takes effect immediately, before the JWT expires.
+	if strings.EqualFold(operator.Status, common.DISABLED) {
+		return nil, errors.New("account disabled")
+	}
 	operator.Password = ""
 	return &operator, nil
 }

--- a/internal/adminapi/auth_test.go
+++ b/internal/adminapi/auth_test.go
@@ -311,6 +311,42 @@ func TestCurrentUserHandler(t *testing.T) {
 	assert.Equal(t, testOpr.Username, user["username"])
 }
 
+// TestResolveOperatorFromContext_DisabledAccount verifies that a token issued to
+// an operator that is subsequently disabled is rejected immediately, before the
+// JWT itself expires (FIX-012).
+func TestResolveOperatorFromContext_DisabledAccount(t *testing.T) {
+	db, e, appCtx, testOpr, cleanup := setupAuthTest(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/me", nil)
+	rec := httptest.NewRecorder()
+	c := CreateTestContext(e, db, req, rec, appCtx)
+	c.Set("current_operator", nil) // force resolution from the JWT, not the test backdoor
+	setJWTUser(t, c, testOpr)
+
+	// While enabled, the token resolves successfully.
+	op, err := resolveOperatorFromContext(c)
+	require.NoError(t, err)
+	require.Equal(t, testOpr.Username, op.Username)
+
+	// Disable the account after the token was issued.
+	testOpr.Status = common.DISABLED
+	require.NoError(t, db.Save(testOpr).Error)
+
+	// The previously valid token must now be rejected.
+	_, err = resolveOperatorFromContext(c)
+	require.Error(t, err)
+
+	// And the protected handler returns 401.
+	rec2 := httptest.NewRecorder()
+	c2 := CreateTestContext(e, db, req, rec2, appCtx)
+	c2.Set("current_operator", nil)
+	setJWTUser(t, c2, testOpr)
+	err = currentUserHandler(c2)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusUnauthorized, rec2.Code)
+}
+
 // TestCurrentUserHandler_NoUser tests the current user handler without a user in context
 func TestCurrentUserHandler_NoUser(t *testing.T) {
 	_, e, _, _, cleanup := setupAuthTest(t)


### PR DESCRIPTION
## FIX-012 — Disabled accounts' issued tokens take effect immediately

### Problem
Disabling an operator only blocked **new** logins. Any JWT already issued (TTL up to 12h) stayed valid, so a revoked operator could keep using the admin API until token expiry.

### Fix
`resolveOperatorFromContext` now re-checks `operator.Status` after loading the record from the database on every request and rejects the token when the account is `disabled`. This resolver backs both the authz middleware (`RequireLevel`) and `currentUserHandler`, so disabling an account is enforced immediately across all protected endpoints (HTTP 401).

### Tests
`TestResolveOperatorFromContext_DisabledAccount` — issues a token while enabled (resolves OK), disables the account, then asserts the resolver errors and the protected handler returns 401.

### Validation
- `go build ./...` ✅
- `go test ./internal/adminapi/` ✅
- `golangci-lint run ./internal/adminapi/...` ✅ (0 issues)

Refs docs/fix-checklist.md FIX-012.