### PR TITLE
refactor(radiusd): separate plugin registry from vendor registry (FIX-016)

### DIFF
--- a/internal/radiusd/integration_test.go
+++ b/internal/radiusd/integration_test.go
@@ -26,10 +26,10 @@ import (
 )
 
 func reRegisterVendorParsers() {
-	registry.RegisterVendorParser(&parsers.DefaultParser{})
-	registry.RegisterVendorParser(&parsers.HuaweiParser{})
-	registry.RegisterVendorParser(&parsers.H3CParser{})
-	registry.RegisterVendorParser(&parsers.ZTEParser{})
+	_ = vendors.RegisterParser(&parsers.DefaultParser{})
+	_ = vendors.RegisterParser(&parsers.HuaweiParser{})
+	_ = vendors.RegisterParser(&parsers.H3CParser{})
+	_ = vendors.RegisterParser(&parsers.ZTEParser{})
 }
 
 func getFreePort() (int, error) {

--- a/internal/radiusd/registry/registry.go
+++ b/internal/radiusd/registry/registry.go
@@ -1,3 +1,12 @@
+// Package registry is the plugin pipeline registry for the RADIUS server. It
+// holds the cross-cutting auth/accounting/EAP plugins that run for every
+// request: password validators, policy checkers, response enhancers, auth
+// guards, accounting handlers, and EAP handlers.
+//
+// It is distinct from the internal/radiusd/vendors package, which is the
+// registry of vendor definitions (vendor codes plus their attribute parsers and
+// response builders). Vendor parser/builder registration and lookup belong in
+// vendors, not here; this package intentionally does not deal with vendors.
 package registry
 
 import (
@@ -7,8 +16,6 @@ import (
 	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/accounting"
 	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/auth"
 	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap"
-	vendorparserspkg "github.com/talkincode/toughradius/v9/internal/radiusd/plugins/vendorparsers"
-	"github.com/talkincode/toughradius/v9/internal/radiusd/vendors"
 )
 
 // Registry holds plugin registrations
@@ -113,46 +120,6 @@ func GetAuthGuards() []auth.Guard {
 	guards := make([]auth.Guard, len(globalRegistry.authGuards))
 	copy(guards, globalRegistry.authGuards)
 	return guards
-}
-
-// RegisterVendorParser registers a vendor parser
-func RegisterVendorParser(parser vendorparserspkg.VendorParser) {
-	_ = vendors.Register(&vendors.VendorInfo{ //nolint:errcheck
-		Code:   parser.VendorCode(),
-		Name:   parser.VendorName(),
-		Parser: parser,
-	})
-}
-
-// GetVendorParser returns a vendor parser
-func GetVendorParser(vendorCode string) (vendorparserspkg.VendorParser, bool) {
-	info, ok := vendors.Get(vendorCode)
-	if ok && info.Parser != nil {
-		return info.Parser, true
-	}
-	// Fallback to default
-	info, ok = vendors.Get("default")
-	if ok && info.Parser != nil {
-		return info.Parser, true
-	}
-	return nil, false
-}
-
-// RegisterVendorResponseBuilder registers a vendor response builder
-func RegisterVendorResponseBuilder(builder vendorparserspkg.VendorResponseBuilder) {
-	_ = vendors.Register(&vendors.VendorInfo{ //nolint:errcheck
-		Code:    builder.VendorCode(),
-		Builder: builder,
-	})
-}
-
-// GetVendorResponseBuilder returns a vendor response builder
-func GetVendorResponseBuilder(vendorCode string) (vendorparserspkg.VendorResponseBuilder, bool) {
-	info, ok := vendors.Get(vendorCode)
-	if ok && info.Builder != nil {
-		return info.Builder, true
-	}
-	return nil, false
 }
 
 // RegisterAccountingHandler registers an accounting handler

--- a/internal/radiusd/vendor_parse.go
+++ b/internal/radiusd/vendor_parse.go
@@ -4,7 +4,7 @@ import (
 	"regexp"
 	"strconv"
 
-	"github.com/talkincode/toughradius/v9/internal/radiusd/registry"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/vendors"
 	"go.uber.org/zap"
 	"layeh.com/radius"
 )
@@ -34,15 +34,15 @@ func ParseVlanIds(nasportid string) (int64, int64) {
 
 // ParseVendor uses the plugin system to parse vendor-specific attributes
 func (s *RadiusService) ParseVendor(r *radius.Request, vendorCode string) *VendorRequest {
-	// Retrieve the corresponding VendorParser from the registry
-	parser, ok := registry.GetVendorParser(vendorCode)
+	// Retrieve the corresponding VendorParser from the vendor registry
+	parser, ok := vendors.GetParser(vendorCode)
 	if !ok {
 		zap.L().Warn("vendor parser not found, using default parser",
 			zap.String("namespace", "radius"),
 			zap.String("vendor_code", vendorCode),
 		)
 		// e.g., if not found, try the default parser
-		parser, ok = registry.GetVendorParser("default")
+		parser, ok = vendors.GetParser("default")
 		if !ok {
 			// e.g., if even the default parser is missing, return an empty result
 			zap.L().Error("default vendor parser not found",

--- a/internal/radiusd/vendors/registry.go
+++ b/internal/radiusd/vendors/registry.go
@@ -1,3 +1,13 @@
+// Package vendors is the registry of RADIUS vendor definitions. Each vendor is
+// described by a VendorInfo that bundles its code, human-readable metadata, and
+// the vendor-specific attribute Parser and response Builder. It is the single
+// source of truth for vendor attribute handling.
+//
+// This is distinct from the internal/radiusd/registry package, which is the
+// plugin pipeline registry (password validators, policy checkers, response
+// enhancers, auth guards, accounting and EAP handlers). Vendor parsers and
+// builders live here, in vendors; cross-cutting auth/acct/eap plugins live in
+// registry. The two registries do not overlap.
 package vendors
 
 import (
@@ -94,6 +104,47 @@ func Register(info *VendorInfo) error {
 // Get retrieves a vendor from the global registry
 func Get(code string) (*VendorInfo, bool) {
 	return globalRegistry.Get(code)
+}
+
+// GetParser returns the attribute parser registered for the given vendor code,
+// falling back to the parser registered under the "default" vendor when the
+// code has no parser of its own. This is the single lookup the RADIUS request
+// pipeline uses to obtain a vendor attribute parser.
+func GetParser(code string) (vendorparsers.VendorParser, bool) {
+	if info, ok := Get(code); ok && info.Parser != nil {
+		return info.Parser, true
+	}
+	if info, ok := Get("default"); ok && info.Parser != nil {
+		return info.Parser, true
+	}
+	return nil, false
+}
+
+// GetResponseBuilder returns the response builder registered for the given
+// vendor code, if one exists.
+func GetResponseBuilder(code string) (vendorparsers.VendorResponseBuilder, bool) {
+	if info, ok := Get(code); ok && info.Builder != nil {
+		return info.Builder, true
+	}
+	return nil, false
+}
+
+// RegisterParser registers a vendor attribute parser under its own vendor code.
+func RegisterParser(parser vendorparsers.VendorParser) error {
+	return Register(&VendorInfo{
+		Code:   parser.VendorCode(),
+		Name:   parser.VendorName(),
+		Parser: parser,
+	})
+}
+
+// RegisterResponseBuilder registers a vendor response builder under its own
+// vendor code.
+func RegisterResponseBuilder(builder vendorparsers.VendorResponseBuilder) error {
+	return Register(&VendorInfo{
+		Code:    builder.VendorCode(),
+		Builder: builder,
+	})
 }
 
 // List returns all registered vendors from the global registry


### PR DESCRIPTION
## FIX-016 — Clarify registry/ vs vendors/ responsibilities

### Problem
Two registries with confusingly similar names, plus an overlap:
- `registry/` — the **plugin pipeline** (password validators, policy checkers, response enhancers, auth guards, accounting/EAP handlers).
- `vendors/` — **vendor definitions** (code, metadata, parser, response builder).

The plugin registry also carried four vendor-bridge functions (`RegisterVendorParser`, `GetVendorParser`, `RegisterVendorResponseBuilder`, `GetVendorResponseBuilder`) that merely wrapped the vendors registry — blurring the boundary. Two of them were dead.

### Fix
Each registry now owns exactly one responsibility:
- Vendor parser/builder lookup moved into `vendors`: `GetParser` / `GetResponseBuilder` / `RegisterParser` / `RegisterResponseBuilder`.
- `ParseVendor` → `vendors.GetParser`; integration test → `vendors.RegisterParser`.
- Removed the four vendor-bridge functions (and the now-unused `vendors`/`vendorparsers` imports) from `registry`.
- Added package doc comments to **both** packages stating their distinct, non-overlapping responsibilities and cross-referencing each other.

### Validation
- `go build ./...` ✅
- `go vet ./internal/radiusd/...` ✅
- `go test ./internal/radiusd/ ./internal/radiusd/registry/ ./internal/radiusd/vendors/` ✅
- `golangci-lint run` on all three ✅ (0 issues)

Refs docs/fix-checklist.md FIX-016.