### PR TITLE
ci: pull latest Go patch via check-latest to fix govulncheck on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
           cache: true
 
       - name: Install golangci-lint
@@ -76,6 +77,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
           cache: true
 
       - name: Download dependencies
@@ -130,6 +132,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
           cache: true
 
       - name: Download dependencies
@@ -180,6 +183,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
           cache: true
 
       - name: Get version info
@@ -242,6 +246,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
           cache: true
 
       - name: Run govulncheck


### PR DESCRIPTION
## Problem
The **Security Scan** job hard-fails on push to main (`govulncheck`'s `continue-on-error` is only true for `pull_request` events). The findings were Go **stdlib** advisories:

- GO-2026-5039 (`net/textproto`)
- GO-2026-5037 (`crypto/x509`)

both fixed in **go1.25.11**. CI built with **go1.25.10** because `actions/setup-go` satisfied `go-version: '1.25'` from the runner's tool cache and didn't fetch the newer patch once it was released.

## Fix
Add `check-latest: true` to every `actions/setup-go@v5` step so the pipeline always resolves the newest `1.25.x` patch (currently 1.25.11), which carries the stdlib security fixes.

This keeps main a **hard gate for actionable (third-party dependency) vulnerabilities** — it does not weaken the gate — while ensuring the toolchain stays current instead of pinning to a stale cached patch. Floating `go-version: '1.25'` is retained so future patch fixes are picked up automatically.

## Notes
This is the durable fix preferred over making govulncheck advisory-on-main (which would also stop gating actionable dependency vulns) or pinning an exact patch (which would re-break on the next advisory).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>