### PR TITLE
perf(radsec): pool per-packet parse buffer + hot-path alloc benchmarks (#307)

### DIFF
--- a/internal/radiusd/hotpath_bench_test.go
+++ b/internal/radiusd/hotpath_bench_test.go
@@ -1,0 +1,162 @@
+package radiusd
+
+import (
+	"bytes"
+	"net"
+	"sync"
+	"testing"
+
+	"layeh.com/radius"
+	"layeh.com/radius/rfc2865"
+	"layeh.com/radius/rfc2866"
+)
+
+// buildBenchAcctPacket builds a realistic, valid Accounting-Request packet whose
+// Request Authenticator matches the shared secret, so CheckRequestSecret takes
+// its success path (the common case in production). The packet is round-tripped
+// through Encode/Parse so its on-wire form is what the hot path actually sees.
+func buildBenchAcctPacket(tb testing.TB) (*radius.Packet, []byte) {
+	tb.Helper()
+	secret := []byte("testing123")
+	p := radius.New(radius.CodeAccountingRequest, secret)
+	_ = rfc2865.UserName_SetString(p, "user0001")
+	_ = rfc2865.NASIPAddress_Set(p, net.IPv4(10, 0, 0, 1))
+	_ = rfc2865.CallingStationID_SetString(p, "00:11:22:33:44:55")
+	_ = rfc2865.CalledStationID_SetString(p, "AP-Office-01")
+	_ = rfc2866.AcctSessionID_SetString(p, "sess-0000000000000001")
+	_ = rfc2866.AcctStatusType_Set(p, rfc2866.AcctStatusType_Value_InterimUpdate)
+	_ = rfc2866.AcctInputOctets_Set(p, 123456)
+	_ = rfc2866.AcctOutputOctets_Set(p, 654321)
+	_ = rfc2866.AcctSessionTime_Set(p, 3600)
+
+	encoded, err := p.Encode()
+	if err != nil {
+		tb.Fatalf("encode: %v", err)
+	}
+	parsed, err := radius.Parse(encoded, secret)
+	if err != nil {
+		tb.Fatalf("parse: %v", err)
+	}
+	return parsed, secret
+}
+
+// BenchmarkCheckRequestSecret measures allocations on the accounting
+// authenticator-verification path, which runs for every accounting packet.
+func BenchmarkCheckRequestSecret(b *testing.B) {
+	svc := &RadiusService{}
+	pkt, secret := buildBenchAcctPacket(b)
+
+	if err := svc.CheckRequestSecret(pkt, secret); err != nil {
+		b.Fatalf("expected valid secret, got %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := svc.CheckRequestSecret(pkt, secret); err != nil {
+			b.Fatalf("unexpected error: %v", err)
+		}
+	}
+}
+
+// BenchmarkParseTcpPacket measures allocations on the RadSec per-packet parse
+// path. A single bytes.Reader is reset each iteration so only parseTcpPacket's
+// own allocations (the data slice, attribute parsing, the packet) are counted.
+func BenchmarkParseTcpPacket(b *testing.B) {
+	pkt, secret := buildBenchAcctPacket(b)
+	encoded, err := pkt.Encode()
+	if err != nil {
+		b.Fatalf("encode: %v", err)
+	}
+
+	rd := bytes.NewReader(nil)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rd.Reset(encoded)
+		if _, err := parseTcpPacket(rd, secret); err != nil {
+			b.Fatalf("parseTcpPacket: %v", err)
+		}
+	}
+}
+
+// BenchmarkPacketLength measures the per-packet response length calculation.
+func BenchmarkPacketLength(b *testing.B) {
+	pkt, _ := buildBenchAcctPacket(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = Length(pkt)
+	}
+}
+
+// TestParseTcpPacket_RoundTrip verifies that a packet parsed from the pooled
+// buffer reproduces the original code, identifier, attributes and authenticator.
+func TestParseTcpPacket_RoundTrip(t *testing.T) {
+	pkt, secret := buildBenchAcctPacket(t)
+	encoded, err := pkt.Encode()
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	got, err := parseTcpPacket(bytes.NewReader(encoded), secret)
+	if err != nil {
+		t.Fatalf("parseTcpPacket: %v", err)
+	}
+	if got.Code != pkt.Code || got.Identifier != pkt.Identifier {
+		t.Fatalf("header mismatch: got code=%v id=%v", got.Code, got.Identifier)
+	}
+	if name := rfc2865.UserName_GetString(got); name != "user0001" {
+		t.Fatalf("attribute mismatch: UserName=%q", name)
+	}
+	if got.Authenticator != pkt.Authenticator {
+		t.Fatalf("authenticator mismatch")
+	}
+}
+
+// TestParseTcpPacket_RejectsMalformedLength verifies the length guards added for
+// safe buffer pooling: a length below the header size and a payload shorter than
+// the 16-byte authenticator are both rejected instead of underflowing or panicking.
+func TestParseTcpPacket_RejectsMalformedLength(t *testing.T) {
+	belowHeader := []byte{1, 2, 0, 3} // Length 3 < 4-byte header
+	if _, err := parseTcpPacket(bytes.NewReader(belowHeader), []byte("s")); err == nil {
+		t.Fatal("expected error for length below header size")
+	}
+
+	shortPayload := []byte{1, 2, 0, 18} // Length 18 => dataLen 14 < 16
+	if _, err := parseTcpPacket(bytes.NewReader(shortPayload), []byte("s")); err == nil {
+		t.Fatal("expected error for payload shorter than authenticator")
+	}
+}
+
+// TestParseTcpPacket_ConcurrentReuseSafe exercises the shared buffer pool from
+// many goroutines; under -race this fails if a pooled buffer is reused while
+// still referenced. It guards against attribute corruption from pool misuse.
+func TestParseTcpPacket_ConcurrentReuseSafe(t *testing.T) {
+	pkt, secret := buildBenchAcctPacket(t)
+	encoded, err := pkt.Encode()
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	want := rfc2865.UserName_GetString(pkt)
+
+	var wg sync.WaitGroup
+	for g := 0; g < 16; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 200; i++ {
+				got, err := parseTcpPacket(bytes.NewReader(encoded), secret)
+				if err != nil {
+					t.Errorf("parseTcpPacket: %v", err)
+					return
+				}
+				if rfc2865.UserName_GetString(got) != want {
+					t.Errorf("attribute corrupted under concurrent pool reuse")
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/radiusd/radsec_server.go
+++ b/internal/radiusd/radsec_server.go
@@ -162,6 +162,24 @@ func (s *RadsecPacketServer) activeDone() {
 	}
 }
 
+// tcpPacketBufferPool recycles the per-packet payload buffer used by
+// parseTcpPacket. radius.ParseAttributes copies attribute bytes out (it appends
+// into freshly allocated slices rather than aliasing the input), and the request
+// authenticator is copied into a fixed-size array, so the buffer holds no live
+// references once parseTcpPacket returns and can be safely reused across packets.
+//
+// Pointers to slices are pooled (not slices directly) to avoid allocating a slice
+// header on every Put. pprof identified this buffer as the largest allocation in
+// our own RadSec ingest path; the remaining per-packet allocations live inside
+// layeh.com/radius and are out of scope for in-tree pooling.
+var tcpPacketBufferPool = sync.Pool{
+	New: func() any {
+		// Most RADIUS packets are well under 512 bytes; the buffer grows on demand.
+		b := make([]byte, 0, 512)
+		return &b
+	},
+}
+
 func parseTcpPacket(r io.Reader, secret []byte) (*radius.Packet, error) {
 	var header struct {
 		Code       uint8
@@ -174,8 +192,25 @@ func parseTcpPacket(r io.Reader, secret []byte) (*radius.Packet, error) {
 		return nil, err
 	}
 
-	s := unsafe.Sizeof(header)
-	var data = make([]byte, header.Length-uint16(s))
+	headerSize := uint16(unsafe.Sizeof(header))
+	// Guard against malformed lengths: a Length below the header size would
+	// underflow the unsigned subtraction and request a huge allocation, and a
+	// payload shorter than the 16-byte authenticator would make data[16:] panic.
+	if header.Length < headerSize {
+		return nil, errors.New("radius: invalid packet length")
+	}
+	dataLen := int(header.Length - headerSize)
+	if dataLen < 16 {
+		return nil, errors.New("radius: short packet")
+	}
+
+	bufp := tcpPacketBufferPool.Get().(*[]byte)
+	defer tcpPacketBufferPool.Put(bufp)
+	if cap(*bufp) < dataLen {
+		*bufp = make([]byte, dataLen)
+	}
+	data := (*bufp)[:dataLen]
+
 	if _, err := io.ReadFull(r, data); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
Closes #307 — investigation into whether the per-packet RADIUS hot path warrants object reuse (`sync.Pool`).

This is an **evidence-first** change: I added hot-path allocation benchmarks, captured pprof allocation profiles, and then acted **only** where the data justified it (per the issue's guidance to avoid unevidenced micro-optimization).

## Findings (`go test -benchmem` + `pprof -alloc_space`)
| Hot path | Allocs/op | Where the allocations live |
|---|---|---|
| `CheckRequestSecret` (per acct packet) | **1** | `layeh.com/radius (*Packet).MarshalBinary`. `md5.New()` contributes **0 heap allocs** — escape analysis stack-allocates the hasher. |
| `parseTcpPacket` (per RadSec packet) | **23** | ~74% inside `layeh.com/radius` (`ParseAttributes` 61.6%, `MarshalBinary` 12.5%); the largest allocation in **our** code was the per-packet payload buffer (19.2%). |

pprof `alloc_space` top:
```
61.63%  layeh.com/radius.ParseAttributes
19.21%  .../radiusd.parseTcpPacket        (the data buffer — ours)
12.54%  layeh.com/radius.(*Packet).MarshalBinary
 0%     .../radiusd.CheckRequestSecret    (md5 is stack-allocated)
```

### Conclusions
- **md5 `sync.Pool` rejected** — `md5.New()` already allocates nothing on the heap, so the commonly-suggested hasher pool yields zero benefit. `CheckRequestSecret` left unchanged.
- **Dominant cost is the third-party parser** (`ParseAttributes`), which can't be pooled in-tree without forking `layeh.com/radius` — out of scope.
- **The one poolable allocation in our code** is the `parseTcpPacket` payload buffer.

## Change
Reuse the `parseTcpPacket` payload buffer via a `sync.Pool`. This is **safe**: `radius.ParseAttributes` copies attribute bytes out (`append(Attribute(nil), …)`, no aliasing) and the authenticator is copied into a fixed array, so the buffer holds no live references once `parseTcpPacket` returns. Pointers to slices are pooled to avoid a slice-header allocation per `Put`. Added guards for malformed lengths (below header size / shorter than the 16-byte authenticator) so the pooled path can't underflow or panic.

## Result
- `parseTcpPacket`: **792 → 680 B/op (-14%), 23 → 22 allocs/op**
- `CheckRequestSecret`: unchanged (1 alloc/op) — correctly left alone
- Benchmarks remain as a permanent allocation-regression baseline. Broader `sync.Pool` use is **not** justified by the current data.

## Tests
- `TestParseTcpPacket_RoundTrip` — pooled-buffer parse reproduces code/id/attributes/authenticator.
- `TestParseTcpPacket_RejectsMalformedLength` — the new length guards.
- `TestParseTcpPacket_ConcurrentReuseSafe` — 16 goroutines × 200 parses; under `-race` this catches any pool misuse / aliasing.

## Verification
- `CGO_ENABLED=0 go build ./...`
- `go test -race -run 'TestParseTcpPacket|TestRadsecPacketServer' ./internal/radiusd/` — pass, no data races
- `go test -short ./internal/radiusd/ ./internal/app/` — pass
- `golangci-lint run` — 0 issues
