### PR TITLE
fix(deps): unify JWT library on golang-jwt/jwt/v5 (FIX-019)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/bwmarrin/snowflake v0.3.0
 	github.com/glebarez/sqlite v1.11.0
 	github.com/gocarina/gocsv v0.0.0-20230616125104-99d496ca653d
-	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/google/uuid v1.6.0
 	github.com/labstack/echo-jwt/v4 v4.4.0
 	github.com/labstack/echo/v4 v4.13.4

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,6 @@ github.com/go-playground/validator/v10 v10.28.0 h1:Q7ibns33JjyW48gHkuFT91qX48KG0
 github.com/go-playground/validator/v10 v10.28.0/go.mod h1:GoI6I1SjPBh9p7ykNE/yj3fFYbyDOpwMn5KXd+m2hUU=
 github.com/gocarina/gocsv v0.0.0-20230616125104-99d496ca653d h1:KbPOUXFUDJxwZ04vbmDOc3yuruGvVO+LOa7cVER3yWw=
 github.com/gocarina/gocsv v0.0.0-20230616125104-99d496ca653d/go.mod h1:5YoVOkjYAQumqlV356Hj3xeYh4BdZuLE0/nRkf2NKkI=
-github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
-github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
 github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=

--- a/internal/webserver/server.go
+++ b/internal/webserver/server.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/360EntSecGroup-Skylar/excelize"
 	"github.com/gocarina/gocsv"
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 	echojwt "github.com/labstack/echo-jwt/v4"
 	"github.com/spf13/cast"
 	"github.com/talkincode/toughradius/v9/internal/app"

--- a/pkg/web/web.go
+++ b/pkg/web/web.go
@@ -18,7 +18,7 @@ import (
 	"time"
 
 	"github.com/360EntSecGroup-Skylar/excelize"
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/labstack/echo/v4"
 	"github.com/spf13/cast"
 	"github.com/talkincode/toughradius/v9/pkg/common"


### PR DESCRIPTION
## FIX-019 — Unify the JWT library version

The codebase mixed **two major versions** of golang-jwt:
- `internal/adminapi` (v9) uses `golang-jwt/jwt/v5`.
- `pkg/web` and `internal/webserver` still imported `golang-jwt/jwt/v4`.

Since `labstack/echo-jwt/v4` already depends on `jwt/v5`, the `v4` import was redundant and a source of subtle `jwt.MapClaims`/`jwt.Token` type-mismatch risk across packages.

### Change
- Migrate `pkg/web/web.go` and `internal/webserver/server.go` from `jwt/v4` to `jwt/v5` (the API surface used — `jwt.New`, `jwt.Parse`, `jwt.MapClaims`, `SigningMethodHS256`, `SignedString` — is source-compatible).
- `go mod tidy` drops the now-unused `github.com/golang-jwt/jwt/v4` dependency.

### Verification
- `go build ./...` green.
- `go test ./internal/webserver/ ./pkg/web/ ./internal/adminapi/` green.
- `golangci-lint run` on the affected packages: 0 issues.

Part of the docs/fix-checklist.md remediation campaign (P2).