### PR TITLE
fix(webserver): remove duplicate DevTools well-known route (FIX-018)

### DIFF
--- a/internal/webserver/server.go
+++ b/internal/webserver/server.go
@@ -168,19 +168,6 @@ func NewAdminServer(appCtx app.AppContext) *AdminServer {
 
 	s.root.GET("/.well-known/appspecific/com.chrome.devtools.json", chromeDevtoolsManifest)
 
-	// Chrome DevTools config filerequestHandle
-	s.root.GET("/.well-known/appspecific/com.chrome.devtools.json", func(c echo.Context) error {
-		return c.JSON(200, map[string]interface{}{
-			"applications": []map[string]interface{}{
-				{
-					"name":    "ToughRADIUS",
-					"version": "9.0",
-					"url":     "/admin",
-				},
-			},
-		})
-	})
-
 	// JWT middleware
 	s.jwtConfig = echojwt.Config{
 		SigningKey:    []byte(appconfig.Web.Secret),


### PR DESCRIPTION
## FIX-018 — Remove duplicate DevTools well-known route

The Chrome DevTools well-known endpoint `/.well-known/appspecific/com.chrome.devtools.json` was registered **twice** in `NewAdminServer`:

1. With the canonical, documented `chromeDevtoolsManifest` handler.
2. Immediately after, with an inline anonymous handler that silently shadowed the first.

This removes the inline duplicate and keeps the `chromeDevtoolsManifest` handler (which emits a richer, documented manifest).

### Verification
- `go build ./...`, `go vet ./internal/webserver/`, and `golangci-lint run ./internal/webserver/...` all green.

Part of the docs/fix-checklist.md remediation campaign (P2).