### PR TITLE
fix(adminapi): strengthen system restore validation (FIX-013)

### DIFF
--- a/internal/adminapi/system_backup.go
+++ b/internal/adminapi/system_backup.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -15,10 +16,18 @@ import (
 
 	"github.com/talkincode/toughradius/v9/internal/domain"
 	"github.com/talkincode/toughradius/v9/internal/webserver"
+	"github.com/talkincode/toughradius/v9/pkg/common"
 )
 
 // backupVersion identifies the backup payload schema.
 const backupVersion = "9.0"
+
+// supportedBackupMajor is the only schema major version restoreSystem accepts.
+const supportedBackupMajor = "9"
+
+// maxRestoreRecords caps the number of records accepted per table on restore,
+// bounding the work a single (potentially malicious) payload can trigger.
+const maxRestoreRecords = 100000
 
 // SystemBackup is the serialized snapshot of the core configuration tables.
 type SystemBackup struct {
@@ -124,10 +133,24 @@ func restoreSystem(c echo.Context) error {
 		return fail(c, http.StatusBadRequest, "INVALID_BACKUP", "Invalid backup file format", err.Error())
 	}
 
-	// Guard against arbitrary or incompatible JSON: a valid backup always carries
-	// a version stamp written by backupSystem.
-	if backup.Version == "" {
-		return fail(c, http.StatusBadRequest, "INVALID_BACKUP", "Backup file is missing a version and may be incompatible", nil)
+	// Strong validation: reject arbitrary, incompatible, or malformed payloads
+	// before touching the database.
+	if err := validateBackup(&backup); err != nil {
+		return fail(c, http.StatusBadRequest, "INVALID_BACKUP", "Backup failed validation", err.Error())
+	}
+
+	// Restoring the operators table can rewrite admin password hashes and
+	// privilege levels, so it is a potential privilege-escalation vector.
+	// Restrict it to super operators even though admins may restore other tables.
+	if len(backup.Operators) > 0 {
+		current, err := resolveOperatorFromContext(c)
+		if err != nil {
+			return fail(c, http.StatusUnauthorized, "UNAUTHORIZED", "Authentication required", nil)
+		}
+		if !strings.EqualFold(current.Level, LevelSuper) {
+			return fail(c, http.StatusForbidden, "PERMISSION_DENIED",
+				"Only super operators may restore the operators table", nil)
+		}
 	}
 
 	result := SystemRestoreResult{}
@@ -180,4 +203,96 @@ func restoreSystem(c echo.Context) error {
 	}
 
 	return ok(c, result)
+}
+
+// validateBackup performs strong, write-free validation of a restore payload.
+// It rejects incompatible schema versions, oversized payloads, and records that
+// are missing required identifiers or carry invalid enum-like values, ensuring a
+// malformed or malicious backup cannot be upserted into the configuration tables.
+func validateBackup(b *SystemBackup) error {
+	major := b.Version
+	if i := strings.IndexByte(major, '.'); i >= 0 {
+		major = major[:i]
+	}
+	if major != supportedBackupMajor {
+		return fmt.Errorf("incompatible backup version %q, expected %s.x", b.Version, supportedBackupMajor)
+	}
+
+	for name, n := range map[string]int{
+		"nodes":     len(b.Nodes),
+		"nas":       len(b.Nas),
+		"profiles":  len(b.Profiles),
+		"users":     len(b.Users),
+		"configs":   len(b.Configs),
+		"operators": len(b.Operators),
+	} {
+		if n > maxRestoreRecords {
+			return fmt.Errorf("table %q has %d records, exceeding the limit of %d", name, n, maxRestoreRecords)
+		}
+	}
+
+	for i := range b.Nodes {
+		if b.Nodes[i].ID == 0 || strings.TrimSpace(b.Nodes[i].Name) == "" {
+			return fmt.Errorf("nodes[%d]: id and name are required", i)
+		}
+	}
+	for i := range b.Nas {
+		if b.Nas[i].ID == 0 || strings.TrimSpace(b.Nas[i].Name) == "" {
+			return fmt.Errorf("nas[%d]: id and name are required", i)
+		}
+		if !isValidStatus(b.Nas[i].Status) {
+			return fmt.Errorf("nas[%d]: invalid status %q", i, b.Nas[i].Status)
+		}
+	}
+	for i := range b.Profiles {
+		if b.Profiles[i].ID == 0 || strings.TrimSpace(b.Profiles[i].Name) == "" {
+			return fmt.Errorf("profiles[%d]: id and name are required", i)
+		}
+	}
+	for i := range b.Users {
+		if b.Users[i].ID == 0 || strings.TrimSpace(b.Users[i].Username) == "" {
+			return fmt.Errorf("users[%d]: id and username are required", i)
+		}
+		if !isValidStatus(b.Users[i].Status) {
+			return fmt.Errorf("users[%d]: invalid status %q", i, b.Users[i].Status)
+		}
+	}
+	for i := range b.Configs {
+		if b.Configs[i].ID == 0 || strings.TrimSpace(b.Configs[i].Name) == "" {
+			return fmt.Errorf("configs[%d]: id and name are required", i)
+		}
+	}
+	for i := range b.Operators {
+		if b.Operators[i].ID == 0 || strings.TrimSpace(b.Operators[i].Username) == "" {
+			return fmt.Errorf("operators[%d]: id and username are required", i)
+		}
+		if !isValidLevel(b.Operators[i].Level) {
+			return fmt.Errorf("operators[%d]: invalid level %q", i, b.Operators[i].Level)
+		}
+		if !isValidStatus(b.Operators[i].Status) {
+			return fmt.Errorf("operators[%d]: invalid status %q", i, b.Operators[i].Status)
+		}
+	}
+	return nil
+}
+
+// isValidStatus reports whether s is an accepted account/device status. An empty
+// status is allowed because callers default it elsewhere.
+func isValidStatus(s string) bool {
+	switch s {
+	case "", common.ENABLED, common.DISABLED:
+		return true
+	default:
+		return false
+	}
+}
+
+// isValidLevel reports whether l is a recognized operator privilege level.
+func isValidLevel(l string) bool {
+	switch l {
+	case LevelSuper, LevelAdmin, LevelOperator:
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/adminapi/system_backup_test.go
+++ b/internal/adminapi/system_backup_test.go
@@ -129,3 +129,87 @@ func TestRestoreSystem_MissingVersion(t *testing.T) {
 	require.NoError(t, restoreSystem(c))
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
+
+// restoreRequest builds a multipart restore request body for the given payload.
+func restoreRequest(t *testing.T, payload []byte) (*http.Request, *httptest.ResponseRecorder) {
+	t.Helper()
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile("upload", "backup.json")
+	require.NoError(t, err)
+	_, err = part.Write(payload)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/system/restore", body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	return req, httptest.NewRecorder()
+}
+
+func TestRestoreSystem_IncompatibleVersion(t *testing.T) {
+	db := setupTestDB(t)
+	appCtx := setupTestApp(t, db)
+
+	req, rec := restoreRequest(t, []byte(`{"version":"8.5"}`))
+	c := CreateTestContext(setupTestEcho(), db, req, rec, appCtx)
+
+	require.NoError(t, restoreSystem(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	var resp ErrorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "INVALID_BACKUP", resp.Error)
+}
+
+func TestRestoreSystem_InvalidOperatorLevel(t *testing.T) {
+	db := setupTestDB(t)
+	appCtx := setupTestApp(t, db)
+
+	// Operator with an unrecognized privilege level must be rejected outright.
+	payload := []byte(`{"version":"9.0","operators":[{"id":"42","username":"evil","level":"root","status":"enabled"}]}`)
+	req, rec := restoreRequest(t, payload)
+	c := CreateTestContext(setupTestEcho(), db, req, rec, appCtx)
+
+	require.NoError(t, restoreSystem(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	var count int64
+	db.Model(&domain.SysOpr{}).Count(&count)
+	assert.Equal(t, int64(0), count, "no operator should have been written")
+}
+
+func TestRestoreSystem_OperatorsRequireSuper(t *testing.T) {
+	db := setupTestDB(t)
+	appCtx := setupTestApp(t, db)
+
+	// A well-formed operator payload, but the caller is only an admin (not super):
+	// restoring the operators table must be forbidden to prevent escalation.
+	payload := []byte(`{"version":"9.0","operators":[{"id":"42","username":"newadmin","level":"super","status":"enabled"}]}`)
+	req, rec := restoreRequest(t, payload)
+	c := CreateTestContext(setupTestEcho(), db, req, rec, appCtx)
+	c.Set("current_operator", &domain.SysOpr{ID: 7, Username: "admin", Level: LevelAdmin, Status: "enabled"})
+
+	require.NoError(t, restoreSystem(c))
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+
+	var count int64
+	db.Model(&domain.SysOpr{}).Count(&count)
+	assert.Equal(t, int64(0), count, "operators must not be written for non-super callers")
+}
+
+func TestRestoreSystem_OperatorsAllowedForSuper(t *testing.T) {
+	db := setupTestDB(t)
+	appCtx := setupTestApp(t, db)
+
+	payload := []byte(`{"version":"9.0","operators":[{"id":"42","username":"newadmin","level":"admin","status":"enabled"}]}`)
+	req, rec := restoreRequest(t, payload)
+	// CreateTestContext injects a super operator by default.
+	c := CreateTestContext(setupTestEcho(), db, req, rec, appCtx)
+
+	require.NoError(t, restoreSystem(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var count int64
+	db.Model(&domain.SysOpr{}).Where("username = ?", "newadmin").Count(&count)
+	assert.Equal(t, int64(1), count)
+}


### PR DESCRIPTION
## FIX-013 — Strong validation for system restore

### Problem
`/system/restore` accepted any JSON carrying a non-empty `version` and upserted it directly into the core configuration tables. A crafted payload could inject arbitrary records or **escalate privileges** through the operators table (admin password hashes / levels).

### Fix
Added write-free `validateBackup()` that runs before any DB write:
- **Version compatibility** — only the supported schema major version (`9.x`) is accepted.
- **Size cap** — each table is limited to `maxRestoreRecords` (100k) to bound resource usage.
- **Required identifiers** — every row must have a non-zero `id` and a non-empty name/username.
- **Enum validation** — operator `level` ∈ {super, admin, operator}; account/device `status` ∈ {enabled, disabled, ""}.

Plus a **privilege boundary**: restoring the `operators` table now requires **super** level (it can rewrite admin hashes/levels). Admins may still restore the other tables.

### Tests
- `TestRestoreSystem_IncompatibleVersion` → 400
- `TestRestoreSystem_InvalidOperatorLevel` → 400, nothing written
- `TestRestoreSystem_OperatorsRequireSuper` → 403 for admin caller, nothing written
- `TestRestoreSystem_OperatorsAllowedForSuper` → 200 happy path
- Existing backup/restore/idempotency tests still pass.

### Validation
- `go build ./...` ✅
- `go test ./internal/adminapi/` ✅
- `golangci-lint run ./internal/adminapi/...` ✅ (0 issues)

Refs docs/fix-checklist.md FIX-013.