### PR TITLE
fix(security): remediate CodeQL high-severity alerts

### DIFF
--- a/cmd/benchmark/bmtest.go
+++ b/cmd/benchmark/bmtest.go
@@ -157,10 +157,19 @@ func runBenchmark() {
 	}
 }
 
+// maskSecret redacts a sensitive value so credentials are never written to
+// stdout/logs by the benchmark tool while still indicating whether one was set.
+func maskSecret(s string) string {
+	if s == "" {
+		return "(empty)"
+	}
+	return "***"
+}
+
 // runAuthTest sends a single authentication request.
 func runAuthTest() {
 	fmt.Printf("Sending Access-Request to %s:%d\n", *server, *authport)
-	fmt.Printf("Username: %s, Password: %s, Secret: %s\n", *user, *passwd, *secret)
+	fmt.Printf("Username: %s, Password: %s, Secret: %s\n", *user, maskSecret(*passwd), maskSecret(*secret))
 
 	pb := bm.NewPacketBuilder(*secret, "bmtest", *nasip)
 	packet, err := pb.BuildAuthRequest(*user, *passwd, *usermac)

--- a/config/config.go
+++ b/config/config.go
@@ -407,9 +407,9 @@ func setEnvIntValue(name string, val *int) {
 		return
 	}
 
-	p, err := strconv.ParseInt(evalue, 10, 64)
+	p, err := strconv.Atoi(evalue)
 	if err == nil {
-		*val = int(p)
+		*val = p
 	}
 }
 

--- a/internal/webserver/server.go
+++ b/internal/webserver/server.go
@@ -174,8 +174,7 @@ func NewAdminServer(appCtx app.AppContext) *AdminServer {
 		SigningMethod: echojwt.AlgorithmHS256,
 		Skipper:       jwtSkipFunc(),
 		ErrorHandler: func(c echo.Context, err error) error {
-			zap.S().Warnf("JWT validation failed: %v, Path: %s, Auth Header: %s",
-				err, c.Path(), c.Request().Header.Get("Authorization"))
+			zap.S().Warnf("JWT validation failed: %v, Path: %s", err, c.Path())
 			return c.JSON(http.StatusUnauthorized, web.RestError("Authentication failed: "+err.Error()))
 		},
 	}

--- a/pkg/web/prequery.go
+++ b/pkg/web/prequery.go
@@ -2,12 +2,27 @@ package web
 
 import (
 	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/talkincode/toughradius/v9/pkg/common"
 	"gorm.io/gorm"
 )
+
+// sqlIdentifierPattern matches a safe SQL identifier reference, optionally
+// table-qualified (e.g. "username" or "radius_user.id"). It deliberately
+// rejects whitespace, quotes, parentheses and any other character that could
+// be used to break out of a column reference and inject SQL.
+var sqlIdentifierPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$`)
+
+// isValidSQLIdentifier reports whether name is a safe column/identifier
+// reference that can be interpolated into a query clause. User-supplied
+// sort/equal/filter field names are validated with this before being used in
+// ORDER BY / WHERE fragments to prevent SQL injection via column names.
+func isValidSQLIdentifier(name string) bool {
+	return sqlIdentifierPattern.MatchString(name)
+}
 
 // PreQuery is a fluent query builder for constructing GORM queries from HTTP request parameters.
 // It provides a chainable API for building complex database queries with:
@@ -249,6 +264,9 @@ func (p *PreQuery) Query(query *gorm.DB) *gorm.DB {
 		query = query.Order(p.defaultOrderby)
 	} else {
 		for name, stype := range ParseSortMap(p.context) {
+			if !isValidSQLIdentifier(name) {
+				continue
+			}
 			query = query.Order(fmt.Sprintf("%s %s", name, stype))
 		}
 	}
@@ -268,6 +286,9 @@ func (p *PreQuery) Query(query *gorm.DB) *gorm.DB {
 		if _, ok := p.params[name]; ok {
 			continue
 		}
+		if !isValidSQLIdentifier(name) {
+			continue
+		}
 		query = query.Where(fmt.Sprintf("%s = ?", name), value)
 	}
 
@@ -280,6 +301,9 @@ func (p *PreQuery) Query(query *gorm.DB) *gorm.DB {
 			continue
 		}
 		if _, ok := p.params[name]; ok {
+			continue
+		}
+		if !isValidSQLIdentifier(name) {
 			continue
 		}
 		if common.InSlice(name, p.equalFieldds) {


### PR DESCRIPTION
Remediates the open CodeQL **high-severity** code-scanning alerts. This PR fixes the genuine true positives in code; the remaining alerts (allowlist-validated SQL, error-only EAP logging, and RFC-mandated MD5) are tracked separately as dismissals with justification.

## Fixes (true positives)

| Alert | Rule | Fix |
|------|------|-----|
| `pkg/web/prequery.go` | `go/sql-injection` | Validate user-supplied **sort / equal / filter column names** against a safe-identifier allowlist (`^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$`) before interpolating into `ORDER BY` / `WHERE`. Hardens line 252 (flagged) **and** the equal/filter clauses (same class, unflagged). |
| `internal/webserver/server.go` | `go/clear-text-logging` | Stop logging the `Authorization` header on JWT validation failure (was leaking bearer tokens). |
| `config/config.go` | `go/incorrect-integer-conversion` | Use `strconv.Atoi` instead of `ParseInt(…,64)` + `int()`, eliminating the int64→int narrowing. |
| `cmd/benchmark/bmtest.go` | `go/clear-text-logging` | Redact password/secret in the load-test tool's console output. |

## Verification

- `CGO_ENABLED=0 go build ./...` ✅
- `go vet` (changed packages) ✅
- `golangci-lint run` (changed packages) → `0 issues` ✅
- `go test ./pkg/web/... ./config/...` ✅

## Not changed (handled as triaged dismissals)

- **5× `go/sql-injection`** in `internal/adminapi/*` — false positives: all go through `parseSort()` which validates the field against a per-model allowlist and forces `ASC`/`DESC`.
- **3× `go/clear-text-logging`** in the EAP plugin — false positives: only the (always-nil, non-sensitive) error is logged, never the password.
- **4× `go/weak-sensitive-data-hashing`** (CHAP, EAP-MD5, RADIUS Response-Authenticator) — won't fix: MD5 is mandated by RFC 2865 / 1994 / 2433.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>