### PR TITLE
fix(radiusd): parse VLAN IDs in vendor parsers (FIX-017)

### DIFF
--- a/internal/radiusd/plugins/vendorparsers/parsers/h3c_parser.go
+++ b/internal/radiusd/plugins/vendorparsers/parsers/h3c_parser.go
@@ -45,12 +45,9 @@ func (p *H3CParser) Parse(r *radius.Request) (*vendorparsers.VendorRequest, erro
 		}
 	}
 
-	// H3C VLAN parsing
+	// H3C VLAN parsing from NAS-Port-Id.
 	nasportid := rfc2869.NASPortID_GetString(r.Packet)
-	if nasportid == "" {
-		vr.Vlanid1 = 0
-		vr.Vlanid2 = 0
-	}
+	vr.Vlanid1, vr.Vlanid2 = vendorparsers.ParseVlanIDs(nasportid)
 
 	return vr, nil
 }

--- a/internal/radiusd/plugins/vendorparsers/parsers/huawei_parser.go
+++ b/internal/radiusd/plugins/vendorparsers/parsers/huawei_parser.go
@@ -7,9 +7,14 @@ import (
 	"github.com/talkincode/toughradius/v9/internal/radiusd/vendors"
 	"layeh.com/radius"
 	"layeh.com/radius/rfc2865"
+	"layeh.com/radius/rfc2869"
 )
 
-// HuaweiParser handles Huawei vendor attributes
+// HuaweiParser handles Huawei vendor attributes.
+//
+// Note: registering a vendor (or shipping its attribute dictionary) does not by
+// itself parse anything — dictionary support is not parse support. A field on
+// VendorRequest is only populated when this parser explicitly extracts it.
 type HuaweiParser struct{}
 
 func (p *HuaweiParser) VendorCode() string {
@@ -29,10 +34,10 @@ func (p *HuaweiParser) Parse(r *radius.Request) (*vendorparsers.VendorRequest, e
 		vr.MacAddr = strings.ReplaceAll(macval, "-", ":")
 	}
 
-	// Huawei devices parse VLANs from NAS-Port-Id or other vendor-specific attributes
-	// Keep it simple here by using default values
-	vr.Vlanid1 = 0
-	vr.Vlanid2 = 0
+	// Huawei encodes VLAN IDs in the NAS-Port-Id attribute. Parse them with the
+	// shared standard parser instead of leaving them stubbed at zero.
+	nasPortID := rfc2869.NASPortID_GetString(r.Packet)
+	vr.Vlanid1, vr.Vlanid2 = vendorparsers.ParseVlanIDs(nasPortID)
 
 	return vr, nil
 }

--- a/internal/radiusd/plugins/vendorparsers/parsers/huawei_parser_test.go
+++ b/internal/radiusd/plugins/vendorparsers/parsers/huawei_parser_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/talkincode/toughradius/v9/internal/radiusd/vendors"
 	"layeh.com/radius"
 	"layeh.com/radius/rfc2865"
+	"layeh.com/radius/rfc2869"
 )
 
 func TestHuaweiParser_VendorCode(t *testing.T) {
@@ -101,4 +102,38 @@ func TestHuaweiParser_Parse_NoAttributes(t *testing.T) {
 	assert.Equal(t, "", vr.MacAddr)
 	assert.Equal(t, int64(0), vr.Vlanid1)
 	assert.Equal(t, int64(0), vr.Vlanid2)
+}
+
+// TestHuaweiParser_Parse_VLAN verifies that the Huawei parser extracts VLAN IDs
+// from NAS-Port-Id instead of leaving them stubbed at zero (FIX-017).
+func TestHuaweiParser_Parse_VLAN(t *testing.T) {
+	parser := &HuaweiParser{}
+
+	tests := []struct {
+		name          string
+		nasPortID     string
+		expectedVlan1 int64
+		expectedVlan2 int64
+	}{
+		{"dual vlan", "3/0/1:2814.727", 2814, 727},
+		{"single vlan", "3/0/1:2814", 2814, 0},
+		{"kv dual vlan", "slot=2;subslot=2;port=22;vlanid=503;vlanid2=100;", 503, 100},
+		{"no vlan", "", 0, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			packet := radius.New(radius.CodeAccessRequest, []byte("secret"))
+			if tt.nasPortID != "" {
+				_ = rfc2869.NASPortID_SetString(packet, tt.nasPortID) //nolint:errcheck
+			}
+			req := &radius.Request{Packet: packet}
+
+			vr, err := parser.Parse(req)
+			require.NoError(t, err)
+			require.NotNil(t, vr)
+			assert.Equal(t, tt.expectedVlan1, vr.Vlanid1)
+			assert.Equal(t, tt.expectedVlan2, vr.Vlanid2)
+		})
+	}
 }

--- a/internal/radiusd/plugins/vendorparsers/parsers/init.go
+++ b/internal/radiusd/plugins/vendorparsers/parsers/init.go
@@ -4,7 +4,14 @@ import (
 	"github.com/talkincode/toughradius/v9/internal/radiusd/vendors"
 )
 
-// init automatically registers all vendor parsers
+// init automatically registers all vendor parsers.
+//
+// Only the vendors listed here have an actual attribute parser. Many more
+// vendors ship an attribute dictionary under internal/radiusd/vendors/<vendor>
+// (constants and VSA definitions), but a dictionary only describes attributes —
+// it does not extract them. In other words, dictionary support is not parse
+// support: requests from a vendor without a parser registered below fall back
+// to the DefaultParser, which reads only the standard RADIUS attributes.
 func init() {
 	// Register with the new centralized registry
 	_ = vendors.Register(&vendors.VendorInfo{ //nolint:errcheck

--- a/internal/radiusd/plugins/vendorparsers/parsers/zte_parser.go
+++ b/internal/radiusd/plugins/vendorparsers/parsers/zte_parser.go
@@ -42,12 +42,9 @@ func (p *ZTEParser) Parse(r *radius.Request) (*vendorparsers.VendorRequest, erro
 		zap.L().Warn("ZTE CallingStationID is empty", zap.String("namespace", "radius"))
 	}
 
-	// VLAN Parse
+	// VLAN parsing from NAS-Port-Id.
 	nasportid := rfc2869.NASPortID_GetString(r.Packet)
-	if nasportid == "" {
-		vr.Vlanid1 = 0
-		vr.Vlanid2 = 0
-	}
+	vr.Vlanid1, vr.Vlanid2 = vendorparsers.ParseVlanIDs(nasportid)
 
 	return vr, nil
 }

--- a/internal/radiusd/plugins/vendorparsers/vlan.go
+++ b/internal/radiusd/plugins/vendorparsers/vlan.go
@@ -1,0 +1,38 @@
+package vendorparsers
+
+import (
+	"regexp"
+	"strconv"
+)
+
+var (
+	// vlanStdRegexp1 matches the "slot/subslot/port:vlan[.vlan2]" NAS-Port-Id
+	// encoding, e.g. "3/0/1:2814.727".
+	vlanStdRegexp1 = regexp.MustCompile(`\w?\s?\d+/\d+/\d+:(\d+)(\.(\d+))?\s?`)
+	// vlanStdRegexp2 matches the "vlanid=<n>;vlanid2=<n>;" NAS-Port-Id encoding,
+	// e.g. "slot=2;subslot=2;port=22;vlanid=503;vlanid2=100;".
+	vlanStdRegexp2 = regexp.MustCompile(`vlanid=(\d+);(vlanid2=?(\d+);)?`)
+)
+
+// ParseVlanIDs extracts the inner and outer VLAN IDs encoded in a NAS-Port-Id
+// string. It recognizes the two common encodings:
+//
+//   - "slot/subslot/port:vlan[.vlan2]"  (e.g. "3/0/1:2814.727")
+//   - "vlanid=<n>;vlanid2=<n>;"         (e.g. "vlanid=503;vlanid2=100;")
+//
+// It returns (0, 0) when the string carries no recognizable VLAN information.
+// This shared helper lets every vendor parser extract VLANs consistently
+// instead of re-implementing (or stubbing out) the logic.
+func ParseVlanIDs(nasPortID string) (vlanid1, vlanid2 int64) {
+	attrs := vlanStdRegexp1.FindStringSubmatch(nasPortID)
+	if attrs == nil {
+		attrs = vlanStdRegexp2.FindStringSubmatch(nasPortID)
+	}
+	if attrs != nil {
+		vlanid1, _ = strconv.ParseInt(attrs[1], 10, 64)
+		if attrs[2] != "" {
+			vlanid2, _ = strconv.ParseInt(attrs[3], 10, 64)
+		}
+	}
+	return vlanid1, vlanid2
+}

--- a/internal/radiusd/plugins/vendorparsers/vlan_test.go
+++ b/internal/radiusd/plugins/vendorparsers/vlan_test.go
@@ -1,0 +1,32 @@
+package vendorparsers
+
+import "testing"
+
+func TestParseVlanIDs(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		vlanid1 int64
+		vlanid2 int64
+	}{
+		{"port and dual vlan", "3/0/1:2814.727", 2814, 727},
+		{"port and single vlan", "3/0/1:2814", 2814, 0},
+		{"kv single vlan", "slot=2;subslot=2;port=22;vlanid=503;", 503, 0},
+		{"kv dual vlan", "slot=2;subslot=2;port=22;vlanid=503;vlanid2=100;", 503, 100},
+		{"empty", "", 0, 0},
+		{"invalid", "invalid-format", 0, 0},
+		{"port only no vlan", "3/0/1:", 0, 0},
+		{"large vlan", "1/0/1:4094.4093", 4094, 4093},
+		{"leading interface name", "GigabitEthernet 1/0/1:100", 100, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v1, v2 := ParseVlanIDs(tt.input)
+			if v1 != tt.vlanid1 || v2 != tt.vlanid2 {
+				t.Errorf("ParseVlanIDs(%q) = (%d, %d), want (%d, %d)",
+					tt.input, v1, v2, tt.vlanid1, tt.vlanid2)
+			}
+		})
+	}
+}

--- a/internal/radiusd/vendor_parse.go
+++ b/internal/radiusd/vendor_parse.go
@@ -1,35 +1,17 @@
 package radiusd
 
 import (
-	"regexp"
-	"strconv"
-
+	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/vendorparsers"
 	"github.com/talkincode/toughradius/v9/internal/radiusd/vendors"
 	"go.uber.org/zap"
 	"layeh.com/radius"
 )
 
-var (
-	vlanStdRegexp1 = regexp.MustCompile(`\w?\s?\d+/\d+/\d+:(\d+)(\.(\d+))?\s?`)
-	vlanStdRegexp2 = regexp.MustCompile(`vlanid=(\d+);(vlanid2=?(\d+);)?`)
-)
-
-// ParseVlanIds parses standard VLAN ID values
+// ParseVlanIds parses standard VLAN ID values from a NAS-Port-Id string. It
+// delegates to vendorparsers.ParseVlanIDs, the single shared implementation
+// used by the vendor parsers.
 func ParseVlanIds(nasportid string) (int64, int64) {
-	var vlanid1 int64 = 0
-	var vlanid2 int64 = 0
-	attrs := vlanStdRegexp1.FindStringSubmatch(nasportid)
-	if attrs == nil {
-		attrs = vlanStdRegexp2.FindStringSubmatch(nasportid)
-	}
-
-	if attrs != nil {
-		vlanid1, _ = strconv.ParseInt(attrs[1], 10, 64)
-		if attrs[2] != "" {
-			vlanid2, _ = strconv.ParseInt(attrs[3], 10, 64)
-		}
-	}
-	return vlanid1, vlanid2
+	return vendorparsers.ParseVlanIDs(nasportid)
 }
 
 // ParseVendor uses the plugin system to parse vendor-specific attributes


### PR DESCRIPTION
## FIX-017 — De-stub vendor VLAN parsing

### Problem
VLAN extraction was stubbed out in every vendor parser:
- **Huawei** parser hard-coded `Vlanid1`/`Vlanid2` to 0.
- **H3C** and **ZTE** parsers read `NAS-Port-Id` but discarded it.

As a result the VLAN bind/recording path (`UpdateBind`) was effectively non-functional for all vendors.

### Change
- Add a single shared helper `vendorparsers.ParseVlanIDs(nasPortID)` holding the two standard NAS-Port-Id VLAN encodings (`slot/subslot/port:vlan[.vlan2]` and `vlanid=<n>;vlanid2=<n>;`).
- Wire the Huawei, H3C and ZTE parsers to it.
- `radiusd.ParseVlanIds` now delegates to the same helper (its existing test suite passes unchanged).
- Clarify **"dictionary ≠ parse"**: vendors that ship only an attribute dictionary (no registered parser) fall back to the default parser, which reads standard RADIUS attributes only. Documented on the parser `init` and the Huawei parser.

### Tests
- New `vendorparsers/vlan_test.go` covering both encodings + edge cases.
- New `TestHuaweiParser_Parse_VLAN` proving the Huawei parser now extracts VLANs from NAS-Port-Id.
- `go build ./...`, targeted `go test`, and `golangci-lint run ./internal/radiusd/...` all green.

Part of the docs/fix-checklist.md remediation campaign (P2).