### PR TITLE
test: cover settings CRUD, authz negatives, accounting helpers, UpdateBind (FIX-023)

### DIFF
--- a/internal/adminapi/accounting_helpers_test.go
+++ b/internal/adminapi/accounting_helpers_test.go
@@ -1,0 +1,60 @@
+package adminapi
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseFlexibleTime(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"rfc3339", "2025-11-01T21:16:00Z", false},
+		{"datetime-local", "2025-11-01T21:16", false},
+		{"date only", "2025-11-01", false},
+		{"empty", "", true},
+		{"garbage", "not-a-time", true},
+		{"partial", "2025-13-40", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseFlexibleTime(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.True(t, got.IsZero())
+				return
+			}
+			require.NoError(t, err)
+			assert.False(t, got.IsZero())
+		})
+	}
+}
+
+func TestParseFlexibleTime_RFC3339Value(t *testing.T) {
+	got, err := parseFlexibleTime("2025-11-01T21:16:00Z")
+	require.NoError(t, err)
+	assert.Equal(t, time.Date(2025, 11, 1, 21, 16, 0, 0, time.UTC), got.UTC())
+}
+
+func TestEscapeLikePattern(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"plain", "plain"},
+		{"50%", "50\\%"},
+		{"a_b", "a\\_b"},
+		{"back\\slash", "back\\\\slash"},
+		{"%_\\", "\\%\\_\\\\"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.want, escapeLikePattern(tt.input))
+		})
+	}
+}

--- a/internal/adminapi/settings_test.go
+++ b/internal/adminapi/settings_test.go
@@ -1,0 +1,239 @@
+package adminapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/talkincode/toughradius/v9/internal/domain"
+)
+
+func newSettingsTestCtx(t *testing.T, method, target, body string) (echo.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	db, e, appCtx := CreateTestAppContext(t)
+	var reader *strings.Reader
+	if body != "" {
+		reader = strings.NewReader(body)
+	} else {
+		reader = strings.NewReader("")
+	}
+	req := httptest.NewRequest(method, target, reader)
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := CreateTestContext(e, db, req, rec, appCtx)
+	return c, rec
+}
+
+func createSettingRow(t *testing.T, c echo.Context, id int64, typ, name, value string) {
+	t.Helper()
+	require.NoError(t, GetDB(c).Create(&domain.SysConfig{
+		ID:        id,
+		Type:      typ,
+		Name:      name,
+		Value:     value,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}).Error)
+}
+
+func TestListSettings(t *testing.T) {
+	c, rec := newSettingsTestCtx(t, http.MethodGet, "/api/v1/system/settings", "")
+	createSettingRow(t, c, 101, "radius", "alpha", "1")
+	createSettingRow(t, c, 102, "radius", "beta", "2")
+	createSettingRow(t, c, 103, "web", "gamma", "3")
+
+	require.NoError(t, listSettings(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp Response
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.NotNil(t, resp.Meta)
+	assert.Equal(t, int64(3), resp.Meta.Total)
+}
+
+func TestListSettings_TypeFilter(t *testing.T) {
+	c, rec := newSettingsTestCtx(t, http.MethodGet, "/api/v1/system/settings?type=radius", "")
+	createSettingRow(t, c, 111, "radius", "alpha", "1")
+	createSettingRow(t, c, 112, "radius", "beta", "2")
+	createSettingRow(t, c, 113, "web", "gamma", "3")
+
+	require.NoError(t, listSettings(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp Response
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.NotNil(t, resp.Meta)
+	assert.Equal(t, int64(2), resp.Meta.Total, "only radius-type settings should match")
+}
+
+func TestGetSettings(t *testing.T) {
+	tests := []struct {
+		name           string
+		id             string
+		seed           bool
+		expectedStatus int
+	}{
+		{"found", "201", true, http.StatusOK},
+		{"invalid id", "not-a-number", false, http.StatusBadRequest},
+		{"not found", "999999", false, http.StatusNotFound},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, rec := newSettingsTestCtx(t, http.MethodGet, "/api/v1/system/settings/"+tt.id, "")
+			if tt.seed {
+				createSettingRow(t, c, 201, "radius", "alpha", "1")
+			}
+			c.SetParamNames("id")
+			c.SetParamValues(tt.id)
+
+			_ = getSettings(c)
+			assert.Equal(t, tt.expectedStatus, rec.Code)
+		})
+	}
+}
+
+func TestCreateSettings(t *testing.T) {
+	tests := []struct {
+		name           string
+		body           string
+		seedDuplicate  bool
+		expectedStatus int
+	}{
+		{"success", `{"type":"radius","name":"NewKey","value":"v1"}`, false, http.StatusOK},
+		{"missing value", `{"type":"radius","name":"NoVal","value":""}`, false, http.StatusBadRequest},
+		{"missing type", `{"type":"","name":"NoType","value":"v"}`, false, http.StatusBadRequest},
+		{"invalid json", `{not-json`, false, http.StatusBadRequest},
+		{"duplicate", `{"type":"radius","name":"DupKey","value":"v"}`, true, http.StatusConflict},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, rec := newSettingsTestCtx(t, http.MethodPost, "/api/v1/system/settings", tt.body)
+			if tt.seedDuplicate {
+				createSettingRow(t, c, 301, "radius", "DupKey", "existing")
+			}
+			_ = createSettings(c)
+			assert.Equal(t, tt.expectedStatus, rec.Code)
+		})
+	}
+}
+
+func TestUpdateSettings(t *testing.T) {
+	tests := []struct {
+		name           string
+		id             string
+		seed           bool
+		body           string
+		expectedStatus int
+	}{
+		{"success", "401", true, `{"value":"updated","remark":"r"}`, http.StatusOK},
+		{"invalid id", "bad", false, `{"value":"x"}`, http.StatusBadRequest},
+		{"not found", "888888", false, `{"value":"x"}`, http.StatusNotFound},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, rec := newSettingsTestCtx(t, http.MethodPut, "/api/v1/system/settings/"+tt.id, tt.body)
+			if tt.seed {
+				createSettingRow(t, c, 401, "radius", "UpdKey", "old")
+			}
+			c.SetParamNames("id")
+			c.SetParamValues(tt.id)
+
+			_ = updateSettings(c)
+			assert.Equal(t, tt.expectedStatus, rec.Code)
+
+			if tt.expectedStatus == http.StatusOK {
+				var got domain.SysConfig
+				require.NoError(t, GetDB(c).Where("id = ?", 401).First(&got).Error)
+				assert.Equal(t, "updated", got.Value)
+			}
+		})
+	}
+}
+
+func TestDeleteSettings(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		c, rec := newSettingsTestCtx(t, http.MethodDelete, "/api/v1/system/settings/501", "")
+		createSettingRow(t, c, 501, "radius", "DelKey", "v")
+		c.SetParamNames("id")
+		c.SetParamValues("501")
+
+		require.NoError(t, deleteSettings(c))
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var count int64
+		GetDB(c).Model(&domain.SysConfig{}).Where("id = ?", 501).Count(&count)
+		assert.Equal(t, int64(0), count)
+	})
+
+	t.Run("invalid id", func(t *testing.T) {
+		c, rec := newSettingsTestCtx(t, http.MethodDelete, "/api/v1/system/settings/bad", "")
+		c.SetParamNames("id")
+		c.SetParamValues("bad")
+
+		_ = deleteSettings(c)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+}
+
+func TestGetConfigSchemas(t *testing.T) {
+	c, rec := newSettingsTestCtx(t, http.MethodGet, "/api/v1/system/config/schemas", "")
+	require.NoError(t, getConfigSchemas(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp Response
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	schemas, ok := resp.Data.([]interface{})
+	require.True(t, ok)
+	assert.NotEmpty(t, schemas, "config schemas should be loaded from the embedded JSON")
+}
+
+func TestReloadConfig(t *testing.T) {
+	c, rec := newSettingsTestCtx(t, http.MethodPost, "/api/v1/system/config/reload", "")
+	require.NoError(t, reloadConfig(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// TestSettingsRequireAdmin_NegativeCases verifies the authorization guard on the
+// settings mutating routes: operator-level accounts are rejected (403) before the
+// handler runs, while admin/super accounts are allowed through.
+func TestSettingsRequireAdmin_NegativeCases(t *testing.T) {
+	guard := requireAdmin()
+	body := `{"type":"radius","name":"GuardKey","value":"v"}`
+
+	cases := []struct {
+		name           string
+		level          string
+		expectAllowed  bool
+		expectedStatus int
+	}{
+		{"operator denied", LevelOperator, false, http.StatusForbidden},
+		{"unknown level denied", "guest", false, http.StatusForbidden},
+		{"admin allowed", LevelAdmin, true, http.StatusOK},
+		{"super allowed", LevelSuper, true, http.StatusOK},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			c, rec := newSettingsTestCtx(t, http.MethodPost, "/api/v1/system/settings", body)
+			c.Set("current_operator", &domain.SysOpr{ID: 1, Level: tt.level, Status: "enabled"})
+
+			handlerRan := false
+			wrapped := guard(func(c echo.Context) error {
+				handlerRan = true
+				return createSettings(c)
+			})
+			require.NoError(t, wrapped(c))
+
+			assert.Equal(t, tt.expectAllowed, handlerRan)
+			assert.Equal(t, tt.expectedStatus, rec.Code)
+		})
+	}
+}
+

--- a/internal/radiusd/radius_updatebind_test.go
+++ b/internal/radiusd/radius_updatebind_test.go
@@ -55,3 +55,37 @@ func TestUpdateBindVlanid1ChangeKeepsVlanid2(t *testing.T) {
 	require.Equal(t, 99, got.Vlanid1, "vlanid1 must be persisted to vlanid1")
 	require.Equal(t, 20, got.Vlanid2, "vlanid2 must be preserved")
 }
+
+// TestUpdateBindMacOnlyChange verifies that a MAC-address change is persisted
+// while the VLAN columns are left untouched when they already match.
+func TestUpdateBindMacOnlyChange(t *testing.T) {
+	svc, db := newUpdateBindTestService(t)
+
+	user := &domain.RadiusUser{Username: "u3", Vlanid1: 10, Vlanid2: 20, MacAddr: "aa:bb"}
+	require.NoError(t, db.Create(user).Error)
+
+	svc.UpdateBind(user, &VendorRequest{Vlanid1: 10, Vlanid2: 20, MacAddr: "cc:dd"})
+
+	var got domain.RadiusUser
+	require.NoError(t, db.Where("username = ?", "u3").First(&got).Error)
+	require.Equal(t, "cc:dd", got.MacAddr, "mac must be updated")
+	require.Equal(t, 10, got.Vlanid1, "vlanid1 must be preserved")
+	require.Equal(t, 20, got.Vlanid2, "vlanid2 must be preserved")
+}
+
+// TestUpdateBindNoChangeIsNoop verifies that an identical request leaves the
+// stored record unchanged (neither the MAC nor the VLAN write branches fire).
+func TestUpdateBindNoChangeIsNoop(t *testing.T) {
+	svc, db := newUpdateBindTestService(t)
+
+	user := &domain.RadiusUser{Username: "u4", Vlanid1: 10, Vlanid2: 20, MacAddr: "aa:bb"}
+	require.NoError(t, db.Create(user).Error)
+
+	svc.UpdateBind(user, &VendorRequest{Vlanid1: 10, Vlanid2: 20, MacAddr: "aa:bb"})
+
+	var got domain.RadiusUser
+	require.NoError(t, db.Where("username = ?", "u4").First(&got).Error)
+	require.Equal(t, "aa:bb", got.MacAddr)
+	require.Equal(t, 10, got.Vlanid1)
+	require.Equal(t, 20, got.Vlanid2)
+}


### PR DESCRIPTION
## FIX-023 — Fill the test gaps from the review

Adds the test coverage called out in the checklist for previously untested or thinly tested branches.

### New / extended tests
- **`settings_test.go`** (new): full CRUD coverage for the system-settings admin API — list, type filter, get (found / not-found / invalid-id), create (success / missing-field / invalid-json / duplicate-conflict), update (success / not-found / invalid-id), delete (success / invalid-id), config schemas, and reload. Plus **authorization negative cases** that drive the mutating routes through `requireAdmin()` and assert `operator`/unknown levels get **403** while `admin`/`super` pass.
- **`accounting_helpers_test.go`** (new): unit tests for `parseFlexibleTime` (all three accepted formats + the error branch) and `escapeLikePattern` (LIKE wildcard-injection escaping).
- **`radius_updatebind_test.go`** (extended): adds the **MAC-only-change** branch and the **no-change no-op** branch alongside the existing VLAN cases.

### Not added (already covered)
Cache-eviction paths (`ProfileCache` `Invalidate`/`InvalidateAll`/`cleanup`/TTL/auto-cleanup) are already comprehensively covered by `profile_cache_test.go`, so no duplicate tests were added.

### Verification
- `go test ./internal/adminapi/ ./internal/radiusd/` green.
- `golangci-lint run ./internal/adminapi/... ./internal/radiusd/`: 0 issues.

Part of the docs/fix-checklist.md remediation campaign (P2) — final item.