### PR TITLE
fix(eap): correct "Sendresponse" comment typo (FIX-020)

### DIFF
--- a/internal/radiusd/plugins/eap/handlers/md5_handler.go
+++ b/internal/radiusd/plugins/eap/handlers/md5_handler.go
@@ -76,7 +76,7 @@ func (h *MD5Handler) HandleIdentity(ctx *eap.EAPContext) (bool, error) {
 	// Set the EAP-Message and Message-Authenticator
 	eap.SetEAPMessageAndAuth(response, eapData, ctx.Secret)
 
-	// Sendresponse
+	// Send the EAP response
 	return true, ctx.ResponseWriter.Write(response)
 }
 

--- a/internal/radiusd/plugins/eap/handlers/mschapv2_handler.go
+++ b/internal/radiusd/plugins/eap/handlers/mschapv2_handler.go
@@ -94,7 +94,7 @@ func (h *MSCHAPv2Handler) HandleIdentity(ctx *eap.EAPContext) (bool, error) {
 	// Set the EAP-Message and Message-Authenticator
 	eap.SetEAPMessageAndAuth(response, eapData, ctx.Secret)
 
-	// Sendresponse
+	// Send the EAP response
 	return true, ctx.ResponseWriter.Write(response)
 }
 

--- a/internal/radiusd/plugins/eap/handlers/otp_handler.go
+++ b/internal/radiusd/plugins/eap/handlers/otp_handler.go
@@ -71,7 +71,7 @@ func (h *OTPHandler) HandleIdentity(ctx *eap.EAPContext) (bool, error) {
 	// Set the EAP-Message and Message-Authenticator
 	eap.SetEAPMessageAndAuth(response, eapData, ctx.Secret)
 
-	// Sendresponse
+	// Send the EAP response
 	return true, ctx.ResponseWriter.Write(response)
 }
 


### PR DESCRIPTION
## FIX-020 — Fix typos

The MD5, OTP and MSCHAPv2 EAP handlers each carried a machine-translation artifact comment `// Sendresponse`. Reworded to `// Send the EAP response`.

Notes:
- The other identifier called out in the review (`EapMethad`) is **already** spelled correctly as `EapMethod` in the current code.
- A repository-wide `misspell` scan (the same linter enabled in CI) reports **no remaining issues** across Go and TS sources.

Part of the docs/fix-checklist.md remediation campaign (P2).