### PR TITLE
refactor(adminapi): centralize sort/order validation helper (FIX-014)

### DIFF
--- a/internal/adminapi/accounting.go
+++ b/internal/adminapi/accounting.go
@@ -11,6 +11,15 @@ import (
 	"github.com/talkincode/toughradius/v9/internal/webserver"
 )
 
+// allowedAcctSortFields is the allowlist of sortable columns for the accounting
+// log list. It prevents SQL injection through the sort parameter, which is
+// interpolated directly into the ORDER BY clause.
+var allowedAcctSortFields = map[string]bool{
+	"id": true, "username": true, "acct_session_id": true,
+	"acct_start_time": true, "acct_stop_time": true, "acct_session_time": true,
+	"nas_addr": true, "framed_ipaddr": true, "acct_input_total": true, "acct_output_total": true,
+}
+
 // ListAccounting retrieves the accounting logs table
 // @Summary get accounting logs table
 // @Tags Accounting
@@ -40,21 +49,7 @@ func ListAccounting(c echo.Context) error {
 		perPage = 10
 	}
 
-	sortField := c.QueryParam("sort")
-	order := c.QueryParam("order")
-
-	// 白名单验证排序字段，防止 SQL 注入
-	allowedSortFields := map[string]bool{
-		"id": true, "username": true, "acct_session_id": true,
-		"acct_start_time": true, "acct_stop_time": true, "acct_session_time": true,
-		"nas_addr": true, "framed_ipaddr": true, "acct_input_total": true, "acct_output_total": true,
-	}
-	if !allowedSortFields[sortField] {
-		sortField = "acct_start_time"
-	}
-	if order != "ASC" && order != "DESC" {
-		order = "DESC"
-	}
+	sortField, order := parseSort(c, allowedAcctSortFields, "acct_start_time", "DESC")
 
 	var total int64
 	var records []domain.RadiusAccounting

--- a/internal/adminapi/helpers.go
+++ b/internal/adminapi/helpers.go
@@ -21,6 +21,27 @@ func parsePagination(c echo.Context) (int, int) {
 	return page, pageSize
 }
 
+// parseSort extracts and validates the `sort` and `order` query parameters
+// against an allowlist of sortable columns, returning values that are safe to
+// interpolate into an ORDER BY clause. Unknown or empty inputs fall back to
+// defaultField/defaultOrder. Centralizing this guard ensures every list
+// endpoint applies the same SQL-injection-safe column allowlist instead of
+// re-implementing (and potentially forgetting) it.
+func parseSort(c echo.Context, allowed map[string]bool, defaultField, defaultOrder string) (field, order string) {
+	field = c.QueryParam("sort")
+	if field == "" || !allowed[field] {
+		field = defaultField
+	}
+	order = strings.ToUpper(strings.TrimSpace(c.QueryParam("order")))
+	if order != "ASC" && order != "DESC" {
+		order = strings.ToUpper(strings.TrimSpace(defaultOrder))
+	}
+	if order != "ASC" && order != "DESC" {
+		order = "ASC"
+	}
+	return field, order
+}
+
 func parseIDParam(c echo.Context, name string) (int64, error) {
 	param := c.Param(name)
 	if param == "" {

--- a/internal/adminapi/helpers_test.go
+++ b/internal/adminapi/helpers_test.go
@@ -1,0 +1,55 @@
+package adminapi
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func sortContext(t *testing.T, sort, order string) echo.Context {
+	t.Helper()
+	q := url.Values{}
+	if sort != "" {
+		q.Set("sort", sort)
+	}
+	if order != "" {
+		q.Set("order", order)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/?"+q.Encode(), nil)
+	rec := httptest.NewRecorder()
+	return echo.New().NewContext(req, rec)
+}
+
+func TestParseSort(t *testing.T) {
+	allowed := map[string]bool{"id": true, "name": true, "created_at": true}
+
+	tests := []struct {
+		name         string
+		sort         string
+		order        string
+		defaultField string
+		defaultOrder string
+		wantField    string
+		wantOrder    string
+	}{
+		{"valid field and order", "name", "ASC", "id", "DESC", "name", "ASC"},
+		{"unknown field falls back to default", "password; DROP TABLE", "ASC", "id", "DESC", "id", "ASC"},
+		{"empty field falls back to default", "", "DESC", "id", "DESC", "id", "DESC"},
+		{"invalid order falls back to default", "name", "bogus", "id", "DESC", "name", "DESC"},
+		{"lowercase order is normalized", "name", "desc", "id", "ASC", "name", "DESC"},
+		{"invalid default order coerced to ASC", "x", "y", "id", "weird", "id", "ASC"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := sortContext(t, tt.sort, tt.order)
+			field, order := parseSort(c, allowed, tt.defaultField, tt.defaultOrder)
+			assert.Equal(t, tt.wantField, field)
+			assert.Equal(t, tt.wantOrder, order)
+		})
+	}
+}

--- a/internal/adminapi/nas.go
+++ b/internal/adminapi/nas.go
@@ -84,14 +84,7 @@ func ListNAS(c echo.Context) error {
 		perPage = 10
 	}
 
-	sortField := c.QueryParam("sort")
-	order := c.QueryParam("order")
-	if sortField == "" || !allowedNasSortFields[sortField] {
-		sortField = "id"
-	}
-	if order != "ASC" && order != "DESC" {
-		order = "DESC"
-	}
+	sortField, order := parseSort(c, allowedNasSortFields, "id", "DESC")
 
 	var total int64
 	var devices []domain.NetNas

--- a/internal/adminapi/profiles.go
+++ b/internal/adminapi/profiles.go
@@ -51,14 +51,7 @@ func ListProfiles(c echo.Context) error {
 		perPage = 10
 	}
 
-	sortField := c.QueryParam("sort")
-	order := c.QueryParam("order")
-	if sortField == "" || !allowedProfileSortFields[sortField] {
-		sortField = "id"
-	}
-	if order != "ASC" && order != "DESC" {
-		order = "DESC"
-	}
+	sortField, order := parseSort(c, allowedProfileSortFields, "id", "DESC")
 
 	var total int64
 	var profiles []domain.RadiusProfile

--- a/internal/adminapi/sessions.go
+++ b/internal/adminapi/sessions.go
@@ -83,16 +83,7 @@ func ListOnlineSessions(c echo.Context) error {
 		perPage = 10
 	}
 
-	sortField := c.QueryParam("sort")
-	order := c.QueryParam("order")
-
-	// Validate sort field against whitelist to prevent SQL injection
-	if sortField == "" || !allowedSessionSortFields[sortField] {
-		sortField = "acct_start_time"
-	}
-	if order != "ASC" && order != "DESC" {
-		order = "DESC"
-	}
+	sortField, order := parseSort(c, allowedSessionSortFields, "acct_start_time", "DESC")
 
 	var total int64
 	var sessions []domain.RadiusOnline

--- a/internal/adminapi/users.go
+++ b/internal/adminapi/users.go
@@ -271,14 +271,7 @@ func listRadiusUsers(c echo.Context) error {
 	page, pageSize := parsePagination(c)
 
 	// Validate and sanitize sort field
-	sortField := c.QueryParam("sort")
-	order := c.QueryParam("order")
-	if sortField == "" || !allowedUserSortFields[sortField] {
-		sortField = "username"
-	}
-	if order != "ASC" && order != "DESC" {
-		order = "ASC"
-	}
+	sortField, order := parseSort(c, allowedUserSortFields, "username", "ASC")
 
 	base := GetDB(c).Model(&domain.RadiusUser{}).
 		Select("radius_user.*, COALESCE(ro.count, 0) AS online_count").


### PR DESCRIPTION
## FIX-014 — Centralize pagination/sort validation (root-fix SQLi-class inconsistency)

### Problem
Five list endpoints (accounting, nas, profiles, sessions, users) each re-implemented the same logic: read `sort`/`order`, validate against a column allowlist, fall back to defaults, then interpolate the column into `ORDER BY`. Duplicating this SQL-injection guard makes it easy for a future endpoint to forget the allowlist.

### Fix
Extracted `parseSort(c, allowed, defaultField, defaultOrder)` into `helpers.go` and routed all five handlers through it.
- Behavior preserved: same per-endpoint defaults.
- Minor improvement: `order` is now case-insensitive.
- Promoted accounting's inline per-request allowlist map to a package-level var for consistency.

### Tests
`TestParseSort` — valid input, unknown/empty field fallback, invalid & lowercase order normalization, default-order coercion to ASC.

### Validation
- `go build ./...` ✅
- `go test ./internal/adminapi/` ✅
- `golangci-lint run ./internal/adminapi/...` ✅ (0 issues)

Refs docs/fix-checklist.md FIX-014.