### PR TITLE
fix(test): repair integration build after vendor parser registry migration

### DIFF
--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins"
 	parsers "github.com/talkincode/toughradius/v9/internal/radiusd/plugins/vendorparsers/parsers"
 	"github.com/talkincode/toughradius/v9/internal/radiusd/registry"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/vendors"
 	"github.com/talkincode/toughradius/v9/internal/webserver"
 	"github.com/talkincode/toughradius/v9/pkg/common"
 )
@@ -210,10 +211,10 @@ func runSuite(env pgEnv, m *testing.M) (code int, err error) {
 
 	// Boot the RADIUS auth/acct servers backed by the same Postgres database.
 	registry.ResetForTest()
-	registry.RegisterVendorParser(&parsers.DefaultParser{})
-	registry.RegisterVendorParser(&parsers.HuaweiParser{})
-	registry.RegisterVendorParser(&parsers.H3CParser{})
-	registry.RegisterVendorParser(&parsers.ZTEParser{})
+	_ = vendors.RegisterParser(&parsers.DefaultParser{})
+	_ = vendors.RegisterParser(&parsers.HuaweiParser{})
+	_ = vendors.RegisterParser(&parsers.H3CParser{})
+	_ = vendors.RegisterParser(&parsers.ZTEParser{})
 
 	radiusSvc := radiusd.NewRadiusService(appCtx)
 	defer radiusSvc.Release()


### PR DESCRIPTION
## Problem
The CI **Integration (PostgreSQL)** job was failing to build:

```
test/integration/main_test.go:213-216: undefined: registry.RegisterVendorParser
```

`registry.RegisterVendorParser` was removed during the FIX-016 vendor registry consolidation (#275). The build-tagged integration suite (`//go:build integration`) still referenced it, but because that tag is excluded from `go test ./...` the regression escaped local verification and only appeared in CI.

## Fix
Migrate the four parser registrations to the current `vendors.RegisterParser` API (matching `internal/radiusd/integration_test.go`) and add the `vendors` import. `registry.ResetForTest()` is retained.

## Verification
- `go vet -tags integration ./test/integration/` ✅
- `go build -tags integration ./...` ✅

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>