### PR TITLE
fix(radsec): close connection on every Serve return path

### DIFF
--- a/internal/radiusd/radsec_server.go
+++ b/internal/radiusd/radsec_server.go
@@ -251,6 +251,17 @@ func parseTcpPacket(r io.Reader, secret []byte) (*radius.Packet, error) {
 
 // Serve accepts incoming connections on conn.
 func (s *RadsecPacketServer) Serve(conn net.Conn) error {
+	// Always close the connection when Serve returns, on every exit path
+	// (nil handler/secret, EOF, network error, fatal framing error, or
+	// shutdown). ListenAndServe runs Serve in a goroutine and discards its
+	// return value, so without this the underlying socket would stay open
+	// until GC/finalizers ran, leaking connections under attack or noisy
+	// clients. Close is idempotent-safe here: Shutdown may also close this
+	// conn via s.listeners, and net.Conn permits concurrent Close/Write, so an
+	// in-flight handler writing to an already-terminating connection simply
+	// gets a write error rather than racing.
+	defer func() { _ = conn.Close() }() //nolint:errcheck
+
 	if s.Handler == nil {
 		return errors.New("radius: nil RadsecHandler")
 	}

--- a/internal/radiusd/radsec_server_test.go
+++ b/internal/radiusd/radsec_server_test.go
@@ -260,6 +260,14 @@ func TestRadsecPacketServer_MalformedFrameClosesConnection(t *testing.T) {
 		t.Fatalf("expected exactly 1 served packet, got %d (stream desynchronized)", got)
 	}
 
+	// Serve must have actually closed its side of the connection, not merely
+	// returned. With net.Pipe, the peer observes io.EOF once the other end is
+	// closed.
+	_ = clientConn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if _, err := clientConn.Read(make([]byte, 1)); err == nil {
+		t.Fatal("expected the connection to be closed by Serve, but read succeeded")
+	}
+
 	_ = clientConn.Close()
 	_ = server.Shutdown(context.Background())
 }


### PR DESCRIPTION
## What

Follow-up to the Copilot review on #318. That PR made a malformed RadSec frame a fatal error that returns from `Serve`, but `Serve` never actually **closes** the connection — and `ListenAndServe` runs it as `go s.Serve(conn)`, discarding the return value. So the socket stayed open (relying on GC/finalizers) on the fatal framing path, leaking connections under attack or noisy clients and contradicting the "treat malformed framing as fatal" intent.

This was in fact a pre-existing leak on **all** `Serve` return paths (EOF, network error, secret error, shutdown), not just the new one.

## The fix

Add a top-level `defer conn.Close()` at the start of `Serve`, so every exit path closes the connection.

Closing here is safe:
- `Shutdown` may also close the conn via `s.listeners` — `net.Conn.Close` is idempotent enough (second close just returns an error we ignore).
- `net.Conn` permits concurrent `Close`/`Write`, so an in-flight handler writing a response to an already-terminating connection gets a write error rather than a data race. The connection is ending in every case Serve returns, so interrupting best-effort responses on it is acceptable.

## Tests

- `TestRadsecPacketServer_MalformedFrameClosesConnection` now also asserts the peer observes the connection being closed (a `Read` on the client end returns an error) after `Serve` returns.
- `CGO_ENABLED=1 go test -race ./internal/radiusd/ -run 'TestParseTcpPacket|TestRadsecPacketServer' -count=5` passes.
- `golangci-lint run ./internal/radiusd/...` → 0 issues.

Refs #307
