### PR TITLE
test(vendors): use realistic MSCHAP challenge length in microsoft VSA test

### DIFF
--- a/internal/radiusd/vendors/microsoft/generated_vsa_test.go
+++ b/internal/radiusd/vendors/microsoft/generated_vsa_test.go
@@ -34,18 +34,30 @@ func vsaVendorCount(t *testing.T, p *radius.Packet, wantVendorID uint32) int {
 // MSCHAP attributes the validator reads off requests: encode under a Microsoft
 // (311) VSA and decode the same bytes back. These carry the challenge/response
 // the validator depends on, so a codec regression would break MSCHAPv2 auth.
+//
+// The lengths match the real on-wire contract enforced by the MSCHAP validator
+// (internal/radiusd/plugins/auth/validators/mschap_validator.go): MS-CHAP-
+// Challenge is exactly 16 bytes and MS-CHAP2-Response is exactly 50 bytes.
 func TestMicrosoftMSCHAPOctetVSARoundTrip(t *testing.T) {
 	p := &radius.Packet{}
 
-	challenge := []byte{0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17}
+	challenge := bytes.Repeat([]byte{0x5A}, 16)
 	response := bytes.Repeat([]byte{0xAB}, 50)
 
 	require.NoError(t, MSCHAPChallenge_Set(p, challenge))
 	require.NoError(t, MSCHAP2Response_Set(p, response))
 
 	assert.Equal(t, 2, vsaVendorCount(t, p, _Microsoft_VendorID))
-	assert.Equal(t, challenge, MSCHAPChallenge_Get(p))
-	assert.Equal(t, response, MSCHAP2Response_Get(p))
+
+	gotChallenge := MSCHAPChallenge_Get(p)
+	gotResponse := MSCHAP2Response_Get(p)
+	assert.Equal(t, challenge, gotChallenge)
+	assert.Equal(t, response, gotResponse)
+
+	// Guard the exact lengths the validator requires; a codec that truncated or
+	// padded the octet value would break MSCHAPv2 authentication.
+	assert.Len(t, gotChallenge, 16)
+	assert.Len(t, gotResponse, 50)
 
 	MSCHAPChallenge_Del(p)
 	assert.Nil(t, MSCHAPChallenge_Get(p))


### PR DESCRIPTION
## Summary

Follow-up to a review comment on #321. The Microsoft VSA round-trip test used an **8-byte** `MS-CHAP-Challenge`, but the MSCHAP validator requires the challenge to be exactly **16 bytes** and the response exactly **50 bytes**:

```go
// internal/radiusd/plugins/auth/validators/mschap_validator.go
if len(challenge) != 16 || len(response) != 50 {
    return errors.NewAuthError("radus_reject_passwd_error", ...)
}
```

An 8-byte challenge doesn't reflect the real on-wire contract and could miss regressions around challenge-length handling.

## Changes

- Use a realistic **16-byte** `MS-CHAP-Challenge` (response was already a correct 50 bytes).
- Assert the decoded lengths are exactly **16 / 50** so a codec that truncated or padded the octet value would be caught — pinning the precise lengths the validator depends on.

## Validation

- `go test ./internal/radiusd/vendors/microsoft/` — pass
- `golangci-lint run ./internal/radiusd/vendors/microsoft/...` — 0 issues

Refs #304
