### PR TITLE
fix(radsec): close connection on malformed frame to avoid stream desync

### DIFF
--- a/internal/radiusd/hotpath_bench_test.go
+++ b/internal/radiusd/hotpath_bench_test.go
@@ -2,6 +2,7 @@ package radiusd
 
 import (
 	"bytes"
+	"errors"
 	"net"
 	"sync"
 	"testing"
@@ -121,23 +122,32 @@ func TestParseTcpPacket_RoundTrip(t *testing.T) {
 }
 
 // TestParseTcpPacket_RejectsMalformedLength verifies the length guards added for
-// safe buffer pooling: a length below the header size and a payload shorter than
-// the 16-byte authenticator are both rejected instead of underflowing or panicking.
+// safe buffer pooling: a length below the header size, a payload shorter than
+// the 16-byte authenticator, and a length above the RFC 2865 maximum are all
+// rejected instead of underflowing, panicking, or driving a large allocation.
+// Each must be classified as a framing error so the Serve loop closes the
+// connection rather than misreading the unconsumed body as the next header.
 func TestParseTcpPacket_RejectsMalformedLength(t *testing.T) {
 	belowHeader := []byte{1, 2, 0, 3} // Length 3 < 4-byte header
 	if _, err := parseTcpPacket(bytes.NewReader(belowHeader), []byte("s")); err == nil {
 		t.Fatal("expected error for length below header size")
+	} else if !errors.Is(err, errMalformedFrame) {
+		t.Fatalf("expected errMalformedFrame, got %v", err)
 	}
 
 	shortPayload := []byte{1, 2, 0, 18} // Length 18 => dataLen 14 < 16
 	if _, err := parseTcpPacket(bytes.NewReader(shortPayload), []byte("s")); err == nil {
 		t.Fatal("expected error for payload shorter than authenticator")
+	} else if !errors.Is(err, errMalformedFrame) {
+		t.Fatalf("expected errMalformedFrame, got %v", err)
 	}
 
 	// Length above the RFC 2865 maximum must be rejected before allocation.
 	overMax := []byte{1, 2, 0xFF, 0xFF} // Length 65535 > 4096
 	if _, err := parseTcpPacket(bytes.NewReader(overMax), []byte("s")); err == nil {
 		t.Fatal("expected error for length above RFC 2865 maximum")
+	} else if !errors.Is(err, errMalformedFrame) {
+		t.Fatalf("expected errMalformedFrame, got %v", err)
 	}
 }
 

--- a/internal/radiusd/radsec_server.go
+++ b/internal/radiusd/radsec_server.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"os"
@@ -33,6 +34,14 @@ const defaultRadsecWorkers = 100
 // exceeds 4096 bytes; rejecting anything larger bounds per-packet allocations
 // (and the size a pooled parse buffer can retain).
 const maxRadiusPacketLength = 4096
+
+// errMalformedFrame indicates the RadSec length prefix could not be trusted to
+// delimit the frame: it is smaller than a valid packet or larger than the RFC
+// 2865 maximum. Because the announced body bytes are NOT consumed from the
+// stream when this is returned, the TCP connection is desynchronized — the
+// remaining bytes would be misread as subsequent packet headers. Callers must
+// treat it as fatal and close the connection rather than continue parsing.
+var errMalformedFrame = errors.New("radius: malformed packet framing")
 
 type packetResponseWriter struct {
 	// listener that received the packet
@@ -204,13 +213,14 @@ func parseTcpPacket(r io.Reader, secret []byte) (*radius.Packet, error) {
 	// than the 16-byte authenticator would make data[16:] panic; and a Length
 	// above the RFC 2865 maximum (4096) must be rejected so a malicious/garbled
 	// length cannot drive a large allocation+read or, via the buffer pool,
-	// permanently retain an oversized backing array.
+	// permanently retain an oversized backing array. These are framing errors:
+	// the body has not been consumed, so the caller must close the connection.
 	if header.Length < headerSize || header.Length > maxRadiusPacketLength {
-		return nil, errors.New("radius: invalid packet length")
+		return nil, fmt.Errorf("%w: length %d", errMalformedFrame, header.Length)
 	}
 	dataLen := int(header.Length - headerSize)
 	if dataLen < 16 {
-		return nil, errors.New("radius: short packet")
+		return nil, fmt.Errorf("%w: payload shorter than authenticator", errMalformedFrame)
 	}
 
 	bufp := tcpPacketBufferPool.Get().(*[]byte)
@@ -301,6 +311,14 @@ func (s *RadsecPacketServer) Serve(conn net.Conn) error {
 			}
 			if _, ok := err.(net.Error); ok {
 				zap.S().Infof("radius: connection error %s: %v", conn.RemoteAddr(), err)
+				return err
+			}
+			// A framing error means the length prefix could not delimit the
+			// frame and its announced body was not consumed, so the stream is
+			// desynchronized. Continuing would misread the body as the next
+			// header; close the connection instead. The client may reconnect.
+			if errors.Is(err, errMalformedFrame) {
+				zap.S().Errorf("radius: closing connection %s on malformed frame: %v", conn.RemoteAddr(), err)
 				return err
 			}
 			zap.S().Errorf("radius: unable to parse packet: %v", err)

--- a/internal/radiusd/radsec_server_test.go
+++ b/internal/radiusd/radsec_server_test.go
@@ -3,6 +3,7 @@ package radiusd
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"net"
 	"sync/atomic"
 	"testing"
@@ -202,4 +203,63 @@ func TestRadsecPacketServer_DefaultWorkerPool(t *testing.T) {
 	if cap(s.workerPool) != defaultRadsecWorkers {
 		t.Fatalf("expected default worker pool capacity %d, got %d", defaultRadsecWorkers, cap(s.workerPool))
 	}
+}
+
+// TestRadsecPacketServer_MalformedFrameClosesConnection verifies that an
+// over-max length prefix is treated as a fatal framing error: Serve returns
+// (closing the connection) instead of continuing, which would misread the
+// frame's unconsumed body as subsequent packet headers and desynchronize the
+// stream. A valid packet sent before the malformed frame must still be served,
+// and the bytes embedded in the malformed frame's body must NOT be processed.
+func TestRadsecPacketServer_MalformedFrameClosesConnection(t *testing.T) {
+	var handled int32
+	served := make(chan struct{}, 8)
+	handler := radsecHandlerFunc(func(w radius.ResponseWriter, r *radius.Request) {
+		atomic.AddInt32(&handled, 1)
+		served <- struct{}{}
+	})
+
+	server := &RadsecPacketServer{
+		Handler: handler,
+		SecretSource: radsecSecretSourceFunc(func(context.Context, net.Addr) ([]byte, error) {
+			return []byte("testing123"), nil
+		}),
+		RadsecWorker: 4,
+	}
+
+	clientConn, serverConn := net.Pipe()
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- server.Serve(serverConn) }()
+
+	// A valid packet must be served normally.
+	go func() { _, _ = clientConn.Write(radsecTestPacket(1)) }()
+	select {
+	case <-served:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for the valid packet to be served")
+	}
+
+	// Now send a frame advertising an over-max Length, followed by a valid
+	// 20-byte packet as its body. Without the framing guard the read loop would
+	// continue and misread that body as the next packet's header.
+	overMax := []byte{1, 9, 0xFF, 0xFF}
+	overMax = append(overMax, radsecTestPacket(2)...)
+	go func() { _, _ = clientConn.Write(overMax) }()
+
+	select {
+	case err := <-serveErr:
+		if !errors.Is(err, errMalformedFrame) {
+			t.Fatalf("expected Serve to return errMalformedFrame, got %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Serve did not close the connection on a malformed frame")
+	}
+
+	// The embedded body must not have been processed as a second packet.
+	if got := atomic.LoadInt32(&handled); got != 1 {
+		t.Fatalf("expected exactly 1 served packet, got %d (stream desynchronized)", got)
+	}
+
+	_ = clientConn.Close()
+	_ = server.Shutdown(context.Background())
 }


### PR DESCRIPTION
## What

Follow-up to the Codex review on #317. That PR added an upper-bound length guard to `parseTcpPacket`, but rejecting an over-range length **without consuming the announced frame body** desynchronizes the RadSec TCP stream.

### The problem

The `Serve` loop logs non-EOF parse errors and then **continues** reading the same `bufio.Reader`. When `parseTcpPacket` returns early on a bad length prefix, the frame's body bytes are still in the stream, so the next loop iteration misreads that body as the next packet's header — generating spurious parse errors until the stream happens to realign or EOFs.

### The fix

- Classify the length-guard failures (`< headerSize`, `> 4096`, payload `< 16`) as a distinct `errMalformedFrame` sentinel.
- In the `Serve` loop, treat `errMalformedFrame` as **fatal**: close the connection (the client may reconnect) instead of `continue`.
- `radius.ParseAttributes` failures still `continue`, because that path already consumed the full frame via `io.ReadFull`, so the stream remains aligned.

## Tests

- New `TestRadsecPacketServer_MalformedFrameClosesConnection`: sends a valid packet (served normally), then an over-max frame whose body is a valid-looking packet; asserts `Serve` returns `errMalformedFrame` (connection closed) and the embedded body is **not** processed as a second packet. Passes 5/5 under `-race`.
- `TestParseTcpPacket_RejectsMalformedLength` now asserts each rejection is classified as `errMalformedFrame`.
- `golangci-lint run ./internal/radiusd/...` → 0 issues.

Refs #307
