### PR TITLE
refactor(eap): return eap.ErrStateNotFound from GetState

### DIFF
--- a/internal/radiusd/plugins/eap/statemanager/memory_state_manager.go
+++ b/internal/radiusd/plugins/eap/statemanager/memory_state_manager.go
@@ -1,7 +1,6 @@
 package statemanager
 
 import (
-"errors"
 "sync"
 "time"
 
@@ -92,29 +91,28 @@ func (m *MemoryStateManager) Close() {
 m.stopOnce.Do(func() { close(m.stopCh) })
 }
 
-// errStateNotFound is returned by GetState when no live state exists for the
-// requested ID (either never stored, already deleted, or expired). It is a
-// package-level sentinel to avoid allocating on the hot not-found path.
-var errStateNotFound = errors.New("state not found")
-
 // GetState returns the EAP state for the given ID. It is a read-mostly
 // operation: the common (non-expired) path holds only a read lock, so
 // concurrent EAP handshakes reading distinct or shared states are not
 // serialized. Expired states are treated as absent and removed lazily under a
 // brief write lock taken only when an expired entry is actually encountered.
+//
+// When no live state exists it returns eap.ErrStateNotFound, matching the
+// EAPStateManager contract and the sentinel used across the EAP subsystem so
+// callers can rely on errors.Is(err, eap.ErrStateNotFound).
 func (m *MemoryStateManager) GetState(stateID string) (*eap.EAPState, error) {
 m.mu.RLock()
 entry, ok := m.states[stateID]
 if !ok {
 m.mu.RUnlock()
-return nil, errStateNotFound
+return nil, eap.ErrStateNotFound
 }
 if time.Now().After(entry.expiresAt) {
 m.mu.RUnlock()
 // Rare path: drop the read lock and remove the expired entry under a
 // write lock so the common path above stays read-only.
 m.deleteIfExpired(stateID)
-return nil, errStateNotFound
+return nil, eap.ErrStateNotFound
 }
 
 // Return a copy to avoid concurrent modification.

--- a/internal/radiusd/plugins/eap/statemanager/memory_state_manager_test.go
+++ b/internal/radiusd/plugins/eap/statemanager/memory_state_manager_test.go
@@ -67,6 +67,20 @@ func TestMemoryStateManager_GetState_NotFound(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, state)
 	assert.Contains(t, err.Error(), "not found")
+	// GetState must return the subsystem's sentinel so callers can match it
+	// with errors.Is, consistently with the EAPStateManager contract.
+	assert.ErrorIs(t, err, eap.ErrStateNotFound)
+}
+
+func TestMemoryStateManager_GetState_ExpiredReturnsSentinel(t *testing.T) {
+	mgr := NewMemoryStateManagerWithTTL(10*time.Millisecond, 0)
+	defer mgr.Close()
+
+	require.NoError(t, mgr.SetState("s1", &eap.EAPState{StateID: "s1"}))
+	time.Sleep(25 * time.Millisecond)
+
+	_, err := mgr.GetState("s1")
+	assert.ErrorIs(t, err, eap.ErrStateNotFound)
 }
 
 func TestMemoryStateManager_GetState_ReturnsCopy(t *testing.T) {


### PR DESCRIPTION
Follow-up to the #305 review (PR #311).

## Problem
`MemoryStateManager.GetState` returned a private `errStateNotFound` ("state not found"), but the EAP subsystem already defines `eap.ErrStateNotFound` ("EAP state not found") which the `EAPStateManager` mocks and the md5/mschapv2/otp handlers use. A caller doing `errors.Is(err, eap.ErrStateNotFound)` would not match the in-memory manager — an inconsistency Copilot flagged on #311.

## Change
- Return `eap.ErrStateNotFound` for both the absent and expired cases, honoring the `EAPStateManager` contract and the subsystem-wide sentinel.
- Remove the now-unused private sentinel and the `errors` import.
- Add `errors.Is(err, eap.ErrStateNotFound)` assertions for the not-found and expired paths.

## Verification
- `go test -race ./internal/radiusd/plugins/eap/...` green.
- `golangci-lint` clean.

Refs #305