### PR TITLE
fix(app): implement SaveSettings instead of no-op placeholder (FIX-021)

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,12 +1,16 @@
 package app
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"runtime/debug"
+	"strings"
 	"time"
 	_ "time/tzdata"
 
 	"github.com/robfig/cron/v3"
+	"github.com/spf13/cast"
 	"github.com/talkincode/toughradius/v9/config"
 	"github.com/talkincode/toughradius/v9/internal/domain"
 	"github.com/talkincode/toughradius/v9/pkg/metrics"
@@ -207,11 +211,35 @@ func (a *Application) GetSettingsBoolValue(category, key string) bool {
 	return a.configManager.GetBool(category, key)
 }
 
-// SaveSettings saves configuration settings
+// SaveSettings persists a batch of configuration settings.
+//
+// Each map key is a fully-qualified configuration key in "category.name" form
+// (matching the keys registered in config_schemas.json) and the value is the
+// new value, which is rendered to its string representation before being
+// written. Every entry is validated and stored through the ConfigManager, which
+// updates both the in-memory cache and the sys_config table atomically per key.
+//
+// If one or more keys fail (unknown key, validation error, or database error),
+// the remaining keys are still attempted and a single joined error describing
+// every failure is returned.
 func (a *Application) SaveSettings(settings map[string]interface{}) error {
-	// TODO: Implement proper settings save logic
-	// This is a placeholder to satisfy the interface
-	return nil
+	if len(settings) == 0 {
+		return nil
+	}
+
+	var errs []error
+	for key, raw := range settings {
+		category, name, ok := strings.Cut(key, ".")
+		if !ok || category == "" || name == "" {
+			errs = append(errs, fmt.Errorf("invalid settings key %q: expected \"category.name\"", key))
+			continue
+		}
+		if err := a.configManager.Set(category, name, cast.ToString(raw)); err != nil {
+			errs = append(errs, fmt.Errorf("save setting %q: %w", key, err))
+		}
+	}
+
+	return errors.Join(errs...)
 }
 
 // ProfileCache returns the profile cache instance

--- a/internal/app/save_settings_test.go
+++ b/internal/app/save_settings_test.go
@@ -1,0 +1,111 @@
+package app
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/talkincode/toughradius/v9/config"
+	"github.com/talkincode/toughradius/v9/internal/domain"
+	"gorm.io/gorm"
+)
+
+func newSaveSettingsTestApp(t *testing.T) *Application {
+	t.Helper()
+
+	dsn := fmt.Sprintf("file:savesettings_%d?mode=memory&cache=shared", time.Now().UnixNano())
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&domain.SysConfig{}))
+
+	app := &Application{gormDB: db, appConfig: &config.AppConfig{}}
+	cm := &ConfigManager{
+		app:     app,
+		configs: make(map[string]string),
+		schemas: make(map[string]*ConfigSchema),
+	}
+	cm.register(&ConfigSchema{
+		Key:     "radius.EapMethod",
+		Type:    TypeString,
+		Default: "eap-md5",
+		Enum:    []string{"eap-md5", "eap-mschapv2"},
+	})
+	cm.register(&ConfigSchema{
+		Key:     "radius.AccountingHistoryDays",
+		Type:    TypeInt,
+		Default: "90",
+	})
+	cm.register(&ConfigSchema{
+		Key:     "radius.IgnorePassword",
+		Type:    TypeBool,
+		Default: "false",
+	})
+	app.configManager = cm
+	return app
+}
+
+func TestSaveSettings_PersistsValidValues(t *testing.T) {
+	app := newSaveSettingsTestApp(t)
+
+	err := app.SaveSettings(map[string]interface{}{
+		"radius.EapMethod":             "eap-mschapv2",
+		"radius.AccountingHistoryDays": 30,
+		"radius.IgnorePassword":        true,
+	})
+	require.NoError(t, err)
+
+	// In-memory cache reflects the new values.
+	assert.Equal(t, "eap-mschapv2", app.GetSettingsStringValue("radius", "EapMethod"))
+	assert.Equal(t, int64(30), app.GetSettingsInt64Value("radius", "AccountingHistoryDays"))
+	assert.True(t, app.GetSettingsBoolValue("radius", "IgnorePassword"))
+
+	// Values are persisted to the sys_config table.
+	var rec domain.SysConfig
+	require.NoError(t, app.gormDB.Where("type = ? AND name = ?", "radius", "EapMethod").First(&rec).Error)
+	assert.Equal(t, "eap-mschapv2", rec.Value)
+}
+
+func TestSaveSettings_EmptyIsNoop(t *testing.T) {
+	app := newSaveSettingsTestApp(t)
+	require.NoError(t, app.SaveSettings(nil))
+	require.NoError(t, app.SaveSettings(map[string]interface{}{}))
+}
+
+func TestSaveSettings_InvalidKeyFormat(t *testing.T) {
+	app := newSaveSettingsTestApp(t)
+
+	err := app.SaveSettings(map[string]interface{}{
+		"missingdot": "value",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid settings key")
+}
+
+func TestSaveSettings_UnknownAndInvalidValuesRejected(t *testing.T) {
+	app := newSaveSettingsTestApp(t)
+
+	// Unknown (unregistered) key is rejected.
+	err := app.SaveSettings(map[string]interface{}{"radius.DoesNotExist": "x"})
+	require.Error(t, err)
+
+	// Enum violation is rejected and leaves the previous value untouched.
+	err = app.SaveSettings(map[string]interface{}{"radius.EapMethod": "eap-bogus"})
+	require.Error(t, err)
+	assert.Equal(t, "eap-md5", app.GetSettingsStringValue("radius", "EapMethod"))
+}
+
+func TestSaveSettings_PartialFailureAppliesValidKeys(t *testing.T) {
+	app := newSaveSettingsTestApp(t)
+
+	err := app.SaveSettings(map[string]interface{}{
+		"radius.EapMethod":    "eap-mschapv2", // valid
+		"radius.DoesNotExist": "x",            // invalid
+	})
+	require.Error(t, err)
+
+	// The valid key is still applied despite the sibling failure.
+	assert.Equal(t, "eap-mschapv2", app.GetSettingsStringValue("radius", "EapMethod"))
+}


### PR DESCRIPTION
## FIX-021 — Implement SaveSettings

`Application.SaveSettings` was an **empty placeholder** that returned `nil` without persisting anything, so any caller relying on it silently dropped configuration changes.

### Change
Implement it on top of the existing `ConfigManager.Set`, which already:
- validates values (type / enum / range), and
- writes through to both the in-memory cache **and** the `sys_config` table.

Behaviour:
- Each map key is a `category.name` configuration key.
- Values are rendered to strings via `spf13/cast` (already a dependency), so `bool`, `int`, `float64` (JSON numbers), and `string` inputs are all handled.
- Failures are aggregated with `errors.Join` — one bad key does not abort the batch, and valid keys are still applied.
- Empty/nil map is a no-op.

### Tests
New `save_settings_test.go` covers: persistence to `sys_config`, empty-map no-op, invalid key format, unknown/invalid-value rejection, and partial-failure (valid keys still applied).

### Verification
- `go build ./...`, `go test ./internal/app/`, `golangci-lint run ./internal/app/...` all green.

Part of the docs/fix-checklist.md remediation campaign (P2).