### PR TITLE
test(vendors): pin VSA wire contract for production-consumer vendors

### DIFF
--- a/internal/radiusd/vendors/h3c/generated_vsa_test.go
+++ b/internal/radiusd/vendors/h3c/generated_vsa_test.go
@@ -1,0 +1,51 @@
+package h3c
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"layeh.com/radius"
+	"layeh.com/radius/rfc2865"
+)
+
+// vsaVendorCount returns how many Vendor-Specific attributes on p carry the
+// given IANA enterprise number. The accept enhancer ships H3C rate limits as
+// VSAs, so the codec must encode them under attribute 26 with vendor 25506.
+func vsaVendorCount(t *testing.T, p *radius.Packet, wantVendorID uint32) int {
+	t.Helper()
+	var n int
+	for _, avp := range p.Attributes {
+		if avp.Type != rfc2865.VendorSpecific_Type {
+			continue
+		}
+		vendorID, _, err := radius.VendorSpecific(avp.Attribute)
+		require.NoError(t, err)
+		if vendorID == wantVendorID {
+			n++
+		}
+	}
+	return n
+}
+
+// TestH3CRateVSARoundTrip pins the wire contract for the H3C bandwidth
+// attributes the accept enhancer ships: encode under H3C (25506) VSAs and
+// decode the same values back.
+func TestH3CRateVSARoundTrip(t *testing.T) {
+	p := &radius.Packet{}
+
+	require.NoError(t, H3CInputAverageRate_Set(p, H3CInputAverageRate(1024)))
+	require.NoError(t, H3COutputAverageRate_Set(p, H3COutputAverageRate(2048)))
+
+	assert.Equal(t, 2, vsaVendorCount(t, p, _H3C_VendorID))
+	assert.Equal(t, H3CInputAverageRate(1024), H3CInputAverageRate_Get(p))
+	assert.Equal(t, H3COutputAverageRate(2048), H3COutputAverageRate_Get(p))
+
+	gets, err := H3CInputAverageRate_Gets(p)
+	require.NoError(t, err)
+	assert.Equal(t, []H3CInputAverageRate{1024}, gets)
+
+	H3CInputAverageRate_Del(p)
+	assert.Equal(t, H3CInputAverageRate(0), H3CInputAverageRate_Get(p))
+	assert.Equal(t, 1, vsaVendorCount(t, p, _H3C_VendorID), "only the output-rate VSA should remain")
+}

--- a/internal/radiusd/vendors/huawei/generated_vsa_test.go
+++ b/internal/radiusd/vendors/huawei/generated_vsa_test.go
@@ -1,0 +1,98 @@
+package huawei
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"layeh.com/radius"
+	"layeh.com/radius/rfc2865"
+)
+
+// countVSAForVendor decodes every Vendor-Specific attribute on p and returns how
+// many carry wantVendorID. It is the on-wire view a NAS sees: the generated
+// codec must pack vendor attributes under RFC 2865 attribute 26 with the
+// vendor's IANA enterprise number, or the device silently ignores them.
+func countVSAForVendor(t *testing.T, p *radius.Packet, wantVendorID uint32) int {
+	t.Helper()
+	var n int
+	for _, avp := range p.Attributes {
+		if avp.Type != rfc2865.VendorSpecific_Type {
+			continue
+		}
+		vendorID, _, err := radius.VendorSpecific(avp.Attribute)
+		require.NoError(t, err)
+		if vendorID == wantVendorID {
+			n++
+		}
+	}
+	return n
+}
+
+// TestHuaweiRateVSARoundTrip exercises the generated Huawei VSA codec end to end
+// for the bandwidth attribute the accept enhancer actually ships to Huawei NAS
+// devices: Set must encode it as a Huawei (2011) Vendor-Specific attribute, and
+// Get/Gets/Lookup must decode the same value back.
+func TestHuaweiRateVSARoundTrip(t *testing.T) {
+	p := &radius.Packet{}
+
+	require.NoError(t, HuaweiInputAverageRate_Set(p, HuaweiInputAverageRate(2048)))
+
+	require.Equal(t, 1, countVSAForVendor(t, p, _Huawei_VendorID),
+		"value must be encoded as exactly one Huawei Vendor-Specific attribute")
+	assert.Equal(t, HuaweiInputAverageRate(2048), HuaweiInputAverageRate_Get(p))
+
+	got, err := HuaweiInputAverageRate_Lookup(p)
+	require.NoError(t, err)
+	assert.Equal(t, HuaweiInputAverageRate(2048), got)
+
+	gets, err := HuaweiInputAverageRate_Gets(p)
+	require.NoError(t, err)
+	assert.Equal(t, []HuaweiInputAverageRate{2048}, gets)
+
+	HuaweiInputAverageRate_Del(p)
+	assert.Equal(t, 0, countVSAForVendor(t, p, _Huawei_VendorID))
+	assert.Equal(t, HuaweiInputAverageRate(0), HuaweiInputAverageRate_Get(p))
+	if _, err := HuaweiInputAverageRate_Lookup(p); err == nil {
+		t.Fatal("Lookup after Del must return an error")
+	}
+}
+
+// TestHuaweiStringAndIPv6VSARoundTrip covers the non-integer value codecs the
+// Huawei enhancer relies on: a string domain name and an IPv6 framed address.
+func TestHuaweiStringAndIPv6VSARoundTrip(t *testing.T) {
+	p := &radius.Packet{}
+
+	require.NoError(t, HuaweiDomainName_SetString(p, "corp.example.net"))
+	assert.Equal(t, "corp.example.net", HuaweiDomainName_GetString(p))
+
+	ip := net.ParseIP("2001:db8::1")
+	require.NotNil(t, ip)
+	require.NoError(t, HuaweiFramedIPv6Address_Set(p, ip))
+	assert.True(t, HuaweiFramedIPv6Address_Get(p).Equal(ip))
+
+	// Two distinct Huawei attributes must produce two Huawei VSAs.
+	assert.Equal(t, 2, countVSAForVendor(t, p, _Huawei_VendorID))
+}
+
+// TestHuaweiVSAVendorIsolation verifies the codec ignores Vendor-Specific
+// attributes belonging to other vendors: a foreign VSA mixed into the packet
+// must not be mistaken for a Huawei attribute, and the Huawei value must still
+// decode correctly. This guards the vendorID mismatch branch in the codec.
+func TestHuaweiVSAVendorIsolation(t *testing.T) {
+	p := &radius.Packet{}
+
+	// Inject a foreign vendor's VSA (Mikrotik enterprise number 14988).
+	foreign, err := radius.NewVendorSpecific(14988, radius.Attribute{1, 4, 0xAA, 0xBB})
+	require.NoError(t, err)
+	p.Add(rfc2865.VendorSpecific_Type, foreign)
+
+	require.NoError(t, HuaweiOutputAverageRate_Set(p, HuaweiOutputAverageRate(4096)))
+
+	assert.Equal(t, HuaweiOutputAverageRate(4096), HuaweiOutputAverageRate_Get(p))
+	assert.Equal(t, 1, countVSAForVendor(t, p, _Huawei_VendorID),
+		"foreign VSA must not be counted as Huawei")
+	assert.Equal(t, 1, countVSAForVendor(t, p, 14988),
+		"foreign VSA must be left intact")
+}

--- a/internal/radiusd/vendors/ikuai/generated_vsa_test.go
+++ b/internal/radiusd/vendors/ikuai/generated_vsa_test.go
@@ -1,0 +1,51 @@
+package ikuai
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"layeh.com/radius"
+	"layeh.com/radius/rfc2865"
+)
+
+// vsaVendorCount returns how many Vendor-Specific attributes on p carry the
+// given IANA enterprise number. The accept enhancer ships iKuai speed limits as
+// VSAs, so the codec must encode them under attribute 26 with vendor 10055.
+func vsaVendorCount(t *testing.T, p *radius.Packet, wantVendorID uint32) int {
+	t.Helper()
+	var n int
+	for _, avp := range p.Attributes {
+		if avp.Type != rfc2865.VendorSpecific_Type {
+			continue
+		}
+		vendorID, _, err := radius.VendorSpecific(avp.Attribute)
+		require.NoError(t, err)
+		if vendorID == wantVendorID {
+			n++
+		}
+	}
+	return n
+}
+
+// TestIKuaiSpeedVSARoundTrip pins the wire contract for the iKuai speed-limit
+// attributes the accept enhancer ships: encode under iKuai (10055) VSAs and
+// decode the same values back.
+func TestIKuaiSpeedVSARoundTrip(t *testing.T) {
+	p := &radius.Packet{}
+
+	require.NoError(t, RPUpstreamSpeedLimit_Set(p, RPUpstreamSpeedLimit(100)))
+	require.NoError(t, RPDownstreamSpeedLimit_Set(p, RPDownstreamSpeedLimit(200)))
+
+	assert.Equal(t, 2, vsaVendorCount(t, p, _IKuai_VendorID))
+	assert.Equal(t, RPUpstreamSpeedLimit(100), RPUpstreamSpeedLimit_Get(p))
+	assert.Equal(t, RPDownstreamSpeedLimit(200), RPDownstreamSpeedLimit_Get(p))
+
+	gets, err := RPUpstreamSpeedLimit_Gets(p)
+	require.NoError(t, err)
+	assert.Equal(t, []RPUpstreamSpeedLimit{100}, gets)
+
+	RPDownstreamSpeedLimit_Del(p)
+	assert.Equal(t, RPDownstreamSpeedLimit(0), RPDownstreamSpeedLimit_Get(p))
+	assert.Equal(t, 1, vsaVendorCount(t, p, _IKuai_VendorID), "only the upstream VSA should remain")
+}

--- a/internal/radiusd/vendors/microsoft/generated_vsa_test.go
+++ b/internal/radiusd/vendors/microsoft/generated_vsa_test.go
@@ -1,0 +1,53 @@
+package microsoft
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"layeh.com/radius"
+	"layeh.com/radius/rfc2865"
+)
+
+// vsaVendorCount returns how many Vendor-Specific attributes on p carry the
+// given IANA enterprise number. The MSCHAPv2 validator/handler read and write
+// these as Microsoft (311) VSAs, so the codec must encode them under attribute
+// 26 with the correct vendor ID.
+func vsaVendorCount(t *testing.T, p *radius.Packet, wantVendorID uint32) int {
+	t.Helper()
+	var n int
+	for _, avp := range p.Attributes {
+		if avp.Type != rfc2865.VendorSpecific_Type {
+			continue
+		}
+		vendorID, _, err := radius.VendorSpecific(avp.Attribute)
+		require.NoError(t, err)
+		if vendorID == wantVendorID {
+			n++
+		}
+	}
+	return n
+}
+
+// TestMicrosoftMSCHAPOctetVSARoundTrip pins the wire contract for the octet
+// MSCHAP attributes the validator reads off requests: encode under a Microsoft
+// (311) VSA and decode the same bytes back. These carry the challenge/response
+// the validator depends on, so a codec regression would break MSCHAPv2 auth.
+func TestMicrosoftMSCHAPOctetVSARoundTrip(t *testing.T) {
+	p := &radius.Packet{}
+
+	challenge := []byte{0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17}
+	response := bytes.Repeat([]byte{0xAB}, 50)
+
+	require.NoError(t, MSCHAPChallenge_Set(p, challenge))
+	require.NoError(t, MSCHAP2Response_Set(p, response))
+
+	assert.Equal(t, 2, vsaVendorCount(t, p, _Microsoft_VendorID))
+	assert.Equal(t, challenge, MSCHAPChallenge_Get(p))
+	assert.Equal(t, response, MSCHAP2Response_Get(p))
+
+	MSCHAPChallenge_Del(p)
+	assert.Nil(t, MSCHAPChallenge_Get(p))
+	assert.Equal(t, 1, vsaVendorCount(t, p, _Microsoft_VendorID), "only the MSCHAP2-Response VSA should remain")
+}

--- a/internal/radiusd/vendors/mikrotik/generated_vsa_test.go
+++ b/internal/radiusd/vendors/mikrotik/generated_vsa_test.go
@@ -1,0 +1,59 @@
+package mikrotik
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"layeh.com/radius"
+	"layeh.com/radius/rfc2865"
+)
+
+// vsaVendorCount returns how many Vendor-Specific attributes on p carry the
+// given IANA enterprise number. The accept enhancer ships Mikrotik-Rate-Limit
+// as a VSA, so the codec must encode it under attribute 26 with vendor 14988.
+func vsaVendorCount(t *testing.T, p *radius.Packet, wantVendorID uint32) int {
+	t.Helper()
+	var n int
+	for _, avp := range p.Attributes {
+		if avp.Type != rfc2865.VendorSpecific_Type {
+			continue
+		}
+		vendorID, _, err := radius.VendorSpecific(avp.Attribute)
+		require.NoError(t, err)
+		if vendorID == wantVendorID {
+			n++
+		}
+	}
+	return n
+}
+
+// TestMikrotikRateLimitStringVSARoundTrip pins the wire contract for the string
+// Mikrotik-Rate-Limit attribute the accept enhancer ships (e.g. "1000k/2000k"):
+// encode under a Mikrotik (14988) VSA and decode the same string back.
+func TestMikrotikRateLimitStringVSARoundTrip(t *testing.T) {
+	p := &radius.Packet{}
+
+	require.NoError(t, MikrotikRateLimit_SetString(p, "1000k/2000k"))
+
+	assert.Equal(t, 1, vsaVendorCount(t, p, _Mikrotik_VendorID))
+	assert.Equal(t, "1000k/2000k", MikrotikRateLimit_GetString(p))
+}
+
+// TestMikrotikIntegerVSARoundTrip exercises the integer value codec and the
+// delete path on a Mikrotik VSA.
+func TestMikrotikIntegerVSARoundTrip(t *testing.T) {
+	p := &radius.Packet{}
+
+	require.NoError(t, MikrotikRecvLimit_Set(p, MikrotikRecvLimit(8192)))
+	assert.Equal(t, 1, vsaVendorCount(t, p, _Mikrotik_VendorID))
+	assert.Equal(t, MikrotikRecvLimit(8192), MikrotikRecvLimit_Get(p))
+
+	gets, err := MikrotikRecvLimit_Gets(p)
+	require.NoError(t, err)
+	assert.Equal(t, []MikrotikRecvLimit{8192}, gets)
+
+	MikrotikRecvLimit_Del(p)
+	assert.Equal(t, 0, vsaVendorCount(t, p, _Mikrotik_VendorID))
+	assert.Equal(t, MikrotikRecvLimit(0), MikrotikRecvLimit_Get(p))
+}

--- a/internal/radiusd/vendors/zte/generated_vsa_test.go
+++ b/internal/radiusd/vendors/zte/generated_vsa_test.go
@@ -1,0 +1,51 @@
+package zte
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"layeh.com/radius"
+	"layeh.com/radius/rfc2865"
+)
+
+// vsaVendorCount returns how many Vendor-Specific attributes on p carry the
+// given IANA enterprise number. The accept enhancer ships ZTE rate limits as
+// VSAs, so the codec must encode them under attribute 26 with vendor 3902.
+func vsaVendorCount(t *testing.T, p *radius.Packet, wantVendorID uint32) int {
+	t.Helper()
+	var n int
+	for _, avp := range p.Attributes {
+		if avp.Type != rfc2865.VendorSpecific_Type {
+			continue
+		}
+		vendorID, _, err := radius.VendorSpecific(avp.Attribute)
+		require.NoError(t, err)
+		if vendorID == wantVendorID {
+			n++
+		}
+	}
+	return n
+}
+
+// TestZTERateVSARoundTrip pins the wire contract for the ZTE rate-control
+// attributes the accept enhancer ships: encode under ZTE (3902) VSAs and decode
+// the same values back.
+func TestZTERateVSARoundTrip(t *testing.T) {
+	p := &radius.Packet{}
+
+	require.NoError(t, ZTERateCtrlSCRUp_Set(p, ZTERateCtrlSCRUp(512)))
+	require.NoError(t, ZTERateCtrlSCRDown_Set(p, ZTERateCtrlSCRDown(4096)))
+
+	assert.Equal(t, 2, vsaVendorCount(t, p, _ZTE_VendorID))
+	assert.Equal(t, ZTERateCtrlSCRUp(512), ZTERateCtrlSCRUp_Get(p))
+	assert.Equal(t, ZTERateCtrlSCRDown(4096), ZTERateCtrlSCRDown_Get(p))
+
+	gets, err := ZTERateCtrlSCRDown_Gets(p)
+	require.NoError(t, err)
+	assert.Equal(t, []ZTERateCtrlSCRDown{4096}, gets)
+
+	ZTERateCtrlSCRUp_Del(p)
+	assert.Equal(t, ZTERateCtrlSCRUp(0), ZTERateCtrlSCRUp_Get(p))
+	assert.Equal(t, 1, vsaVendorCount(t, p, _ZTE_VendorID), "only the down-rate VSA should remain")
+}


### PR DESCRIPTION
## What

Follow-up to the audit discussion on test coverage. The hand-written vendor **parsers** (`plugins/vendorparsers/parsers/`) and **enhancers** (`plugins/auth/enhancers/`) are well covered (100% / 90%), but the auto-**generated** per-vendor VSA dictionaries (`vendors/<v>/generated.go`) had **no direct tests** at all.

Those files contain the real byte-level VSA codec — `_X_AddVendor` / `_GetsVendor` / `_LookupVendor` / `_DelVendor` — that packs vendor attributes under RFC 2865 attribute 26 with the vendor's IANA enterprise number. That is the exact wire form a NAS sees. A silent dictionary regeneration that changed a vendor ID or broke TLV packing would corrupt what we send to real hardware, with nothing to catch it. (The generated `_Set` codec even contains a latent `i+i` slice-index typo, so "generated" ≠ "trusted".)

## Scope

This PR covers the **six vendors whose VSAs are actually emitted in production**:

| Vendor | ID | Production consumer | Attributes pinned |
|---|---|---|---|
| huawei | 2011 | `huawei_enhancer` | input/output average rate, domain name (string), framed IPv6, + vendor isolation + delete |
| h3c | 25506 | `h3c_enhancer` | input/output average rate |
| zte | 3902 | `zte_enhancer` | rate-control up/down |
| ikuai | 10055 | `ikuai_enhancer` | up/down speed limit |
| mikrotik | 14988 | `mikrotik_enhancer` | Mikrotik-Rate-Limit (string) + integer + delete |
| microsoft | 311 | `mschap_validator` / mschapv2 handler | MSCHAP challenge + MSCHAP2-Response (octets) |

Each test asserts `Set` encodes **exactly one** Vendor-Specific attribute carrying the **correct vendor ID**, and that `Get`/`Gets`/`Lookup` decode the same value back. The huawei test additionally pins vendor isolation (a foreign VSA must be ignored) and the delete path, which exercises the shared generated codec template.

## Deliberately out of scope

- **Not chasing coverage %** on the dictionaries — each `generated.go` is thousands of lines of mostly-unused accessors (`huawei` alone is ~11.7k lines), so a high % would be vanity. These tests pin the *contract* for what's actually shipped.
- The latent `i+i` typo in the generated `_Set`-to-empty branch is **not** triggered here (production sets each attribute once); it lives in `DO NOT EDIT` generated code and is better fixed in the generator. Filed separately if confirmed reachable.
- Dictionary-only vendors with no current consumer (cisco/juniper/aruba/…) follow in a separate PR.

## Tests

- `go test ./internal/radiusd/vendors/{huawei,h3c,zte,ikuai,mikrotik,microsoft}/` — all pass.
- `golangci-lint run ./internal/radiusd/vendors/...` → 0 issues.

Refs #304
