### PR TITLE
fix(lint): check error returns in setvendor empty-VSA test (unblocks CI)

### DIFF
--- a/internal/radiusd/vendors/mikrotik/setvendor_test.go
+++ b/internal/radiusd/vendors/mikrotik/setvendor_test.go
@@ -79,11 +79,19 @@ func TestSetVendorReplaceSameAttribute(t *testing.T) {
 // wrong elements; it must be "i+1".
 func TestSetVendorDeletesEmptyVSAAtNonZeroIndex(t *testing.T) {
 	p := &radius.Packet{}
-	rfc2865.UserName_SetString(p, "alice")
-	rfc2865.NASIdentifier_SetString(p, "nas-1")
+	if err := rfc2865.UserName_SetString(p, "alice"); err != nil {
+		t.Fatalf("set UserName: %v", err)
+	}
+	if err := rfc2865.NASIdentifier_SetString(p, "nas-1"); err != nil {
+		t.Fatalf("set NASIdentifier: %v", err)
+	}
 
-	MikrotikRecvLimit_Set(p, 1000) // VSA now at index 2
-	MikrotikRecvLimit_Set(p, 2000) // removes the empty VSA at index 2, re-adds
+	if err := MikrotikRecvLimit_Set(p, 1000); err != nil { // VSA now at index 2
+		t.Fatalf("first set: %v", err)
+	}
+	if err := MikrotikRecvLimit_Set(p, 2000); err != nil { // removes the empty VSA at index 2, re-adds
+		t.Fatalf("second set: %v", err)
+	}
 
 	if got, err := MikrotikRecvLimit_Lookup(p); err != nil || got != 2000 {
 		t.Fatalf("MikrotikRecvLimit_Lookup = %d, %v; want 2000, nil", got, err)


### PR DESCRIPTION
## 问题

`main` 当前 CI 的 **Lint job 失败**（最近一次 push `d52e070d` 红），导致所有 PR 都被门禁卡住（Build 因 `needs: [lint, test]` 被 skip）。

根因：commit `4be1e7df` 新增的 `internal/radiusd/vendors/mikrotik/setvendor_test.go` 中，`TestSetVendorDeletesEmptyVSAAtNonZeroIndex` 有 4 处未检查错误返回，被 golangci-lint `errcheck` 拦截：

- `rfc2865.UserName_SetString(p, "alice")`
- `rfc2865.NASIdentifier_SetString(p, "nas-1")`
- `MikrotikRecvLimit_Set(p, 1000)`
- `MikrotikRecvLimit_Set(p, 2000)`

## 修复

为这 4 处调用补上 `if err := ...; err != nil { t.Fatalf(...) }` 检查，与同文件中已通过 lint 的 `TestSetVendorReplaceSameAttribute` 保持一致的约定。

## 验证

- `go test ./internal/radiusd/vendors/mikrotik/` ✅ ok
- `gofmt -l` 干净
- 仅改测试文件，无运行时行为变更

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>