### PR TITLE
test(radsec): assert closed-conn read returns EOF, not a timeout

### DIFF
--- a/internal/radiusd/radsec_server_test.go
+++ b/internal/radiusd/radsec_server_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"io"
 	"net"
 	"sync/atomic"
 	"testing"
@@ -261,11 +262,17 @@ func TestRadsecPacketServer_MalformedFrameClosesConnection(t *testing.T) {
 	}
 
 	// Serve must have actually closed its side of the connection, not merely
-	// returned. With net.Pipe, the peer observes io.EOF once the other end is
-	// closed.
+	// returned. With net.Pipe the peer observes io.EOF once the other end is
+	// closed; if Serve left the connection open, the read would instead block
+	// until the deadline and return a timeout — so a timeout must be treated as
+	// a failure, not accepted as "some error".
 	_ = clientConn.SetReadDeadline(time.Now().Add(2 * time.Second))
-	if _, err := clientConn.Read(make([]byte, 1)); err == nil {
-		t.Fatal("expected the connection to be closed by Serve, but read succeeded")
+	_, err := clientConn.Read(make([]byte, 1))
+	if ne, ok := err.(net.Error); ok && ne.Timeout() {
+		t.Fatal("read timed out: Serve returned but did not close the connection")
+	}
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("expected io.EOF from the closed connection, got %v", err)
 	}
 
 	_ = clientConn.Close()


### PR DESCRIPTION
## What

Follow-up to the Copilot review on #319. The `TestRadsecPacketServer_MalformedFrameClosesConnection` connection-closed assertion was:

```go
if _, err := clientConn.Read(...); err == nil {
    t.Fatal("expected the connection to be closed ...")
}
```

As the reviewer noted, this passes even if `Serve` does **not** close the connection: with the peer still open, the `Read` blocks until its 2s deadline and returns an i/o **timeout** error — which is also non-nil, so the check would wrongly succeed.

## The fix

Tighten the assertion so it actually verifies the close:

- A `net.Error` with `Timeout() == true` is now an explicit failure.
- The read must return `io.EOF`, which `net.Pipe` delivers only once the peer closes its end.

Verified empirically: a closed `net.Pipe` peer yields `io.EOF`; an open peer yields an i/o timeout.

## Tests

- `CGO_ENABLED=1 go test -race -run TestRadsecPacketServer_MalformedFrameClosesConnection -count=10` passes.
- `golangci-lint run ./internal/radiusd/...` → 0 issues.

Refs #307
