### PR TITLE
fix(accounting): make Accounting-Start idempotent on Acct-Session-Id (#302)

### DIFF
--- a/internal/adminapi/sessions_test.go
+++ b/internal/adminapi/sessions_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -14,6 +15,12 @@ import (
 	"github.com/talkincode/toughradius/v9/internal/domain"
 	"gorm.io/gorm"
 )
+
+// testSessionSeq guarantees each created test session gets a unique
+// Acct-Session-Id, which the unique index on radius_online.acct_session_id now
+// enforces. Real concurrent sessions for one user always carry distinct
+// Acct-Session-Id values.
+var testSessionSeq atomic.Int64
 
 // createTestOnlineSession Create test online session data
 func createTestOnlineSession(db *gorm.DB, username, nasAddr, framedIp string) *domain.RadiusOnline {
@@ -31,7 +38,7 @@ func createTestOnlineSession(db *gorm.DB, username, nasAddr, framedIp string) *d
 		NasPortId:         "port-1",
 		NasPortType:       15, // Ethernet
 		ServiceType:       2,  // Framed
-		AcctSessionId:     "session-" + username,
+		AcctSessionId:     fmt.Sprintf("session-%s-%d", username, testSessionSeq.Add(1)),
 		AcctSessionTime:   1800,
 		AcctInputTotal:    1024000,
 		AcctOutputTotal:   2048000,

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -162,6 +162,9 @@ func (a *Application) MigrateDB(track bool) (err error) {
 			}
 		}
 	}()
+	// Remove duplicate online rows before AutoMigrate creates the unique
+	// index on radius_online.acct_session_id (idempotency backstop).
+	a.dedupOnlineSessions()
 	if track {
 		if err := a.gormDB.Debug().Migrator().AutoMigrate(domain.Tables...); err != nil {
 			zap.S().Error(err)
@@ -172,6 +175,31 @@ func (a *Application) MigrateDB(track bool) (err error) {
 		}
 	}
 	return nil
+}
+
+// dedupOnlineSessions removes duplicate radius_online rows that share the same
+// Acct-Session-Id before AutoMigrate creates the unique index on that column.
+// Existing deployments may already contain duplicate online rows produced by
+// retransmitted Accounting-Start packets; without this cleanup the unique
+// index creation would fail and the idempotency guarantee would silently not
+// apply. It keeps the row with the smallest id per Acct-Session-Id and is
+// best-effort: failures are logged but never abort startup.
+func (a *Application) dedupOnlineSessions() {
+	if a.gormDB == nil {
+		return
+	}
+	if !a.gormDB.Migrator().HasTable(&domain.RadiusOnline{}) {
+		return
+	}
+	table := domain.RadiusOnline{}.TableName()
+	sql := fmt.Sprintf(
+		"DELETE FROM %s WHERE id NOT IN (SELECT min_id FROM (SELECT MIN(id) AS min_id FROM %s GROUP BY acct_session_id) AS keep_ids)",
+		table, table,
+	)
+	if err := a.gormDB.Exec(sql).Error; err != nil {
+		zap.L().Warn("dedup radius_online before unique index failed",
+			zap.String("namespace", "radius"), zap.Error(err))
+	}
 }
 
 func (a *Application) DropAll() {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -162,19 +162,47 @@ func (a *Application) MigrateDB(track bool) (err error) {
 			}
 		}
 	}()
-	// Remove duplicate online rows before AutoMigrate creates the unique
-	// index on radius_online.acct_session_id (idempotency backstop).
+	// Remove duplicate online rows and drop the legacy non-unique index before
+	// AutoMigrate creates the unique index on radius_online.acct_session_id
+	// (idempotency backstop, including the upgrade path).
 	a.dedupOnlineSessions()
+	a.dropLegacyOnlineSessionIndex()
 	if track {
-		if err := a.gormDB.Debug().Migrator().AutoMigrate(domain.Tables...); err != nil {
-			zap.S().Error(err)
+		if mErr := a.gormDB.Debug().Migrator().AutoMigrate(domain.Tables...); mErr != nil {
+			zap.S().Error(mErr)
+			return mErr
 		}
 	} else {
-		if err := a.gormDB.Migrator().AutoMigrate(domain.Tables...); err != nil {
-			zap.S().Error(err)
+		if mErr := a.gormDB.Migrator().AutoMigrate(domain.Tables...); mErr != nil {
+			zap.S().Error(mErr)
+			return mErr
 		}
 	}
 	return nil
+}
+
+// dropLegacyOnlineSessionIndex removes the pre-existing non-unique index on
+// radius_online.acct_session_id created by older schema versions (the column
+// used gorm:"index", named idx_radius_online_acct_session_id). AutoMigrate will
+// not convert that index to unique, so it must be dropped first; AutoMigrate
+// then creates the new unique index (udx_radius_online_acct_session_id) that the
+// ON CONFLICT idempotency clause depends on. Best-effort: failures are logged.
+func (a *Application) dropLegacyOnlineSessionIndex() {
+	if a.gormDB == nil {
+		return
+	}
+	m := a.gormDB.Migrator()
+	if !m.HasTable(&domain.RadiusOnline{}) {
+		return
+	}
+	const legacyIdx = "idx_radius_online_acct_session_id"
+	if !m.HasIndex(&domain.RadiusOnline{}, legacyIdx) {
+		return
+	}
+	if err := m.DropIndex(&domain.RadiusOnline{}, legacyIdx); err != nil {
+		zap.L().Warn("drop legacy radius_online index failed",
+			zap.String("namespace", "radius"), zap.Error(err))
+	}
 }
 
 // dedupOnlineSessions removes duplicate radius_online rows that share the same

--- a/internal/app/dedup_online_test.go
+++ b/internal/app/dedup_online_test.go
@@ -1,0 +1,49 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/require"
+	"github.com/talkincode/toughradius/v9/internal/domain"
+	"gorm.io/gorm"
+)
+
+// TestDedupOnlineSessions verifies the pre-migration cleanup removes duplicate
+// radius_online rows (left over from before the unique index existed) so that
+// AutoMigrate can subsequently create the unique index on acct_session_id.
+func TestDedupOnlineSessions(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+
+	// Simulate a legacy table without the unique index, holding duplicates.
+	require.NoError(t, db.Exec(
+		`CREATE TABLE radius_online (id INTEGER PRIMARY KEY, acct_session_id TEXT, username TEXT)`).Error)
+	require.NoError(t, db.Exec(
+		`INSERT INTO radius_online (id, acct_session_id, username) VALUES
+			(1,'sess-1','u'),(2,'sess-1','u'),(3,'sess-2','u'),(4,'sess-2','u'),(5,'sess-3','u')`).Error)
+
+	a := &Application{gormDB: db}
+	a.dedupOnlineSessions()
+
+	var total int64
+	require.NoError(t, db.Raw(`SELECT COUNT(1) FROM radius_online`).Scan(&total).Error)
+	require.Equal(t, int64(3), total, "one row should remain per acct_session_id")
+
+	// After dedup, AutoMigrate must be able to add the unique index cleanly.
+	require.NoError(t, db.AutoMigrate(&domain.RadiusOnline{}))
+
+	// And the unique index must now reject a duplicate acct_session_id.
+	err = db.Exec(
+		`INSERT INTO radius_online (id, acct_session_id, username) VALUES (99,'sess-1','u')`).Error
+	require.Error(t, err, "unique index should reject duplicate acct_session_id after migration")
+}
+
+// TestDedupOnlineSessions_NoTable verifies the cleanup is a no-op (no panic,
+// no error) when the table does not exist yet, e.g. on a fresh install.
+func TestDedupOnlineSessions_NoTable(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	a := &Application{gormDB: db}
+	require.NotPanics(t, a.dedupOnlineSessions)
+}

--- a/internal/app/dedup_online_test.go
+++ b/internal/app/dedup_online_test.go
@@ -47,3 +47,35 @@ func TestDedupOnlineSessions_NoTable(t *testing.T) {
 	a := &Application{gormDB: db}
 	require.NotPanics(t, a.dedupOnlineSessions)
 }
+
+// TestUpgradePath_LegacyNonUniqueIndex reproduces the upgrade scenario from the
+// PR review: a deployment that already has the legacy non-unique index
+// (idx_radius_online_acct_session_id) plus duplicate rows. After dedup + legacy
+// index drop, AutoMigrate must create the unique index so ON CONFLICT works.
+func TestUpgradePath_LegacyNonUniqueIndex(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+
+	// Legacy schema: non-unique index named like GORM's gorm:"index" default.
+	require.NoError(t, db.Exec(
+		`CREATE TABLE radius_online (id INTEGER PRIMARY KEY, acct_session_id TEXT, username TEXT)`).Error)
+	require.NoError(t, db.Exec(
+		`CREATE INDEX idx_radius_online_acct_session_id ON radius_online (acct_session_id)`).Error)
+	require.NoError(t, db.Exec(
+		`INSERT INTO radius_online (id, acct_session_id, username) VALUES
+			(1,'sess-1','u'),(2,'sess-1','u'),(3,'sess-2','u')`).Error)
+
+	a := &Application{gormDB: db}
+	a.dedupOnlineSessions()
+	a.dropLegacyOnlineSessionIndex()
+
+	require.False(t, db.Migrator().HasIndex(&domain.RadiusOnline{}, "idx_radius_online_acct_session_id"),
+		"legacy non-unique index should be dropped")
+	require.NoError(t, db.AutoMigrate(&domain.RadiusOnline{}))
+	require.True(t, db.Migrator().HasIndex(&domain.RadiusOnline{}, "udx_radius_online_acct_session_id"),
+		"unique index should be created after migration")
+
+	err = db.Exec(
+		`INSERT INTO radius_online (id, acct_session_id, username) VALUES (99,'sess-1','u')`).Error
+	require.Error(t, err, "unique index must reject duplicate acct_session_id on the upgrade path")
+}

--- a/internal/domain/radius.go
+++ b/internal/domain/radius.go
@@ -89,7 +89,7 @@ type RadiusOnline struct {
 	NasPortId           string    `json:"nas_port_id"`
 	NasPortType         int       `json:"nas_port_type"`
 	ServiceType         int       `json:"service_type"`
-	AcctSessionId       string    `gorm:"index" json:"acct_session_id"`
+	AcctSessionId       string    `gorm:"uniqueIndex" json:"acct_session_id"`
 	AcctSessionTime     int       `json:"acct_session_time"`
 	AcctInputTotal      int64     `json:"acct_input_total,string"`
 	AcctOutputTotal     int64     `json:"acct_output_total,string"`

--- a/internal/domain/radius.go
+++ b/internal/domain/radius.go
@@ -89,7 +89,7 @@ type RadiusOnline struct {
 	NasPortId           string    `json:"nas_port_id"`
 	NasPortType         int       `json:"nas_port_type"`
 	ServiceType         int       `json:"service_type"`
-	AcctSessionId       string    `gorm:"uniqueIndex" json:"acct_session_id"`
+	AcctSessionId       string    `gorm:"uniqueIndex:udx_radius_online_acct_session_id" json:"acct_session_id"`
 	AcctSessionTime     int       `json:"acct_session_time"`
 	AcctInputTotal      int64     `json:"acct_input_total,string"`
 	AcctOutputTotal     int64     `json:"acct_output_total,string"`

--- a/internal/radiusd/plugins/accounting/handlers/handlers_test.go
+++ b/internal/radiusd/plugins/accounting/handlers/handlers_test.go
@@ -32,12 +32,15 @@ func newMockSessionRepo() *mockSessionRepository {
 	}
 }
 
-func (m *mockSessionRepository) Create(ctx context.Context, session *domain.RadiusOnline) error {
+func (m *mockSessionRepository) Create(ctx context.Context, session *domain.RadiusOnline) (bool, error) {
 	if m.createErr != nil {
-		return m.createErr
+		return false, m.createErr
+	}
+	if _, ok := m.sessions[session.AcctSessionId]; ok {
+		return false, nil
 	}
 	m.sessions[session.AcctSessionId] = session
-	return nil
+	return true, nil
 }
 
 func (m *mockSessionRepository) Update(ctx context.Context, session *domain.RadiusOnline) error {
@@ -244,6 +247,23 @@ func TestStartHandler_Handle_NilVendorRequest(t *testing.T) {
 
 	err := handler.Handle(ctx)
 	assert.NoError(t, err)
+}
+
+// TestStartHandler_Handle_DuplicateStartIdempotent reproduces issue #302: a
+// retransmitted Accounting-Start for the same Acct-Session-Id must not create a
+// second online row nor a second accounting record.
+func TestStartHandler_Handle_DuplicateStartIdempotent(t *testing.T) {
+	sessionRepo := newMockSessionRepo()
+	acctRepo := newMockAccountingRepo()
+	handler := NewStartHandler(sessionRepo, acctRepo)
+
+	ctx := createMockAccountingContext(int(rfc2866.AcctStatusType_Value_Start))
+
+	require.NoError(t, handler.Handle(ctx))
+	require.NoError(t, handler.Handle(ctx)) // retransmission
+
+	assert.Len(t, sessionRepo.sessions, 1, "duplicate start must not add an online row")
+	assert.Len(t, acctRepo.records, 1, "duplicate start must not add an accounting record")
 }
 
 // ============ StopHandler Tests ============

--- a/internal/radiusd/plugins/accounting/handlers/handlers_test.go
+++ b/internal/radiusd/plugins/accounting/handlers/handlers_test.go
@@ -233,8 +233,10 @@ func TestStartHandler_Handle_AccountingCreateError(t *testing.T) {
 	err := handler.Handle(ctx)
 
 	assert.Error(t, err)
-	// Session was created, but accounting failed
-	assert.Len(t, sessionRepo.sessions, 1)
+	// The online row is rolled back (compensating delete) when accounting
+	// creation fails, so a retransmission re-creates both records instead of
+	// being skipped as a duplicate.
+	assert.Empty(t, sessionRepo.sessions)
 }
 
 func TestStartHandler_Handle_NilVendorRequest(t *testing.T) {
@@ -264,6 +266,29 @@ func TestStartHandler_Handle_DuplicateStartIdempotent(t *testing.T) {
 
 	assert.Len(t, sessionRepo.sessions, 1, "duplicate start must not add an online row")
 	assert.Len(t, acctRepo.records, 1, "duplicate start must not add an accounting record")
+}
+
+// TestStartHandler_Handle_AccountingErrorThenRetry verifies that when the
+// accounting insert fails, the rolled-back online row lets a subsequent
+// retransmission recreate both records (no permanently missing accounting).
+func TestStartHandler_Handle_AccountingErrorThenRetry(t *testing.T) {
+	sessionRepo := newMockSessionRepo()
+	acctRepo := newMockAccountingRepo()
+	acctRepo.createErr = errors.New("transient accounting error")
+	handler := NewStartHandler(sessionRepo, acctRepo)
+
+	ctx := createMockAccountingContext(int(rfc2866.AcctStatusType_Value_Start))
+
+	// First attempt fails on accounting; the online row is rolled back.
+	require.Error(t, handler.Handle(ctx))
+	assert.Empty(t, sessionRepo.sessions)
+	assert.Empty(t, acctRepo.records)
+
+	// Retransmission after the accounting backend recovers.
+	acctRepo.createErr = nil
+	require.NoError(t, handler.Handle(ctx))
+	assert.Len(t, sessionRepo.sessions, 1)
+	assert.Len(t, acctRepo.records, 1)
 }
 
 // ============ StopHandler Tests ============

--- a/internal/radiusd/plugins/accounting/handlers/start_handler.go
+++ b/internal/radiusd/plugins/accounting/handlers/start_handler.go
@@ -50,8 +50,10 @@ func (h *StartHandler) Handle(acctCtx *accounting.AccountingContext) error {
 	// Construct the online session record
 	online := h.buildRadiusOnline(acctCtx.Request, vendorReq, acctCtx.NAS, acctCtx.NASIP)
 
-	// Create online session
-	err := h.sessionRepo.Create(acctCtx.Context, &online)
+	// Create online session. Create is idempotent on Acct-Session-Id: a
+	// retransmitted Accounting-Start returns created=false instead of
+	// inserting a duplicate online row.
+	created, err := h.sessionRepo.Create(acctCtx.Context, &online)
 	if err != nil {
 		zap.L().Error("add radius online error",
 			zap.String("namespace", "radius"),
@@ -61,7 +63,19 @@ func (h *StartHandler) Handle(acctCtx *accounting.AccountingContext) error {
 		return err
 	}
 
-	// Create accounting record
+	// Duplicate Accounting-Start retransmission: the online session already
+	// exists for this Acct-Session-Id. Skip creating another accounting record
+	// so traffic/time counters are not double-billed.
+	if !created {
+		zap.L().Debug("duplicate accounting start ignored",
+			zap.String("namespace", "radius"),
+			zap.String("username", acctCtx.Username),
+			zap.String("session_id", online.AcctSessionId),
+		)
+		return nil
+	}
+
+	// Create accounting record (only for newly created sessions)
 	accounting := h.buildRadiusAccounting(&online, true)
 	if err := h.accountingRepo.Create(acctCtx.Context, &accounting); err != nil {
 		zap.L().Error("add radius accounting error",

--- a/internal/radiusd/plugins/accounting/handlers/start_handler.go
+++ b/internal/radiusd/plugins/accounting/handlers/start_handler.go
@@ -83,6 +83,19 @@ func (h *StartHandler) Handle(acctCtx *accounting.AccountingContext) error {
 			zap.String("username", acctCtx.Username),
 			zap.Error(err),
 		)
+		// Compensating delete: the online row was just inserted but the
+		// accounting record could not be created. Remove the online row so the
+		// NAS retransmission is treated as a fresh start (Create returns
+		// created=true) and both records are recreated, instead of being
+		// skipped as a duplicate and leaving the session without accounting.
+		if delErr := h.sessionRepo.Delete(acctCtx.Context, online.AcctSessionId); delErr != nil {
+			zap.L().Error("rollback online after accounting error failed",
+				zap.String("namespace", "radius"),
+				zap.String("username", acctCtx.Username),
+				zap.String("session_id", online.AcctSessionId),
+				zap.Error(delErr),
+			)
+		}
 		return err
 	}
 

--- a/internal/radiusd/plugins/auth/checkers/online_count_checker_test.go
+++ b/internal/radiusd/plugins/auth/checkers/online_count_checker_test.go
@@ -25,8 +25,8 @@ func (m *mockSessionRepository) CountByUsername(ctx context.Context, username st
 }
 
 // Implement other interface methods (unused in tests)
-func (m *mockSessionRepository) Create(ctx context.Context, session *domain.RadiusOnline) error {
-	return nil
+func (m *mockSessionRepository) Create(ctx context.Context, session *domain.RadiusOnline) (bool, error) {
+	return true, nil
 }
 
 func (m *mockSessionRepository) Update(ctx context.Context, session *domain.RadiusOnline) error {

--- a/internal/radiusd/repository/gorm/session_repository.go
+++ b/internal/radiusd/repository/gorm/session_repository.go
@@ -9,6 +9,7 @@ import (
 	"github.com/talkincode/toughradius/v9/internal/radiusd/repository"
 	"github.com/talkincode/toughradius/v9/pkg/common"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // GormSessionRepository is the GORM implementation of the session repository
@@ -25,17 +26,28 @@ func NewGormSessionRepository(db *gorm.DB) repository.SessionRepository {
 	}
 }
 
-func (r *GormSessionRepository) Create(ctx context.Context, session *domain.RadiusOnline) error {
+// Create inserts the online session idempotently. The insert relies on the
+// unique index on acct_session_id together with an ON CONFLICT DO NOTHING
+// clause, so a retransmitted Accounting-Start can never produce a duplicate
+// online row. It returns created=false when the row already existed.
+func (r *GormSessionRepository) Create(ctx context.Context, session *domain.RadiusOnline) (bool, error) {
 	if session.ID == 0 {
 		session.ID = common.UUIDint64()
 	}
-	if err := r.db.WithContext(ctx).Create(session).Error; err != nil {
-		return err
+	result := r.db.WithContext(ctx).
+		Clauses(clause.OnConflict{
+			Columns:   []clause.Column{{Name: "acct_session_id"}},
+			DoNothing: true,
+		}).
+		Create(session)
+	if result.Error != nil {
+		return false, result.Error
 	}
-	if session != nil {
+	created := result.RowsAffected > 0
+	if created {
 		r.invalidate(session.Username)
 	}
-	return nil
+	return created, nil
 }
 
 func (r *GormSessionRepository) Update(ctx context.Context, session *domain.RadiusOnline) error {

--- a/internal/radiusd/repository/gorm/session_repository_test.go
+++ b/internal/radiusd/repository/gorm/session_repository_test.go
@@ -1,0 +1,84 @@
+package gorm
+
+import (
+	"context"
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/require"
+	"github.com/talkincode/toughradius/v9/internal/domain"
+	"gorm.io/gorm"
+)
+
+func newSessionTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&domain.RadiusOnline{}))
+	return db
+}
+
+func countOnline(t *testing.T, db *gorm.DB, sessionId string) int64 {
+	t.Helper()
+	var count int64
+	require.NoError(t, db.Model(&domain.RadiusOnline{}).
+		Where("acct_session_id = ?", sessionId).Count(&count).Error)
+	return count
+}
+
+// TestSessionRepository_Create_Idempotent reproduces the duplicate
+// Accounting-Start retransmission scenario from issue #302: inserting the same
+// Acct-Session-Id twice must keep exactly one online row, and the second call
+// must report created=false so the caller can skip duplicate accounting.
+func TestSessionRepository_Create_Idempotent(t *testing.T) {
+	db := newSessionTestDB(t)
+	repo := NewGormSessionRepository(db)
+	ctx := context.Background()
+
+	created, err := repo.Create(ctx, &domain.RadiusOnline{Username: "u1", AcctSessionId: "sess-1"})
+	require.NoError(t, err)
+	require.True(t, created, "first insert should create a row")
+
+	created, err = repo.Create(ctx, &domain.RadiusOnline{Username: "u1", AcctSessionId: "sess-1"})
+	require.NoError(t, err)
+	require.False(t, created, "retransmitted Accounting-Start must not create a duplicate")
+
+	require.Equal(t, int64(1), countOnline(t, db, "sess-1"))
+}
+
+// TestSessionRepository_Create_DistinctSessions verifies the unique index does
+// not collapse legitimately different sessions.
+func TestSessionRepository_Create_DistinctSessions(t *testing.T) {
+	db := newSessionTestDB(t)
+	repo := NewGormSessionRepository(db)
+	ctx := context.Background()
+
+	for _, sid := range []string{"a", "b", "c"} {
+		created, err := repo.Create(ctx, &domain.RadiusOnline{Username: "u1", AcctSessionId: sid})
+		require.NoError(t, err)
+		require.True(t, created)
+	}
+
+	var total int64
+	require.NoError(t, db.Model(&domain.RadiusOnline{}).Count(&total).Error)
+	require.Equal(t, int64(3), total)
+}
+
+// TestSessionRepository_Create_RecreateAfterDelete verifies a session id can be
+// reused once the previous session is stopped (online row deleted).
+func TestSessionRepository_Create_RecreateAfterDelete(t *testing.T) {
+	db := newSessionTestDB(t)
+	repo := NewGormSessionRepository(db)
+	ctx := context.Background()
+
+	created, err := repo.Create(ctx, &domain.RadiusOnline{Username: "u1", AcctSessionId: "sess-1"})
+	require.NoError(t, err)
+	require.True(t, created)
+
+	require.NoError(t, repo.Delete(ctx, "sess-1"))
+
+	created, err = repo.Create(ctx, &domain.RadiusOnline{Username: "u1", AcctSessionId: "sess-1"})
+	require.NoError(t, err)
+	require.True(t, created, "session id should be reusable after the online row is deleted")
+	require.Equal(t, int64(1), countOnline(t, db, "sess-1"))
+}

--- a/internal/radiusd/repository/interfaces.go
+++ b/internal/radiusd/repository/interfaces.go
@@ -29,8 +29,12 @@ type UserRepository interface {
 
 // SessionRepository manages online sessions
 type SessionRepository interface {
-	// Create Create online session
-	Create(ctx context.Context, session *domain.RadiusOnline) error
+	// Create inserts an online session idempotently keyed on Acct-Session-Id.
+	// It returns created=true when a new row was inserted, and created=false
+	// when a row with the same Acct-Session-Id already exists (for example a
+	// retransmitted Accounting-Start). Duplicate inserts are a no-op rather
+	// than an error so accounting stays idempotent under UDP retransmission.
+	Create(ctx context.Context, session *domain.RadiusOnline) (created bool, err error)
 
 	// Update updates session data
 	Update(ctx context.Context, session *domain.RadiusOnline) error


### PR DESCRIPTION
## 问题

RADIUS 计费基于 UDP，NAS 在未收到 Accounting-Response 时会重传 Accounting-Start。此前 `StartHandler` 无条件 `Create` 在线/计费记录，且 `Acct-Session-Id` 仅为普通 `index`，导致重传会插入**重复的在线会话**（真实用户报告 #172）与**重复计费记录**（流量/时长翻倍）。

## 改动

- `radius_online.acct_session_id` 增加 **uniqueIndex**。
- `SessionRepository.Create` 改为幂等插入（`ON CONFLICT DO NOTHING`），返回 `created bool`。依赖 DB 唯一索引而非应用层检查，**对并发计费 worker 池是 race-safe 的**。
- `StartHandler` 在在线会话已存在（重传）时跳过创建计费记录，避免重复计费。
- `MigrateDB` 在 `AutoMigrate` 前对 `radius_online` 去重（每个 `acct_session_id` 保留最小 id），使**已有脏数据的存量库**也能成功建唯一索引。
- 未对历史计费表 `radius_accounting` 加硬唯一约束（其 `Acct-Session-Id` 在 NAS 重启后可合法复现，且有 90 天滚动清理）；计费幂等通过"在线会话是否新建"间接保证。

## 测试

- `session_repository_test.go`：内存 SQLite 验证 DB 级幂等、不误合并不同会话、Stop 后可复用会话 id。
- `handlers_test.go`：`TestStartHandler_Handle_DuplicateStartIdempotent` 重传 Start 只产生 1 在线 + 1 计费。
- `dedup_online_test.go`：去重后 `AutoMigrate` 能建唯一索引且拒绝重复。

本地 `go build/vet/test` 与 `golangci-lint v2.12.2` 均通过。

Closes #302
Refs #172