### PR TITLE
refactor(radsec): close shutdown/acquire race in acquireWorkerSlot

### DIFF
--- a/internal/radiusd/radsec_server.go
+++ b/internal/radiusd/radsec_server.go
@@ -119,7 +119,7 @@ func (s *RadsecPacketServer) acquireWorkerSlot() bool {
 	}
 	select {
 	case s.workerPool <- struct{}{}:
-		return true
+		return s.keepSlotUnlessShutdown()
 	default:
 	}
 	// Pool saturated: record the back-pressure event for observability, then
@@ -127,10 +127,23 @@ func (s *RadsecPacketServer) acquireWorkerSlot() bool {
 	app.IncRadiusMetric(app.MetricsRadiusRadsecSaturated)
 	select {
 	case s.workerPool <- struct{}{}:
-		return true
+		return s.keepSlotUnlessShutdown()
 	case <-s.ctx.Done():
 		return false
 	}
+}
+
+// keepSlotUnlessShutdown re-checks the shutdown signal after a slot was acquired.
+// Acquiring a free slot (a non-blocking channel send) and observing ctx are two
+// separate steps, so Shutdown can cancel ctx in between. Re-checking here and
+// releasing the slot on shutdown closes that race deterministically: no new
+// handler is started once shutdown has begun, and the slot is handed back.
+func (s *RadsecPacketServer) keepSlotUnlessShutdown() bool {
+	if s.ctx.Err() != nil {
+		<-s.workerPool
+		return false
+	}
+	return true
 }
 
 // releaseWorkerSlot returns a slot to the bounded worker pool. It must be called

--- a/internal/radiusd/radsec_server.go
+++ b/internal/radiusd/radsec_server.go
@@ -140,7 +140,7 @@ func (s *RadsecPacketServer) acquireWorkerSlot() bool {
 // handler is started once shutdown has begun, and the slot is handed back.
 func (s *RadsecPacketServer) keepSlotUnlessShutdown() bool {
 	if s.ctx.Err() != nil {
-		<-s.workerPool
+		s.releaseWorkerSlot()
 		return false
 	}
 	return true

--- a/internal/radiusd/radsec_server_test.go
+++ b/internal/radiusd/radsec_server_test.go
@@ -169,6 +169,27 @@ func TestRadsecPacketServer_AcquireWorkerSlotShutdownFreeSlot(t *testing.T) {
 	}
 }
 
+// TestRadsecPacketServer_KeepSlotUnlessShutdownReleases verifies the race-closing
+// re-check: when shutdown is signaled after a slot was acquired, the slot is
+// released and false is returned, so a handler is not started during shutdown.
+func TestRadsecPacketServer_KeepSlotUnlessShutdownReleases(t *testing.T) {
+	s := &RadsecPacketServer{RadsecWorker: 1}
+	s.mu.Lock()
+	s.initLocked()
+	s.mu.Unlock()
+
+	// Simulate a successful non-blocking send that raced with shutdown.
+	s.workerPool <- struct{}{}
+	s.ctxDone()
+
+	if s.keepSlotUnlessShutdown() {
+		t.Fatal("keepSlotUnlessShutdown should return false during shutdown")
+	}
+	if len(s.workerPool) != 0 {
+		t.Fatalf("slot should be released on shutdown, occupied=%d", len(s.workerPool))
+	}
+}
+
 // TestRadsecPacketServer_DefaultWorkerPool verifies that an unconfigured
 // RadsecWorker falls back to a bounded, buffered pool instead of producing an
 // unbuffered (deadlock-prone) channel.


### PR DESCRIPTION
## Summary
Follow-up addressing the Codex P2 comment on #314 (already merged). Refs #306.

`acquireWorkerSlot` checked `ctx.Err()` up front, but that check and the subsequent non-blocking slot send are separate steps. If `Shutdown` cancels `ctx` in between and the pool has free capacity, a handler could still be started after shutdown had begun.

## Change
Add `keepSlotUnlessShutdown`, called immediately after a slot is acquired (in both the fast and post-saturation paths). It re-checks `ctx.Err()` and, if shutdown has begun, releases the slot and returns `false`. This makes the shutdown-vs-acquire decision deterministic.

Note: any handler that legitimately starts just before shutdown is still tracked by `activeCount` and awaited by `Shutdown` via `lastActive`, so graceful shutdown was already preserved; this change additionally prevents starting new handlers once shutdown is observable.

## Tests
- `TestRadsecPacketServer_KeepSlotUnlessShutdownReleases` — deterministically takes a slot, signals shutdown, asserts `keepSlotUnlessShutdown` returns `false` and the slot is released.
- Existing radsec tests still pass under `-race`.

## Verification
- `CGO_ENABLED=0 go build ./...`
- `go test -race -run TestRadsecPacketServer ./internal/radiusd/` — pass, no data races
- `golangci-lint run ./internal/radiusd/...` — 0 issues
