### PR TITLE
refactor(radsec): honor shutdown first in acquireWorkerSlot

### DIFF
--- a/internal/radiusd/radsec_server.go
+++ b/internal/radiusd/radsec_server.go
@@ -25,7 +25,7 @@ import (
 // defaultRadsecWorkers bounds the number of concurrent RadSec handler goroutines
 // when RadsecWorker is left unconfigured (<= 0). A zero-capacity worker channel
 // would otherwise be unbuffered and deadlock the read loop, so a sane default is
-// applied. It mirrors the config default (config.DefaultConfig: radsec_worker).
+// applied. It mirrors config.DefaultAppConfig.Radiusd.RadsecWorker.
 const defaultRadsecWorkers = 100
 
 type packetResponseWriter struct {
@@ -111,6 +111,12 @@ func (s *RadsecPacketServer) initLocked() {
 // the bounded back-pressure used on the UDP accounting path
 // (AcctService.submitAcctTask), adapted to RadSec's connection-oriented transport.
 func (s *RadsecPacketServer) acquireWorkerSlot() bool {
+	// Honor shutdown first: once the server is stopping, never start a new
+	// handler even if the pool still has free slots. This keeps the documented
+	// "returns false when shutting down" contract consistent.
+	if s.ctx.Err() != nil {
+		return false
+	}
 	select {
 	case s.workerPool <- struct{}{}:
 		return true

--- a/internal/radiusd/radsec_server_test.go
+++ b/internal/radiusd/radsec_server_test.go
@@ -153,6 +153,22 @@ func TestRadsecPacketServer_AcquireWorkerSlotShutdown(t *testing.T) {
 	}
 }
 
+// TestRadsecPacketServer_AcquireWorkerSlotShutdownFreeSlot verifies that once the
+// server is shutting down, acquireWorkerSlot returns false even when the pool
+// still has free capacity, so no new handlers are started during shutdown.
+func TestRadsecPacketServer_AcquireWorkerSlotShutdownFreeSlot(t *testing.T) {
+	s := &RadsecPacketServer{RadsecWorker: 4}
+	s.mu.Lock()
+	s.initLocked()
+	s.mu.Unlock()
+
+	s.ctxDone()
+
+	if s.acquireWorkerSlot() {
+		t.Fatal("acquire should fail after shutdown even with free pool capacity")
+	}
+}
+
 // TestRadsecPacketServer_DefaultWorkerPool verifies that an unconfigured
 // RadsecWorker falls back to a bounded, buffered pool instead of producing an
 // unbuffered (deadlock-prone) channel.


### PR DESCRIPTION
## Summary
Follow-up addressing the two Copilot review comments on #313 (already merged). Refs #306.

1. **Honor shutdown first in `acquireWorkerSlot`.** The method documented that it returns `false` when the server is shutting down, but it could still grab a free slot and return `true` after `s.ctx` was canceled (the shutdown signal). Now it checks `s.ctx.Err()` up front, so no new handler goroutines start once shutdown has begun — consistent with the contract and avoids racing handlers against `Shutdown`.

2. **Doc reference fix.** `defaultRadsecWorkers` comment referenced a non-existent `config.DefaultConfig`; corrected to `config.DefaultAppConfig.Radiusd.RadsecWorker` (config/config.go:433).

## Tests
- New `TestRadsecPacketServer_AcquireWorkerSlotShutdownFreeSlot` — after shutdown, acquire returns `false` even when the pool has free capacity.
- Existing radsec tests unchanged and passing.

## Verification
- `CGO_ENABLED=0 go build ./...`
- `go test -run TestRadsecPacketServer ./internal/radiusd/` — pass
- `golangci-lint run ./internal/radiusd/...` — 0 issues
