### PR TITLE
fix(radsec): cap parsed packet length to RFC 2865 maximum

### DIFF
--- a/internal/radiusd/hotpath_bench_test.go
+++ b/internal/radiusd/hotpath_bench_test.go
@@ -19,15 +19,21 @@ func buildBenchAcctPacket(tb testing.TB) (*radius.Packet, []byte) {
 	tb.Helper()
 	secret := []byte("testing123")
 	p := radius.New(radius.CodeAccountingRequest, secret)
-	_ = rfc2865.UserName_SetString(p, "user0001")
-	_ = rfc2865.NASIPAddress_Set(p, net.IPv4(10, 0, 0, 1))
-	_ = rfc2865.CallingStationID_SetString(p, "00:11:22:33:44:55")
-	_ = rfc2865.CalledStationID_SetString(p, "AP-Office-01")
-	_ = rfc2866.AcctSessionID_SetString(p, "sess-0000000000000001")
-	_ = rfc2866.AcctStatusType_Set(p, rfc2866.AcctStatusType_Value_InterimUpdate)
-	_ = rfc2866.AcctInputOctets_Set(p, 123456)
-	_ = rfc2866.AcctOutputOctets_Set(p, 654321)
-	_ = rfc2866.AcctSessionTime_Set(p, 3600)
+	set := func(err error) {
+		tb.Helper()
+		if err != nil {
+			tb.Fatalf("set attribute: %v", err)
+		}
+	}
+	set(rfc2865.UserName_SetString(p, "user0001"))
+	set(rfc2865.NASIPAddress_Set(p, net.IPv4(10, 0, 0, 1)))
+	set(rfc2865.CallingStationID_SetString(p, "00:11:22:33:44:55"))
+	set(rfc2865.CalledStationID_SetString(p, "AP-Office-01"))
+	set(rfc2866.AcctSessionID_SetString(p, "sess-0000000000000001"))
+	set(rfc2866.AcctStatusType_Set(p, rfc2866.AcctStatusType_Value_InterimUpdate))
+	set(rfc2866.AcctInputOctets_Set(p, 123456))
+	set(rfc2866.AcctOutputOctets_Set(p, 654321))
+	set(rfc2866.AcctSessionTime_Set(p, 3600))
 
 	encoded, err := p.Encode()
 	if err != nil {
@@ -126,6 +132,12 @@ func TestParseTcpPacket_RejectsMalformedLength(t *testing.T) {
 	shortPayload := []byte{1, 2, 0, 18} // Length 18 => dataLen 14 < 16
 	if _, err := parseTcpPacket(bytes.NewReader(shortPayload), []byte("s")); err == nil {
 		t.Fatal("expected error for payload shorter than authenticator")
+	}
+
+	// Length above the RFC 2865 maximum must be rejected before allocation.
+	overMax := []byte{1, 2, 0xFF, 0xFF} // Length 65535 > 4096
+	if _, err := parseTcpPacket(bytes.NewReader(overMax), []byte("s")); err == nil {
+		t.Fatal("expected error for length above RFC 2865 maximum")
 	}
 }
 

--- a/internal/radiusd/radsec_server.go
+++ b/internal/radiusd/radsec_server.go
@@ -28,6 +28,12 @@ import (
 // applied. It mirrors config.DefaultAppConfig.Radiusd.RadsecWorker.
 const defaultRadsecWorkers = 100
 
+// maxRadiusPacketLength is the maximum RADIUS packet length per RFC 2865 §3. The
+// 2-byte Length field can encode up to 65535, but a conformant packet never
+// exceeds 4096 bytes; rejecting anything larger bounds per-packet allocations
+// (and the size a pooled parse buffer can retain).
+const maxRadiusPacketLength = 4096
+
 type packetResponseWriter struct {
 	// listener that received the packet
 	conn net.Conn
@@ -193,10 +199,13 @@ func parseTcpPacket(r io.Reader, secret []byte) (*radius.Packet, error) {
 	}
 
 	headerSize := uint16(unsafe.Sizeof(header))
-	// Guard against malformed lengths: a Length below the header size would
-	// underflow the unsigned subtraction and request a huge allocation, and a
-	// payload shorter than the 16-byte authenticator would make data[16:] panic.
-	if header.Length < headerSize {
+	// Guard the length field before allocating or reading. A Length below the
+	// header size would underflow the unsigned subtraction; a payload shorter
+	// than the 16-byte authenticator would make data[16:] panic; and a Length
+	// above the RFC 2865 maximum (4096) must be rejected so a malicious/garbled
+	// length cannot drive a large allocation+read or, via the buffer pool,
+	// permanently retain an oversized backing array.
+	if header.Length < headerSize || header.Length > maxRadiusPacketLength {
 		return nil, errors.New("radius: invalid packet length")
 	}
 	dataLen := int(header.Length - headerSize)


### PR DESCRIPTION
## What

Follow-up hardening for #316 (the `parseTcpPacket` buffer-pool change), addressing two Copilot review findings on that merged PR.

### 1. Cap parsed packet length to the RFC 2865 maximum (important)

`parseTcpPacket` already guarded the *lower* bound of the 2-byte `Length` field, but still trusted its *upper* bound. Two problems:

- A malicious or garbled `Length` (up to 65535) could drive a large allocation and read on every RadSec connection.
- Because #316 made the parse buffer a `sync.Pool` of `*[]byte`, a single oversized packet would grow the pooled backing array and the pool would **retain it permanently**.

Now any `Length` above `maxRadiusPacketLength` (4096, per RFC 2865 §3) is rejected **before** allocating, bounding both the per-packet allocation and the pooled buffer's retained size.

### 2. Benchmark helper fails on attribute setter errors

`buildBenchAcctPacket` used `_ = rfcXXXX_Set(...)`, so a setter failure would silently leave the benchmark running on an invalid packet. It now fails the test/benchmark immediately via a small `set(err)` helper.

## Tests

- Extended `TestParseTcpPacket_RejectsMalformedLength` to assert a `Length` above the RFC maximum is rejected.
- `CGO_ENABLED=1 go test -race ./internal/radiusd/ -run 'TestParseTcpPacket|TestRadsecPacketServer'` passes.
- `golangci-lint run ./internal/radiusd/...` → 0 issues.
- Benchmarks re-run; `parseTcpPacket` numbers unchanged.

Refs #307
