### PR TITLE
fix(adminapi): remove auth test backdoor from production (FIX-022)

### DIFF
--- a/internal/adminapi/auth.go
+++ b/internal/adminapi/auth.go
@@ -126,10 +126,19 @@ func currentUserHandler(c echo.Context) error {
 	})
 }
 
+// testOperatorResolver is a test-only seam. It is nil in production builds and
+// is assigned only by test code (see test_helpers_test.go), letting unit tests
+// inject an already-resolved operator without standing up the full JWT
+// middleware. Production code never assigns it, so the shipped binary always
+// resolves caller identity from the signed JWT below and never trusts an
+// operator placed directly into the request context.
+var testOperatorResolver func(c echo.Context) (*domain.SysOpr, bool)
+
 func resolveOperatorFromContext(c echo.Context) (*domain.SysOpr, error) {
-	// Check for directly injected operator (for testing)
-	if op, ok := c.Get("current_operator").(*domain.SysOpr); ok {
-		return op, nil
+	if testOperatorResolver != nil {
+		if op, ok := testOperatorResolver(c); ok {
+			return op, nil
+		}
 	}
 
 	userVal := c.Get("user")

--- a/internal/adminapi/auth_test.go
+++ b/internal/adminapi/auth_test.go
@@ -347,6 +347,26 @@ func TestResolveOperatorFromContext_DisabledAccount(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, rec2.Code)
 }
 
+// TestResolveOperatorFromContext_IgnoresInjectedOperatorInProduction proves the
+// FIX-022 hardening: with the test-only seam disabled (as in production builds),
+// an operator placed directly into the request context is NOT trusted, and
+// resolution falls through to the signed-JWT path.
+func TestResolveOperatorFromContext_IgnoresInjectedOperatorInProduction(t *testing.T) {
+	saved := testOperatorResolver
+	testOperatorResolver = nil // simulate the production build (no test seam)
+	t.Cleanup(func() { testOperatorResolver = saved })
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/auth/me", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("current_operator", &domain.SysOpr{ID: 1, Username: "attacker", Level: "super", Status: "enabled"})
+
+	op, err := resolveOperatorFromContext(c)
+	require.Error(t, err, "injected current_operator must not be trusted in production")
+	require.Nil(t, op)
+}
+
 // TestCurrentUserHandler_NoUser tests the current user handler without a user in context
 func TestCurrentUserHandler_NoUser(t *testing.T) {
 	_, e, _, _, cleanup := setupAuthTest(t)

--- a/internal/adminapi/test_helpers_test.go
+++ b/internal/adminapi/test_helpers_test.go
@@ -15,6 +15,20 @@ import (
 	"gorm.io/gorm"
 )
 
+// init wires the test-only operator-resolution seam so that tests can inject an
+// authenticated operator by calling c.Set("current_operator", op). This runs
+// only in the test binary; the production build leaves testOperatorResolver nil
+// and therefore never trusts a context-injected operator.
+func init() {
+	testOperatorResolver = func(c echo.Context) (*domain.SysOpr, bool) {
+		op, ok := c.Get("current_operator").(*domain.SysOpr)
+		if !ok || op == nil {
+			return nil, false
+		}
+		return op, true
+	}
+}
+
 // setupTestEcho creates an Echo instance with a validator
 func setupTestEcho() *echo.Echo {
 	e := echo.New()


### PR DESCRIPTION
## FIX-022 — Remove the authentication test backdoor from production

### Problem
`resolveOperatorFromContext` trusted an operator injected directly into the echo context via `c.Get("current_operator")` **as its first step**, bypassing JWT verification:

```go
// Check for directly injected operator (for testing)
if op, ok := c.Get("current_operator").(*domain.SysOpr); ok {
    return op, nil
}
```

Echo context values are server-side only (not remotely settable), but this is a landmine: any handler/middleware that sets `current_operator` silently bypasses auth. The function is the **single choke point** for the `RequireLevel` authz middleware *and* every operator-management handler, so the bypass was broadly reachable.

Separately, `test_helpers.go` was **not** a `_test.go` file, so the test scaffolding (and its `testing`, `net/http/httptest`, `glebarez/sqlite`, `testify` imports) was compiled **into the production binary**.

### Change
- Replace the context-value backdoor with an unexported, **test-only seam** `testOperatorResolver` — `nil` in production builds, assigned only by test code. Production now always resolves identity from the signed JWT and never trusts a context-injected operator.
- `git mv test_helpers.go test_helpers_test.go` so the test scaffolding leaves the production build. All 16 consumers are white-box `package adminapi` test files. The seam is registered from an `init()` there (defensive: rejects typed-nil).
- Add `TestResolveOperatorFromContext_IgnoresInjectedOperatorInProduction`, which disables the seam (simulating production) and asserts an injected operator is rejected.

### Verification
- `go build ./...` green; `go list -deps ./internal/adminapi` no longer includes `testing`/`httptest`/`testify`.
- `go test ./internal/adminapi/` green (full suite, incl. new security test).
- `golangci-lint run ./internal/adminapi/...`: 0 issues.

Part of the docs/fix-checklist.md remediation campaign (P2).