### PR TITLE
perf(radiusd): shard authentication rate-limit lock per user

### DIFF
--- a/internal/radiusd/auth_rate_limiter.go
+++ b/internal/radiusd/auth_rate_limiter.go
@@ -1,0 +1,120 @@
+package radiusd
+
+import (
+	"sync"
+	"time"
+
+	radiuserrors "github.com/talkincode/toughradius/v9/internal/radiusd/errors"
+)
+
+// defaultAuthRateShards is the number of shards used by the authentication
+// rate limiter. It must be a power of two so the shard index can be computed
+// with a bitmask. A higher count lowers lock contention at a negligible memory
+// cost (one mutex + one map header per shard).
+const defaultAuthRateShards = 256
+
+// maxAuthRateShards caps the shard count so the power-of-two rounding stays
+// within uint32 range and avoids pathologically large allocations.
+const maxAuthRateShards = 1 << 16
+
+// authRateShard is a single partition of the rate-limit state, guarded by its
+// own mutex so that requests for usernames hashing to different shards never
+// contend on the same lock.
+type authRateShard struct {
+	mu    sync.Mutex
+	users map[string]AuthRateUser
+}
+
+// authRateLimiter implements per-user authentication rate limiting backed by a
+// fixed set of independently locked shards. Replacing the previous single
+// global mutex removes the serialization point that capped authentication
+// throughput on multi-core machines: distinct users now contend only when they
+// happen to hash to the same shard.
+type authRateLimiter struct {
+	shards []*authRateShard
+	mask   uint32
+}
+
+// newAuthRateLimiter creates a rate limiter with the given number of shards.
+// shardCount is rounded up to the next power of two (minimum 1, capped at
+// maxAuthRateShards).
+func newAuthRateLimiter(shardCount int) *authRateLimiter {
+	if shardCount < 1 {
+		shardCount = 1
+	}
+	n := 1
+	for n < shardCount && n < maxAuthRateShards {
+		n <<= 1
+	}
+	shards := make([]*authRateShard, n)
+	for i := range shards {
+		shards[i] = &authRateShard{users: make(map[string]AuthRateUser)}
+	}
+	// n is a power of two in [1, maxAuthRateShards], so n-1 fits in uint32.
+	return &authRateLimiter{shards: shards, mask: uint32(n - 1)} //nolint:gosec // G115: n is bounded by maxAuthRateShards
+}
+
+// fnv1a computes a 32-bit FNV-1a hash without allocating, suitable for the hot
+// authentication path.
+func fnv1a(s string) uint32 {
+	const (
+		offset32 = 2166136261
+		prime32  = 16777619
+	)
+	h := uint32(offset32)
+	for i := 0; i < len(s); i++ {
+		h ^= uint32(s[i])
+		h *= prime32
+	}
+	return h
+}
+
+func (l *authRateLimiter) shardFor(username string) *authRateShard {
+	return l.shards[fnv1a(username)&l.mask]
+}
+
+// check records an authentication attempt for username. It returns a
+// rate-limit error if a previous attempt is still within interval; otherwise it
+// stores the new attempt timestamp and returns nil.
+func (l *authRateLimiter) check(username string, interval time.Duration) error {
+	sh := l.shardFor(username)
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	if val, ok := sh.users[username]; ok {
+		if time.Now().Before(val.Starttime.Add(interval)) {
+			return radiuserrors.NewOnlineLimitError("there is a authentication still in process")
+		}
+	}
+	sh.users[username] = AuthRateUser{Username: username, Starttime: time.Now()}
+	return nil
+}
+
+// release removes any rate-limit state for username, allowing an immediate
+// subsequent authentication.
+func (l *authRateLimiter) release(username string) {
+	sh := l.shardFor(username)
+	sh.mu.Lock()
+	delete(sh.users, username)
+	sh.mu.Unlock()
+}
+
+// get returns the stored rate-limit entry for username, used for introspection
+// and testing.
+func (l *authRateLimiter) get(username string) (AuthRateUser, bool) {
+	sh := l.shardFor(username)
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	v, ok := sh.users[username]
+	return v, ok
+}
+
+// len returns the total number of tracked users across all shards.
+func (l *authRateLimiter) len() int {
+	total := 0
+	for _, sh := range l.shards {
+		sh.mu.Lock()
+		total += len(sh.users)
+		sh.mu.Unlock()
+	}
+	return total
+}

--- a/internal/radiusd/auth_rate_limiter_test.go
+++ b/internal/radiusd/auth_rate_limiter_test.go
@@ -1,0 +1,132 @@
+package radiusd
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestNewAuthRateLimiterRoundsToPowerOfTwo(t *testing.T) {
+	cases := map[int]int{1: 1, 2: 2, 3: 4, 100: 128, 256: 256, 257: 512}
+	for in, want := range cases {
+		l := newAuthRateLimiter(in)
+		if len(l.shards) != want {
+			t.Errorf("newAuthRateLimiter(%d): got %d shards, want %d", in, len(l.shards), want)
+		}
+		if int(l.mask) != want-1 {
+			t.Errorf("newAuthRateLimiter(%d): got mask %d, want %d", in, l.mask, want-1)
+		}
+	}
+}
+
+func TestAuthRateLimiterCheckReleaseGet(t *testing.T) {
+	l := newAuthRateLimiter(defaultAuthRateShards)
+
+	if err := l.check("u1", time.Second); err != nil {
+		t.Fatalf("first check should pass: %v", err)
+	}
+	if err := l.check("u1", time.Second); err == nil {
+		t.Fatal("second check within window should be limited")
+	}
+	if _, ok := l.get("u1"); !ok {
+		t.Fatal("u1 should be present after check")
+	}
+	l.release("u1")
+	if _, ok := l.get("u1"); ok {
+		t.Fatal("u1 should be absent after release")
+	}
+	if err := l.check("u1", time.Second); err != nil {
+		t.Fatalf("check after release should pass: %v", err)
+	}
+}
+
+func TestAuthRateLimiterDistinctUsersAndLen(t *testing.T) {
+	l := newAuthRateLimiter(defaultAuthRateShards)
+	const n = 500
+	for i := 0; i < n; i++ {
+		if err := l.check(fmt.Sprintf("user-%d", i), time.Minute); err != nil {
+			t.Fatalf("distinct user %d should pass: %v", i, err)
+		}
+	}
+	if got := l.len(); got != n {
+		t.Fatalf("len: got %d, want %d", got, n)
+	}
+}
+
+func TestAuthRateLimiterExpiry(t *testing.T) {
+	l := newAuthRateLimiter(defaultAuthRateShards)
+	if err := l.check("u1", 50*time.Millisecond); err != nil {
+		t.Fatalf("first check should pass: %v", err)
+	}
+	time.Sleep(80 * time.Millisecond)
+	if err := l.check("u1", 50*time.Millisecond); err != nil {
+		t.Fatalf("check after expiry should pass: %v", err)
+	}
+}
+
+// globalRateLimiter is a single-mutex baseline used only to demonstrate, via
+// benchmarks, the contention the sharded limiter removes. It mirrors the
+// previous CheckAuthRateLimit/ReleaseAuthRateLimit implementation.
+type globalRateLimiter struct {
+	mu    sync.Mutex
+	users map[string]AuthRateUser
+}
+
+func newGlobalRateLimiter() *globalRateLimiter {
+	return &globalRateLimiter{users: make(map[string]AuthRateUser)}
+}
+
+func (g *globalRateLimiter) check(username string, interval time.Duration) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if val, ok := g.users[username]; ok {
+		if time.Now().Before(val.Starttime.Add(interval)) {
+			return errBenchLimited
+		}
+	}
+	g.users[username] = AuthRateUser{Username: username, Starttime: time.Now()}
+	return nil
+}
+
+func (g *globalRateLimiter) release(username string) {
+	g.mu.Lock()
+	delete(g.users, username)
+	g.mu.Unlock()
+}
+
+var errBenchLimited = fmt.Errorf("limited")
+
+// BenchmarkAuthRateLimiter_Sharded measures the check+release cycle for many
+// distinct users running in parallel (the high-concurrency scenario from the
+// issue). Compare against BenchmarkAuthRateLimiter_Global to see the win.
+func BenchmarkAuthRateLimiter_Sharded(b *testing.B) {
+	l := newAuthRateLimiter(defaultAuthRateShards)
+	var seq uint64
+	b.RunParallel(func(pb *testing.PB) {
+		prefix := atomic.AddUint64(&seq, 1)
+		var i uint64
+		for pb.Next() {
+			i++
+			u := fmt.Sprintf("u-%d-%d", prefix, i)
+			_ = l.check(u, time.Second)
+			l.release(u)
+		}
+	})
+}
+
+func BenchmarkAuthRateLimiter_Global(b *testing.B) {
+	g := newGlobalRateLimiter()
+	var seq uint64
+	b.RunParallel(func(pb *testing.PB) {
+		prefix := atomic.AddUint64(&seq, 1)
+		var i uint64
+		for pb.Next() {
+			i++
+			u := fmt.Sprintf("u-%d-%d", prefix, i)
+			_ = g.check(u, time.Second)
+			g.release(u)
+		}
+	})
+}

--- a/internal/radiusd/radius.go
+++ b/internal/radiusd/radius.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"os"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/panjf2000/ants/v2"
@@ -63,9 +62,8 @@ type AuthRateUser struct {
 
 type RadiusService struct {
 	appCtx        app.AppContext // Use interface instead of concrete type
-	AuthRateCache map[string]AuthRateUser
+	authRate      *authRateLimiter
 	TaskPool      *ants.Pool
-	arclock       sync.Mutex
 	nasCache      *cachepkg.TTLCache[*domain.NetNas]
 	userCache     *cachepkg.TTLCache[*domain.RadiusUser]
 
@@ -93,8 +91,7 @@ func NewRadiusService(appCtx app.AppContext) *RadiusService {
 	db := appCtx.DB()
 	s := &RadiusService{
 		appCtx:        appCtx,
-		AuthRateCache: make(map[string]AuthRateUser),
-		arclock:       sync.Mutex{},
+		authRate:      newAuthRateLimiter(defaultAuthRateShards),
 		TaskPool:      pool,
 		nasCache:      cachepkg.NewTTLCache[*domain.NetNas](time.Minute, 512),
 		userCache:     cachepkg.NewTTLCache[*domain.RadiusUser](10*time.Second, 2048),
@@ -256,28 +253,14 @@ func GetNetRadiusOnlineFromRequest(r *radius.Request, vr *VendorRequest, nas *do
 }
 
 // CheckAuthRateLimit
-// Authentication frequency detection, each user can only authenticate once every few seconds
+// Authentication frequency detection, each user can only authenticate once every few seconds.
+// Backed by a sharded limiter so different users do not contend on a single global lock.
 func (s *RadiusService) CheckAuthRateLimit(username string) error {
-	s.arclock.Lock()
-	defer s.arclock.Unlock()
-	val, ok := s.AuthRateCache[username]
-	if ok {
-		if time.Now().Before(val.Starttime.Add(time.Duration(RadiusAuthRateInterval) * time.Second)) {
-			return radiuserrors.NewOnlineLimitError("there is a authentication still in process")
-		}
-		delete(s.AuthRateCache, username)
-	}
-	s.AuthRateCache[username] = AuthRateUser{
-		Username:  username,
-		Starttime: time.Now(),
-	}
-	return nil
+	return s.authRate.check(username, time.Duration(RadiusAuthRateInterval)*time.Second)
 }
 
 func (s *RadiusService) ReleaseAuthRateLimit(username string) {
-	s.arclock.Lock()
-	defer s.arclock.Unlock()
-	delete(s.AuthRateCache, username)
+	s.authRate.release(username)
 }
 
 func (s *RadiusService) Release() {

--- a/internal/radiusd/radius_test.go
+++ b/internal/radiusd/radius_test.go
@@ -13,8 +13,7 @@ import (
 
 func TestCheckAuthRateLimitBasic(t *testing.T) {
 	service := &RadiusService{
-		AuthRateCache: make(map[string]AuthRateUser),
-		arclock:       sync.Mutex{},
+		authRate: newAuthRateLimiter(defaultAuthRateShards),
 	}
 
 	// TestFirst authentication
@@ -40,8 +39,7 @@ func TestCheckAuthRateLimitBasic(t *testing.T) {
 
 func TestCheckAuthRateLimitAfterWait(t *testing.T) {
 	service := &RadiusService{
-		AuthRateCache: make(map[string]AuthRateUser),
-		arclock:       sync.Mutex{},
+		authRate: newAuthRateLimiter(defaultAuthRateShards),
 	}
 
 	// First authentication
@@ -59,8 +57,7 @@ func TestCheckAuthRateLimitAfterWait(t *testing.T) {
 
 func TestCheckAuthRateLimitDifferentUsers(t *testing.T) {
 	service := &RadiusService{
-		AuthRateCache: make(map[string]AuthRateUser),
-		arclock:       sync.Mutex{},
+		authRate: newAuthRateLimiter(defaultAuthRateShards),
 	}
 
 	// Authentication of different users should not affect each other
@@ -75,9 +72,7 @@ func TestCheckAuthRateLimitDifferentUsers(t *testing.T) {
 	}
 
 	// Validate two users currently in the cache
-	service.arclock.Lock()
-	count := len(service.AuthRateCache)
-	service.arclock.Unlock()
+	count := service.authRate.len()
 
 	if count != 2 {
 		t.Errorf("expected 2 users in cache, got %d", count)
@@ -86,8 +81,7 @@ func TestCheckAuthRateLimitDifferentUsers(t *testing.T) {
 
 func TestReleaseAuthRateLimit(t *testing.T) {
 	service := &RadiusService{
-		AuthRateCache: make(map[string]AuthRateUser),
-		arclock:       sync.Mutex{},
+		authRate: newAuthRateLimiter(defaultAuthRateShards),
 	}
 
 	// Add user to rate limit cache
@@ -97,9 +91,7 @@ func TestReleaseAuthRateLimit(t *testing.T) {
 	service.ReleaseAuthRateLimit("user1")
 
 	// Validate the user is removed from the cache
-	service.arclock.Lock()
-	_, exists := service.AuthRateCache["user1"]
-	service.arclock.Unlock()
+	_, exists := service.authRate.get("user1")
 
 	if exists {
 		t.Error("user should be removed from cache after release")
@@ -114,8 +106,7 @@ func TestReleaseAuthRateLimit(t *testing.T) {
 
 func TestCheckAuthRateLimitConcurrent(t *testing.T) {
 	service := &RadiusService{
-		AuthRateCache: make(map[string]AuthRateUser),
-		arclock:       sync.Mutex{},
+		authRate: newAuthRateLimiter(defaultAuthRateShards),
 	}
 
 	var wg sync.WaitGroup
@@ -154,8 +145,7 @@ func TestCheckAuthRateLimitConcurrent(t *testing.T) {
 
 func TestAuthRateCacheConcurrentAccess(t *testing.T) {
 	service := &RadiusService{
-		AuthRateCache: make(map[string]AuthRateUser),
-		arclock:       sync.Mutex{},
+		authRate: newAuthRateLimiter(defaultAuthRateShards),
 	}
 
 	var wg sync.WaitGroup
@@ -174,9 +164,7 @@ func TestAuthRateCacheConcurrentAccess(t *testing.T) {
 	wg.Wait()
 
 	// Validate the number of users in the cache
-	service.arclock.Lock()
-	count := len(service.AuthRateCache)
-	service.arclock.Unlock()
+	count := service.authRate.len()
 
 	if count != userCount {
 		t.Logf("Note: Expected %d users, got %d", userCount, count)
@@ -185,17 +173,14 @@ func TestAuthRateCacheConcurrentAccess(t *testing.T) {
 
 func TestReleaseAuthRateLimitNonexistent(t *testing.T) {
 	service := &RadiusService{
-		AuthRateCache: make(map[string]AuthRateUser),
-		arclock:       sync.Mutex{},
+		authRate: newAuthRateLimiter(defaultAuthRateShards),
 	}
 
 	// Releasing a non-existent user should not panic
 	service.ReleaseAuthRateLimit("nonexistent-user")
 
 	// Validate the cache is empty
-	service.arclock.Lock()
-	count := len(service.AuthRateCache)
-	service.arclock.Unlock()
+	count := service.authRate.len()
 
 	if count != 0 {
 		t.Errorf("expected empty cache, got %d entries", count)
@@ -204,17 +189,15 @@ func TestReleaseAuthRateLimitNonexistent(t *testing.T) {
 
 func TestAuthRateLimitExpiry(t *testing.T) {
 	service := &RadiusService{
-		AuthRateCache: make(map[string]AuthRateUser),
-		arclock:       sync.Mutex{},
+		authRate: newAuthRateLimiter(defaultAuthRateShards),
 	}
 
 	// Add user
 	_ = service.CheckAuthRateLimit("user1")
 
 	// Get add time
-	service.arclock.Lock()
-	startTime := service.AuthRateCache["user1"].Starttime
-	service.arclock.Unlock()
+	entry, _ := service.authRate.get("user1")
+	startTime := entry.Starttime
 
 	// Validatetimestamp
 	if time.Since(startTime) > time.Second {


### PR DESCRIPTION
## Summary
Replaces the single global mutex (`arclock`) guarding the authentication rate-limit map with a **sharded limiter**, removing the serialization point that capped authentication throughput on multi-core machines.

Closes #303

## Problem
The auth replay/rate-limit guard protected one `map[string]AuthRateUser` with a single `sync.Mutex`. Every `Access-Request` acquired that lock twice (`CheckAuthRateLimit` entry + `ReleaseAuthRateLimit` on defer), serializing **all users and all authentication requests** and cancelling out the concurrency provided by the `ants` worker pool.

## Change
- New `authRateLimiter` (`internal/radiusd/auth_rate_limiter.go`): state is partitioned across a power-of-two set of independently locked shards, selected by an allocation-free FNV-1a hash of the username. Distinct users contend only on hash collisions instead of one global lock.
- `RadiusService` now holds `authRate *authRateLimiter` instead of `AuthRateCache` + `arclock`; `CheckAuthRateLimit`/`ReleaseAuthRateLimit` delegate to it. **Rate-limit semantics are unchanged.**
- Default 256 shards (capped at 65536), negligible memory cost.

## Benchmark evidence
Comparison benchmark (sharded vs. single-mutex baseline mirroring the old impl), distinct users, parallel, `GOMAXPROCS=8`:

```
BenchmarkAuthRateLimiter_Sharded-8   200000   126.3 ns/op
BenchmarkAuthRateLimiter_Global-8    200000   306.2 ns/op
```

~2.4x higher throughput for distinct users under contention.

## Tests
- Updated existing `radius_test.go` to use the limiter's accessor methods (`len`/`get`).
- Added `auth_rate_limiter_test.go`: power-of-two rounding, check/release/get, distinct-user counting, expiry, and the comparison benchmarks.
- `go build ./...`, full `go test ./...`, `-race` on the limiter tests, and `golangci-lint` all green.

## Notes
- Pure refactor of the concurrency primitive; no protocol/behavior change.
