### PR TITLE
fix(radsec): bound RadSec handler goroutines before spawn (#306)

### DIFF
--- a/internal/app/radius_metrics.go
+++ b/internal/app/radius_metrics.go
@@ -18,6 +18,7 @@ const (
 	MetricsRadiusRejectUnauthorized = "radus_reject_unauthorized"
 	MetricsRadiusAuthDrop           = "radus_auth_drop"
 	MetricsRadiusAcctDrop           = "radus_acct_drop"
+	MetricsRadiusRadsecSaturated    = "radus_radsec_saturated"
 	MetricsRadiusAccept             = "radus_accept"
 	MetricsRadiusAccounting         = "radus_accounting"
 )
@@ -36,6 +37,7 @@ var metricsNames = []string{
 	MetricsRadiusRejectUnauthorized,
 	MetricsRadiusAuthDrop,
 	MetricsRadiusAcctDrop,
+	MetricsRadiusRadsecSaturated,
 	MetricsRadiusAccept,
 	MetricsRadiusAccounting,
 }

--- a/internal/radiusd/radsec_server.go
+++ b/internal/radiusd/radsec_server.go
@@ -16,10 +16,17 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/talkincode/toughradius/v9/internal/app"
 	"github.com/talkincode/toughradius/v9/pkg/common"
 	"go.uber.org/zap"
 	"layeh.com/radius"
 )
+
+// defaultRadsecWorkers bounds the number of concurrent RadSec handler goroutines
+// when RadsecWorker is left unconfigured (<= 0). A zero-capacity worker channel
+// would otherwise be unbuffered and deadlock the read loop, so a sane default is
+// applied. It mirrors the config default (config.DefaultConfig: radsec_worker).
+const defaultRadsecWorkers = 100
 
 type packetResponseWriter struct {
 	// listener that received the packet
@@ -82,11 +89,48 @@ type RadsecPacketServer struct {
 
 func (s *RadsecPacketServer) initLocked() {
 	if s.ctx == nil {
+		workers := s.RadsecWorker
+		if workers <= 0 {
+			workers = defaultRadsecWorkers
+		}
 		s.ctx, s.ctxDone = context.WithCancel(context.Background())
 		s.listeners = make(map[net.Conn]uint)
 		s.lastActive = make(chan struct{})
-		s.workerPool = make(chan struct{}, s.RadsecWorker)
+		s.workerPool = make(chan struct{}, workers)
 	}
+}
+
+// acquireWorkerSlot reserves a slot in the bounded worker pool before a handler
+// goroutine is spawned. It returns false when the server is shutting down.
+//
+// Acquiring the slot synchronously in the read loop (rather than inside the
+// spawned goroutine) is what actually bounds the number of in-flight handler
+// goroutines to the pool capacity: when the pool is saturated the read loop
+// stops pulling packets off the connection, which applies natural TCP back-
+// pressure instead of letting a flood spawn unbounded goroutines. This mirrors
+// the bounded back-pressure used on the UDP accounting path
+// (AcctService.submitAcctTask), adapted to RadSec's connection-oriented transport.
+func (s *RadsecPacketServer) acquireWorkerSlot() bool {
+	select {
+	case s.workerPool <- struct{}{}:
+		return true
+	default:
+	}
+	// Pool saturated: record the back-pressure event for observability, then
+	// block until a slot frees or the server shuts down.
+	app.IncRadiusMetric(app.MetricsRadiusRadsecSaturated)
+	select {
+	case s.workerPool <- struct{}{}:
+		return true
+	case <-s.ctx.Done():
+		return false
+	}
+}
+
+// releaseWorkerSlot returns a slot to the bounded worker pool. It must be called
+// exactly once for every successful acquireWorkerSlot.
+func (s *RadsecPacketServer) releaseWorkerSlot() {
+	<-s.workerPool
 }
 
 func (s *RadsecPacketServer) activeAdd() {
@@ -200,12 +244,18 @@ func (s *RadsecPacketServer) Serve(conn net.Conn) error {
 			continue
 		}
 
+		// Reserve a worker slot before spawning the handler goroutine. This
+		// bounds in-flight handler goroutines to the pool size and applies TCP
+		// back-pressure when saturated instead of spawning goroutines without
+		// limit. On shutdown the acquire is interrupted and Serve returns.
+		if !s.acquireWorkerSlot() {
+			return radius.ErrServerShutdown
+		}
+
 		s.activeAdd()
 		go func(packet *radius.Packet, conn net.Conn) {
 			defer s.activeDone()
-
-			s.workerPool <- struct{}{}
-			defer func() { <-s.workerPool }()
+			defer s.releaseWorkerSlot()
 
 			key := requestKey{
 				IP:         conn.RemoteAddr().String(),

--- a/internal/radiusd/radsec_server_test.go
+++ b/internal/radiusd/radsec_server_test.go
@@ -1,0 +1,168 @@
+package radiusd
+
+import (
+	"context"
+	"encoding/binary"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"layeh.com/radius"
+)
+
+// radsecHandlerFunc adapts a function to the RadsecHandler interface.
+type radsecHandlerFunc func(w radius.ResponseWriter, r *radius.Request)
+
+func (f radsecHandlerFunc) ServeRADIUS(w radius.ResponseWriter, r *radius.Request) { f(w, r) }
+
+// radsecSecretSourceFunc adapts a function to the radius.SecretSource interface.
+type radsecSecretSourceFunc func(ctx context.Context, remoteAddr net.Addr) ([]byte, error)
+
+func (f radsecSecretSourceFunc) RADIUSSecret(ctx context.Context, remoteAddr net.Addr) ([]byte, error) {
+	return f(ctx, remoteAddr)
+}
+
+// radsecTestPacket builds a minimal valid RADIUS-over-TCP packet: a 4-byte
+// header (Code, Identifier, Length) followed by the 16-byte authenticator and
+// no attributes. Length is 20 (4 header + 16 authenticator).
+func radsecTestPacket(id byte) []byte {
+	buf := make([]byte, 20)
+	buf[0] = 1 // Code = Access-Request
+	buf[1] = id
+	binary.BigEndian.PutUint16(buf[2:4], 20)
+	return buf
+}
+
+// TestRadsecPacketServer_BoundsConcurrentHandlers verifies that the read loop
+// never spawns more concurrent handler goroutines than RadsecWorker, even when
+// many packets arrive while handlers are slow. This is the regression guard for
+// the unbounded-goroutine issue: the worker slot must be acquired before the
+// handler goroutine is spawned.
+func TestRadsecPacketServer_BoundsConcurrentHandlers(t *testing.T) {
+	const workers = 4
+	const total = 16
+
+	var running int32
+	var maxRunning int32
+	release := make(chan struct{})
+	started := make(chan struct{}, total)
+
+	handler := radsecHandlerFunc(func(w radius.ResponseWriter, r *radius.Request) {
+		cur := atomic.AddInt32(&running, 1)
+		for {
+			old := atomic.LoadInt32(&maxRunning)
+			if cur <= old || atomic.CompareAndSwapInt32(&maxRunning, old, cur) {
+				break
+			}
+		}
+		started <- struct{}{}
+		<-release
+		atomic.AddInt32(&running, -1)
+	})
+
+	server := &RadsecPacketServer{
+		Handler: handler,
+		SecretSource: radsecSecretSourceFunc(func(context.Context, net.Addr) ([]byte, error) {
+			return []byte("testing123"), nil
+		}),
+		RadsecWorker: workers,
+	}
+
+	clientConn, serverConn := net.Pipe()
+	go func() { _ = server.Serve(serverConn) }()
+
+	// Feed packets with distinct identifiers so the per-(IP,Identifier) dedup
+	// does not collapse them. net.Pipe is unbounded backpressure: writes block
+	// until the server reads, so a stalled read loop naturally stalls writes.
+	go func() {
+		for i := 0; i < total; i++ {
+			if _, err := clientConn.Write(radsecTestPacket(byte(i))); err != nil {
+				return
+			}
+		}
+	}()
+
+	// Wait until the pool is fully occupied.
+	for i := 0; i < workers; i++ {
+		select {
+		case <-started:
+		case <-time.After(3 * time.Second):
+			t.Fatalf("timed out waiting for handler %d to start", i)
+		}
+	}
+
+	// With the pool saturated, no additional handler must start until a slot
+	// frees. If a 5th handler starts here, the goroutine was spawned before
+	// acquiring a worker slot (the bug).
+	select {
+	case <-started:
+		t.Fatal("a handler started while the worker pool was saturated; goroutines are not bounded")
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	if got := atomic.LoadInt32(&running); got != workers {
+		t.Fatalf("expected exactly %d concurrent handlers, got %d", workers, got)
+	}
+
+	// Release everything and drain the remaining packets.
+	close(release)
+	for i := workers; i < total; i++ {
+		select {
+		case <-started:
+		case <-time.After(3 * time.Second):
+			t.Fatalf("timed out draining handler %d", i)
+		}
+	}
+
+	if got := atomic.LoadInt32(&maxRunning); got > workers {
+		t.Fatalf("max concurrent handlers %d exceeded worker limit %d", got, workers)
+	}
+
+	_ = clientConn.Close()
+	_ = server.Shutdown(context.Background())
+}
+
+// TestRadsecPacketServer_AcquireWorkerSlotShutdown verifies that a blocked slot
+// acquisition is released when the server shuts down, so Serve cannot hang on a
+// saturated pool during shutdown.
+func TestRadsecPacketServer_AcquireWorkerSlotShutdown(t *testing.T) {
+	s := &RadsecPacketServer{RadsecWorker: 1}
+	s.mu.Lock()
+	s.initLocked()
+	s.mu.Unlock()
+
+	if !s.acquireWorkerSlot() {
+		t.Fatal("first acquire on an empty pool should succeed")
+	}
+
+	// Pool is now full. A second acquire would block; trigger shutdown and
+	// ensure it returns false instead of blocking forever.
+	s.ctxDone()
+
+	done := make(chan bool, 1)
+	go func() { done <- s.acquireWorkerSlot() }()
+
+	select {
+	case ok := <-done:
+		if ok {
+			t.Fatal("acquire should fail after shutdown when the pool is saturated")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("acquireWorkerSlot blocked after shutdown")
+	}
+}
+
+// TestRadsecPacketServer_DefaultWorkerPool verifies that an unconfigured
+// RadsecWorker falls back to a bounded, buffered pool instead of producing an
+// unbuffered (deadlock-prone) channel.
+func TestRadsecPacketServer_DefaultWorkerPool(t *testing.T) {
+	s := &RadsecPacketServer{}
+	s.mu.Lock()
+	s.initLocked()
+	s.mu.Unlock()
+
+	if cap(s.workerPool) != defaultRadsecWorkers {
+		t.Fatalf("expected default worker pool capacity %d, got %d", defaultRadsecWorkers, cap(s.workerPool))
+	}
+}


### PR DESCRIPTION
## Summary
Closes #306.

RadSec (`internal/radiusd/radsec_server.go`) spawned **one goroutine per inbound packet** and only acquired the `workerPool` semaphore **inside** that goroutine. Under a connection flood with slow handlers, goroutines accumulated without limit (all blocked on the channel send) — a goroutine-explosion / OOM risk. The UDP accounting path already bounds this via the ants pool (`AcctService.submitAcctTask`); RadSec lacked the equivalent.

## Change
- **Acquire the worker slot synchronously in the read loop *before* spawning the handler goroutine.** This caps in-flight handler goroutines at `RadsecWorker` and applies natural TCP back-pressure (the loop stops reading when saturated) instead of letting submitters pile up.
- New `acquireWorkerSlot()` / `releaseWorkerSlot()` helpers. Acquire is **shutdown-aware** via `ctx.Done()`, so `Serve` cannot hang on a saturated pool during shutdown.
- **Default `RadsecWorker` to 100 when unconfigured (`<= 0`)** — a zero-capacity channel would be unbuffered and deadlock the loop.
- New `radus_radsec_saturated` metric to surface back-pressure events, mirroring the accounting drop metric.

## Why blocking (not drop)
RadSec is connection-oriented (TCP/TLS), so back-pressure is applied by pausing reads — the correct TCP analog of the connectionless UDP accounting path's drop-on-overload. No packets are silently dropped; the client's TCP window fills instead.

## Tests
`internal/radiusd/radsec_server_test.go` (net.Pipe driven, no real TLS needed):
- `TestRadsecPacketServer_BoundsConcurrentHandlers` — feeds 16 packets at 4 workers; asserts concurrency never exceeds 4 and that no 5th handler starts while saturated (the regression guard).
- `TestRadsecPacketServer_AcquireWorkerSlotShutdown` — a blocked acquire returns on shutdown.
- `TestRadsecPacketServer_DefaultWorkerPool` — unconfigured worker count yields a bounded, buffered pool.

## Verification
- `CGO_ENABLED=0 go build ./...`
- `go test -short ./internal/radiusd/ ./internal/app/` (CI-equivalent) — pass
- `go test -race -count=5 -run TestRadsecPacketServer ./internal/radiusd/` — pass, no data races
- `golangci-lint run` — 0 issues
