### PR TITLE
test(vendors): pin VSA wire contract for dictionary-only vendors

### DIFF
--- a/internal/radiusd/vendors/alcatel/generated_vsa_test.go
+++ b/internal/radiusd/vendors/alcatel/generated_vsa_test.go
@@ -1,0 +1,61 @@
+package alcatel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"layeh.com/radius"
+	"layeh.com/radius/rfc2865"
+)
+
+// vsaVendorCount returns how many Vendor-Specific attributes on p carry the
+// given IANA enterprise number. The generated codec packs each VSA under its
+// own RFC 2865 attribute-26 envelope, so this counts only this dictionary's
+// attributes and ignores foreign vendors.
+func vsaVendorCount(t *testing.T, p *radius.Packet, wantVendorID uint32) int {
+	t.Helper()
+	var n int
+	for _, avp := range p.Attributes {
+		if avp.Type != rfc2865.VendorSpecific_Type {
+			continue
+		}
+		vendorID, _, err := radius.VendorSpecific(avp.Attribute)
+		require.NoError(t, err)
+		if vendorID == wantVendorID {
+			n++
+		}
+	}
+	return n
+}
+
+// TestAlcatelPrimaryHomeAgentStringVSARoundTrip pins the wire contract for the
+// Alcatel VSA dictionary. No accept enhancer ships Alcatel VSAs today, so this
+// round-trip is the only guard that the attribute encodes under an Alcatel
+// (3041) Vendor-Specific attribute and decodes the same string back.
+func TestAlcatelPrimaryHomeAgentStringVSARoundTrip(t *testing.T) {
+	p := &radius.Packet{}
+
+	const value = "ha-primary-01"
+	require.NoError(t, AATPrimaryHomeAgent_SetString(p, value))
+
+	assert.Equal(t, 1, vsaVendorCount(t, p, _Alcatel_VendorID))
+	assert.Equal(t, value, AATPrimaryHomeAgent_GetString(p))
+
+	AATPrimaryHomeAgent_Del(p)
+	assert.Equal(t, "", AATPrimaryHomeAgent_GetString(p))
+	assert.Equal(t, 0, vsaVendorCount(t, p, _Alcatel_VendorID), "the Alcatel VSA should be gone after delete")
+}
+
+// TestAlcatelVSAVendorIsolation ensures the Alcatel accessors ignore a foreign
+// vendor's attribute carried in the same packet.
+func TestAlcatelVSAVendorIsolation(t *testing.T) {
+	p := &radius.Packet{}
+
+	foreign, err := radius.NewVendorSpecific(14988, radius.Attribute{1, 4, 0xAA, 0xBB})
+	require.NoError(t, err)
+	p.Add(rfc2865.VendorSpecific_Type, foreign)
+
+	assert.Equal(t, 0, vsaVendorCount(t, p, _Alcatel_VendorID))
+	assert.Equal(t, "", AATPrimaryHomeAgent_GetString(p), "a foreign VSA must not be read as an Alcatel attribute")
+}

--- a/internal/radiusd/vendors/aruba/generated_vsa_test.go
+++ b/internal/radiusd/vendors/aruba/generated_vsa_test.go
@@ -1,0 +1,61 @@
+package aruba
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"layeh.com/radius"
+	"layeh.com/radius/rfc2865"
+)
+
+// vsaVendorCount returns how many Vendor-Specific attributes on p carry the
+// given IANA enterprise number. The generated codec packs each VSA under its
+// own RFC 2865 attribute-26 envelope, so this counts only this dictionary's
+// attributes and ignores foreign vendors.
+func vsaVendorCount(t *testing.T, p *radius.Packet, wantVendorID uint32) int {
+	t.Helper()
+	var n int
+	for _, avp := range p.Attributes {
+		if avp.Type != rfc2865.VendorSpecific_Type {
+			continue
+		}
+		vendorID, _, err := radius.VendorSpecific(avp.Attribute)
+		require.NoError(t, err)
+		if vendorID == wantVendorID {
+			n++
+		}
+	}
+	return n
+}
+
+// TestArubaUserRoleStringVSARoundTrip pins the wire contract for the Aruba VSA
+// dictionary. No accept enhancer ships Aruba VSAs today, so this round-trip is
+// the only guard that Aruba-User-Role encodes under an Aruba (14823)
+// Vendor-Specific attribute and decodes the same string back.
+func TestArubaUserRoleStringVSARoundTrip(t *testing.T) {
+	p := &radius.Packet{}
+
+	const value = "authenticated-guest"
+	require.NoError(t, ArubaUserRole_SetString(p, value))
+
+	assert.Equal(t, 1, vsaVendorCount(t, p, _Aruba_VendorID))
+	assert.Equal(t, value, ArubaUserRole_GetString(p))
+
+	ArubaUserRole_Del(p)
+	assert.Equal(t, "", ArubaUserRole_GetString(p))
+	assert.Equal(t, 0, vsaVendorCount(t, p, _Aruba_VendorID), "the Aruba VSA should be gone after delete")
+}
+
+// TestArubaVSAVendorIsolation ensures the Aruba accessors ignore a foreign
+// vendor's attribute carried in the same packet.
+func TestArubaVSAVendorIsolation(t *testing.T) {
+	p := &radius.Packet{}
+
+	foreign, err := radius.NewVendorSpecific(14988, radius.Attribute{1, 4, 0xAA, 0xBB})
+	require.NoError(t, err)
+	p.Add(rfc2865.VendorSpecific_Type, foreign)
+
+	assert.Equal(t, 0, vsaVendorCount(t, p, _Aruba_VendorID))
+	assert.Equal(t, "", ArubaUserRole_GetString(p), "a foreign VSA must not be read as an Aruba attribute")
+}

--- a/internal/radiusd/vendors/cisco/generated_vsa_test.go
+++ b/internal/radiusd/vendors/cisco/generated_vsa_test.go
@@ -1,0 +1,61 @@
+package cisco
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"layeh.com/radius"
+	"layeh.com/radius/rfc2865"
+)
+
+// vsaVendorCount returns how many Vendor-Specific attributes on p carry the
+// given IANA enterprise number. The generated codec packs each VSA under its
+// own RFC 2865 attribute-26 envelope, so this counts only this dictionary's
+// attributes and ignores foreign vendors.
+func vsaVendorCount(t *testing.T, p *radius.Packet, wantVendorID uint32) int {
+	t.Helper()
+	var n int
+	for _, avp := range p.Attributes {
+		if avp.Type != rfc2865.VendorSpecific_Type {
+			continue
+		}
+		vendorID, _, err := radius.VendorSpecific(avp.Attribute)
+		require.NoError(t, err)
+		if vendorID == wantVendorID {
+			n++
+		}
+	}
+	return n
+}
+
+// TestCiscoAVPairStringVSARoundTrip pins the wire contract for the Cisco VSA
+// dictionary. No accept enhancer ships Cisco VSAs today, so this round-trip is
+// the only guard that Cisco-AVPair encodes under a Cisco (9) Vendor-Specific
+// attribute and decodes the same string back.
+func TestCiscoAVPairStringVSARoundTrip(t *testing.T) {
+	p := &radius.Packet{}
+
+	const value = "subscriber:traffic-class=premium"
+	require.NoError(t, CiscoAVPair_SetString(p, value))
+
+	assert.Equal(t, 1, vsaVendorCount(t, p, _Cisco_VendorID))
+	assert.Equal(t, value, CiscoAVPair_GetString(p))
+
+	CiscoAVPair_Del(p)
+	assert.Equal(t, "", CiscoAVPair_GetString(p))
+	assert.Equal(t, 0, vsaVendorCount(t, p, _Cisco_VendorID), "the Cisco VSA should be gone after delete")
+}
+
+// TestCiscoVSAVendorIsolation ensures the Cisco accessors ignore a foreign
+// vendor's attribute carried in the same packet.
+func TestCiscoVSAVendorIsolation(t *testing.T) {
+	p := &radius.Packet{}
+
+	foreign, err := radius.NewVendorSpecific(14988, radius.Attribute{1, 4, 0xAA, 0xBB})
+	require.NoError(t, err)
+	p.Add(rfc2865.VendorSpecific_Type, foreign)
+
+	assert.Equal(t, 0, vsaVendorCount(t, p, _Cisco_VendorID))
+	assert.Equal(t, "", CiscoAVPair_GetString(p), "a foreign VSA must not be read as a Cisco attribute")
+}

--- a/internal/radiusd/vendors/f5/generated_vsa_test.go
+++ b/internal/radiusd/vendors/f5/generated_vsa_test.go
@@ -1,0 +1,61 @@
+package f5
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"layeh.com/radius"
+	"layeh.com/radius/rfc2865"
+)
+
+// vsaVendorCount returns how many Vendor-Specific attributes on p carry the
+// given IANA enterprise number. The generated codec packs each VSA under its
+// own RFC 2865 attribute-26 envelope, so this counts only this dictionary's
+// attributes and ignores foreign vendors.
+func vsaVendorCount(t *testing.T, p *radius.Packet, wantVendorID uint32) int {
+	t.Helper()
+	var n int
+	for _, avp := range p.Attributes {
+		if avp.Type != rfc2865.VendorSpecific_Type {
+			continue
+		}
+		vendorID, _, err := radius.VendorSpecific(avp.Attribute)
+		require.NoError(t, err)
+		if vendorID == wantVendorID {
+			n++
+		}
+	}
+	return n
+}
+
+// TestF5LTMUserPartitionStringVSARoundTrip pins the wire contract for the F5
+// VSA dictionary. No accept enhancer ships F5 VSAs today, so this round-trip is
+// the only guard that F5-LTM-User-Partition encodes under an F5 (3375)
+// Vendor-Specific attribute and decodes the same string back.
+func TestF5LTMUserPartitionStringVSARoundTrip(t *testing.T) {
+	p := &radius.Packet{}
+
+	const value = "Common"
+	require.NoError(t, F5LTMUserPartition_SetString(p, value))
+
+	assert.Equal(t, 1, vsaVendorCount(t, p, _F5_VendorID))
+	assert.Equal(t, value, F5LTMUserPartition_GetString(p))
+
+	F5LTMUserPartition_Del(p)
+	assert.Equal(t, "", F5LTMUserPartition_GetString(p))
+	assert.Equal(t, 0, vsaVendorCount(t, p, _F5_VendorID), "the F5 VSA should be gone after delete")
+}
+
+// TestF5VSAVendorIsolation ensures the F5 accessors ignore a foreign vendor's
+// attribute carried in the same packet.
+func TestF5VSAVendorIsolation(t *testing.T) {
+	p := &radius.Packet{}
+
+	foreign, err := radius.NewVendorSpecific(14988, radius.Attribute{1, 4, 0xAA, 0xBB})
+	require.NoError(t, err)
+	p.Add(rfc2865.VendorSpecific_Type, foreign)
+
+	assert.Equal(t, 0, vsaVendorCount(t, p, _F5_VendorID))
+	assert.Equal(t, "", F5LTMUserPartition_GetString(p), "a foreign VSA must not be read as an F5 attribute")
+}

--- a/internal/radiusd/vendors/hillstone/generated_vsa_test.go
+++ b/internal/radiusd/vendors/hillstone/generated_vsa_test.go
@@ -1,0 +1,61 @@
+package hillstone
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"layeh.com/radius"
+	"layeh.com/radius/rfc2865"
+)
+
+// vsaVendorCount returns how many Vendor-Specific attributes on p carry the
+// given IANA enterprise number. The generated codec packs each VSA under its
+// own RFC 2865 attribute-26 envelope, so this counts only this dictionary's
+// attributes and ignores foreign vendors.
+func vsaVendorCount(t *testing.T, p *radius.Packet, wantVendorID uint32) int {
+	t.Helper()
+	var n int
+	for _, avp := range p.Attributes {
+		if avp.Type != rfc2865.VendorSpecific_Type {
+			continue
+		}
+		vendorID, _, err := radius.VendorSpecific(avp.Attribute)
+		require.NoError(t, err)
+		if vendorID == wantVendorID {
+			n++
+		}
+	}
+	return n
+}
+
+// TestHillstoneUserMobileNumberStringVSARoundTrip pins the wire contract for
+// the Hillstone VSA dictionary. No accept enhancer ships Hillstone VSAs today,
+// so this round-trip is the only guard that the attribute encodes under a
+// Hillstone (28557) Vendor-Specific attribute and decodes the same string back.
+func TestHillstoneUserMobileNumberStringVSARoundTrip(t *testing.T) {
+	p := &radius.Packet{}
+
+	const value = "13800138000"
+	require.NoError(t, HillstoneUserMobileNumber_SetString(p, value))
+
+	assert.Equal(t, 1, vsaVendorCount(t, p, _Hillstone_VendorID))
+	assert.Equal(t, value, HillstoneUserMobileNumber_GetString(p))
+
+	HillstoneUserMobileNumber_Del(p)
+	assert.Equal(t, "", HillstoneUserMobileNumber_GetString(p))
+	assert.Equal(t, 0, vsaVendorCount(t, p, _Hillstone_VendorID), "the Hillstone VSA should be gone after delete")
+}
+
+// TestHillstoneVSAVendorIsolation ensures the Hillstone accessors ignore a
+// foreign vendor's attribute carried in the same packet.
+func TestHillstoneVSAVendorIsolation(t *testing.T) {
+	p := &radius.Packet{}
+
+	foreign, err := radius.NewVendorSpecific(14988, radius.Attribute{1, 4, 0xAA, 0xBB})
+	require.NoError(t, err)
+	p.Add(rfc2865.VendorSpecific_Type, foreign)
+
+	assert.Equal(t, 0, vsaVendorCount(t, p, _Hillstone_VendorID))
+	assert.Equal(t, "", HillstoneUserMobileNumber_GetString(p), "a foreign VSA must not be read as a Hillstone attribute")
+}

--- a/internal/radiusd/vendors/juniper/generated_vsa_test.go
+++ b/internal/radiusd/vendors/juniper/generated_vsa_test.go
@@ -1,0 +1,61 @@
+package juniper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"layeh.com/radius"
+	"layeh.com/radius/rfc2865"
+)
+
+// vsaVendorCount returns how many Vendor-Specific attributes on p carry the
+// given IANA enterprise number. The generated codec packs each VSA under its
+// own RFC 2865 attribute-26 envelope, so this counts only this dictionary's
+// attributes and ignores foreign vendors.
+func vsaVendorCount(t *testing.T, p *radius.Packet, wantVendorID uint32) int {
+	t.Helper()
+	var n int
+	for _, avp := range p.Attributes {
+		if avp.Type != rfc2865.VendorSpecific_Type {
+			continue
+		}
+		vendorID, _, err := radius.VendorSpecific(avp.Attribute)
+		require.NoError(t, err)
+		if vendorID == wantVendorID {
+			n++
+		}
+	}
+	return n
+}
+
+// TestJuniperLocalUserNameStringVSARoundTrip pins the wire contract for the
+// Juniper VSA dictionary. No accept enhancer ships Juniper VSAs today, so this
+// round-trip is the only guard that Juniper-Local-User-Name encodes under a
+// Juniper (2636) Vendor-Specific attribute and decodes the same string back.
+func TestJuniperLocalUserNameStringVSARoundTrip(t *testing.T) {
+	p := &radius.Packet{}
+
+	const value = "netops-admin"
+	require.NoError(t, JuniperLocalUserName_SetString(p, value))
+
+	assert.Equal(t, 1, vsaVendorCount(t, p, _Juniper_VendorID))
+	assert.Equal(t, value, JuniperLocalUserName_GetString(p))
+
+	JuniperLocalUserName_Del(p)
+	assert.Equal(t, "", JuniperLocalUserName_GetString(p))
+	assert.Equal(t, 0, vsaVendorCount(t, p, _Juniper_VendorID), "the Juniper VSA should be gone after delete")
+}
+
+// TestJuniperVSAVendorIsolation ensures the Juniper accessors ignore a foreign
+// vendor's attribute carried in the same packet.
+func TestJuniperVSAVendorIsolation(t *testing.T) {
+	p := &radius.Packet{}
+
+	foreign, err := radius.NewVendorSpecific(14988, radius.Attribute{1, 4, 0xAA, 0xBB})
+	require.NoError(t, err)
+	p.Add(rfc2865.VendorSpecific_Type, foreign)
+
+	assert.Equal(t, 0, vsaVendorCount(t, p, _Juniper_VendorID))
+	assert.Equal(t, "", JuniperLocalUserName_GetString(p), "a foreign VSA must not be read as a Juniper attribute")
+}

--- a/internal/radiusd/vendors/pfSense/generated_vsa_test.go
+++ b/internal/radiusd/vendors/pfSense/generated_vsa_test.go
@@ -1,0 +1,62 @@
+package pfSense
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"layeh.com/radius"
+	"layeh.com/radius/rfc2865"
+)
+
+// vsaVendorCount returns how many Vendor-Specific attributes on p carry the
+// given IANA enterprise number. The generated codec packs each VSA under its
+// own RFC 2865 attribute-26 envelope, so this counts only this dictionary's
+// attributes and ignores foreign vendors.
+func vsaVendorCount(t *testing.T, p *radius.Packet, wantVendorID uint32) int {
+	t.Helper()
+	var n int
+	for _, avp := range p.Attributes {
+		if avp.Type != rfc2865.VendorSpecific_Type {
+			continue
+		}
+		vendorID, _, err := radius.VendorSpecific(avp.Attribute)
+		require.NoError(t, err)
+		if vendorID == wantVendorID {
+			n++
+		}
+	}
+	return n
+}
+
+// TestPfSenseBandwidthMaxUpIntegerVSARoundTrip pins the wire contract for the
+// pfSense VSA dictionary. No accept enhancer ships pfSense VSAs today, so this
+// round-trip is the only guard that the 32-bit Bandwidth-Max-Up attribute
+// encodes under a pfSense (13644) Vendor-Specific attribute and decodes the
+// same integer value back.
+func TestPfSenseBandwidthMaxUpIntegerVSARoundTrip(t *testing.T) {
+	p := &radius.Packet{}
+
+	const value PfSenseBandwidthMaxUp = 2048
+	require.NoError(t, PfSenseBandwidthMaxUp_Set(p, value))
+
+	assert.Equal(t, 1, vsaVendorCount(t, p, _PfSense_VendorID))
+	assert.Equal(t, value, PfSenseBandwidthMaxUp_Get(p))
+
+	PfSenseBandwidthMaxUp_Del(p)
+	assert.Equal(t, PfSenseBandwidthMaxUp(0), PfSenseBandwidthMaxUp_Get(p))
+	assert.Equal(t, 0, vsaVendorCount(t, p, _PfSense_VendorID), "the pfSense VSA should be gone after delete")
+}
+
+// TestPfSenseVSAVendorIsolation ensures the pfSense accessors ignore a foreign
+// vendor's attribute carried in the same packet.
+func TestPfSenseVSAVendorIsolation(t *testing.T) {
+	p := &radius.Packet{}
+
+	foreign, err := radius.NewVendorSpecific(14988, radius.Attribute{1, 4, 0xAA, 0xBB})
+	require.NoError(t, err)
+	p.Add(rfc2865.VendorSpecific_Type, foreign)
+
+	assert.Equal(t, 0, vsaVendorCount(t, p, _PfSense_VendorID))
+	assert.Equal(t, PfSenseBandwidthMaxUp(0), PfSenseBandwidthMaxUp_Get(p), "a foreign VSA must not be read as a pfSense attribute")
+}

--- a/internal/radiusd/vendors/radback/generated_vsa_test.go
+++ b/internal/radiusd/vendors/radback/generated_vsa_test.go
@@ -1,0 +1,61 @@
+package radback
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"layeh.com/radius"
+	"layeh.com/radius/rfc2865"
+)
+
+// vsaVendorCount returns how many Vendor-Specific attributes on p carry the
+// given IANA enterprise number. The generated codec packs each VSA under its
+// own RFC 2865 attribute-26 envelope, so this counts only this dictionary's
+// attributes and ignores foreign vendors.
+func vsaVendorCount(t *testing.T, p *radius.Packet, wantVendorID uint32) int {
+	t.Helper()
+	var n int
+	for _, avp := range p.Attributes {
+		if avp.Type != rfc2865.VendorSpecific_Type {
+			continue
+		}
+		vendorID, _, err := radius.VendorSpecific(avp.Attribute)
+		require.NoError(t, err)
+		if vendorID == wantVendorID {
+			n++
+		}
+	}
+	return n
+}
+
+// TestRedbackContextNameStringVSARoundTrip pins the wire contract for the
+// Redback VSA dictionary. No accept enhancer ships Redback VSAs today, so this
+// round-trip is the only guard that Context-Name encodes under a Redback (2352)
+// Vendor-Specific attribute and decodes the same string back.
+func TestRedbackContextNameStringVSARoundTrip(t *testing.T) {
+	p := &radius.Packet{}
+
+	const value = "vrf-customer-a"
+	require.NoError(t, ContextName_SetString(p, value))
+
+	assert.Equal(t, 1, vsaVendorCount(t, p, _Redback_VendorID))
+	assert.Equal(t, value, ContextName_GetString(p))
+
+	ContextName_Del(p)
+	assert.Equal(t, "", ContextName_GetString(p))
+	assert.Equal(t, 0, vsaVendorCount(t, p, _Redback_VendorID), "the Redback VSA should be gone after delete")
+}
+
+// TestRedbackVSAVendorIsolation ensures the Redback accessors ignore a foreign
+// vendor's attribute carried in the same packet.
+func TestRedbackVSAVendorIsolation(t *testing.T) {
+	p := &radius.Packet{}
+
+	foreign, err := radius.NewVendorSpecific(14988, radius.Attribute{1, 4, 0xAA, 0xBB})
+	require.NoError(t, err)
+	p.Add(rfc2865.VendorSpecific_Type, foreign)
+
+	assert.Equal(t, 0, vsaVendorCount(t, p, _Redback_VendorID))
+	assert.Equal(t, "", ContextName_GetString(p), "a foreign VSA must not be read as a Redback attribute")
+}

--- a/internal/radiusd/vendors/unix/generated_vsa_test.go
+++ b/internal/radiusd/vendors/unix/generated_vsa_test.go
@@ -1,0 +1,61 @@
+package unix
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"layeh.com/radius"
+	"layeh.com/radius/rfc2865"
+)
+
+// vsaVendorCount returns how many Vendor-Specific attributes on p carry the
+// given IANA enterprise number. The generated codec packs each VSA under its
+// own RFC 2865 attribute-26 envelope, so this counts only this dictionary's
+// attributes and ignores foreign vendors.
+func vsaVendorCount(t *testing.T, p *radius.Packet, wantVendorID uint32) int {
+	t.Helper()
+	var n int
+	for _, avp := range p.Attributes {
+		if avp.Type != rfc2865.VendorSpecific_Type {
+			continue
+		}
+		vendorID, _, err := radius.VendorSpecific(avp.Attribute)
+		require.NoError(t, err)
+		if vendorID == wantVendorID {
+			n++
+		}
+	}
+	return n
+}
+
+// TestUnixFTPHomeStringVSARoundTrip pins the wire contract for the Unix VSA
+// dictionary. No accept enhancer ships Unix VSAs today, so this round-trip is
+// the only guard that Unix-FTP-Home encodes under a Unix (4) Vendor-Specific
+// attribute and decodes the same string back.
+func TestUnixFTPHomeStringVSARoundTrip(t *testing.T) {
+	p := &radius.Packet{}
+
+	const value = "/home/ftp/user1"
+	require.NoError(t, UnixFTPHome_SetString(p, value))
+
+	assert.Equal(t, 1, vsaVendorCount(t, p, _Unix_VendorID))
+	assert.Equal(t, value, UnixFTPHome_GetString(p))
+
+	UnixFTPHome_Del(p)
+	assert.Equal(t, "", UnixFTPHome_GetString(p))
+	assert.Equal(t, 0, vsaVendorCount(t, p, _Unix_VendorID), "the Unix VSA should be gone after delete")
+}
+
+// TestUnixVSAVendorIsolation ensures the Unix accessors ignore a foreign
+// vendor's attribute carried in the same packet.
+func TestUnixVSAVendorIsolation(t *testing.T) {
+	p := &radius.Packet{}
+
+	foreign, err := radius.NewVendorSpecific(14988, radius.Attribute{1, 4, 0xAA, 0xBB})
+	require.NoError(t, err)
+	p.Add(rfc2865.VendorSpecific_Type, foreign)
+
+	assert.Equal(t, 0, vsaVendorCount(t, p, _Unix_VendorID))
+	assert.Equal(t, "", UnixFTPHome_GetString(p), "a foreign VSA must not be read as a Unix attribute")
+}


### PR DESCRIPTION
## Summary

Completes the vendor VSA wire-contract test pass started in #321. That PR covered the six dictionaries with a production accept-enhancer consumer (huawei, h3c, zte, ikuai, mikrotik, microsoft). This PR covers the **nine dictionary-only vendors that have no consumer today** and were therefore sitting at **0% coverage** with nothing exercising their generated codec:

| Vendor | Enterprise # | Attribute under test | Type |
| --- | --- | --- | --- |
| cisco | 9 | `Cisco-AVPair` | string |
| juniper | 2636 | `Juniper-Local-User-Name` | string |
| aruba | 14823 | `Aruba-User-Role` | string |
| alcatel | 3041 | `AAT-Primary-Home-Agent` | string |
| f5 | 3375 | `F5-LTM-User-Partition` | string |
| hillstone | 28557 | `Hillstone-User-Mobile-Number` | string |
| radback | 2352 | `Context-Name` | string |
| unix | 4 | `Unix-FTP-Home` | string |
| pfSense | 13644 | `Bandwidth-Max-Up` | integer (uint32) |

## What each test pins

For each vendor the round-trip test:

1. Encodes a representative attribute via the generated `_Set`/`_SetString`.
2. Asserts **exactly one** Vendor-Specific attribute is emitted under the **correct IANA enterprise number** (decoded straight off `rfc2865.VendorSpecific_Type` via `radius.VendorSpecific`, not via the same accessor under test).
3. Round-trips the value back through `_Get`/`_GetString`.
4. Deletes it and confirms the VSA is gone.
5. A vendor-isolation case injects a foreign vendor's VSA (Mikrotik, 14988) and verifies it is **never** misread as this vendor's attribute.

## Why contract, not coverage

These dictionaries are large auto-generated (`radius-dict-gen`) accessor surfaces. Chasing a coverage percentage across thousands of unused typed accessors would be noise. Instead each test pins the part that actually matters for interop: the **vendor ID + TLV framing + value fidelity** of the shared codec template. A regression there (wrong enterprise number, truncated value, mis-scoped delete) would now fail CI for every vendor family.

## Validation

- `go test ./internal/radiusd/vendors/...` — all pass
- `golangci-lint run ./internal/radiusd/vendors/...` — 0 issues
- `CGO_ENABLED=0 go build ./...` — clean

Refs #304
