### PR TITLE
M1.4 / TR-F004: classify EAP-TLS failures to AuthError metrics

### DIFF
--- a/internal/radiusd/auth_stages.go
+++ b/internal/radiusd/auth_stages.go
@@ -1,6 +1,7 @@
 package radiusd
 
 import (
+	stderrs "errors"
 	"fmt"
 	"net"
 	"strings"
@@ -142,11 +143,9 @@ func (s *AuthService) stageEAPDispatch(ctx *AuthPipelineContext) error {
 	)
 
 	if eapErr != nil {
-		zap.L().Warn("eap handling failed",
-			zap.String("namespace", "radius"),
-			zap.Error(eapErr),
-		)
-		_ = s.eapHelper.SendEAPFailure(ctx.Writer, ctx.Request, ctx.NAS.Secret, eapErr)
+		rejectErr := mapEAPDispatchError(eapErr)
+		s.logEAPFailure(ctx, rejectErr)
+		_ = s.eapHelper.SendEAPFailure(ctx.Writer, ctx.Request, ctx.NAS.Secret, rejectErr)
 		s.eapHelper.CleanupState(ctx.Request)
 		ctx.Stop()
 		return nil
@@ -156,7 +155,9 @@ func (s *AuthService) stageEAPDispatch(ctx *AuthPipelineContext) error {
 		if success {
 			err := s.AuthenticateUserWithPlugins(ctx.Context, ctx.Request, ctx.Response, ctx.User, ctx.NAS, ctx.VendorRequestForPlugin, ctx.IsMacAuth, SkipPasswordValidation())
 			if err != nil {
-				_ = s.eapHelper.SendEAPFailure(ctx.Writer, ctx.Request, ctx.NAS.Secret, err)
+				rejectErr := mapEAPDispatchError(err)
+				s.logEAPFailure(ctx, rejectErr)
+				_ = s.eapHelper.SendEAPFailure(ctx.Writer, ctx.Request, ctx.NAS.Secret, rejectErr)
 				s.eapHelper.CleanupState(ctx.Request)
 				ctx.Stop()
 				return nil
@@ -167,6 +168,72 @@ func (s *AuthService) stageEAPDispatch(ctx *AuthPipelineContext) error {
 	}
 
 	return nil
+}
+
+func mapEAPDispatchError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	if authErr, ok := radiuserrors.GetAuthError(err); ok {
+		cloned := *authErr
+		if cloned.ErrorStage == "" {
+			cloned.ErrorStage = StageEAPDispatch
+		}
+		return &cloned
+	}
+
+	switch {
+	case stderrs.Is(err, eap.ErrPasswordMismatch):
+		return newEAPDispatchAuthError(app.MetricsRadiusRejectPasswdError, "eap password validation failed", err)
+	case stderrs.Is(err, eap.ErrTLSIdentityMismatch):
+		return newEAPDispatchAuthError(app.MetricsRadiusRejectUnauthorized, "eap-tls certificate identity mismatch", err)
+	case stderrs.Is(err, eap.ErrTLSNoIdentity):
+		return newEAPDispatchAuthError(app.MetricsRadiusRejectUnauthorized, "eap-tls certificate identity missing", err)
+	case stderrs.Is(err, eap.ErrTLSNotConfigured):
+		return newEAPDispatchAuthError(app.MetricsRadiusRejectOther, "eap-tls trust configuration missing", err)
+	case stderrs.Is(err, eap.ErrTLSHandshakeFailed):
+		return newEAPDispatchAuthError(app.MetricsRadiusRejectOther, "eap-tls handshake failed", err)
+	case stderrs.Is(err, eap.ErrTLSUnexpectedFragment):
+		return newEAPDispatchAuthError(app.MetricsRadiusRejectOther, "eap-tls fragmentation exchange failed", err)
+	case stderrs.Is(err, eap.ErrStateNotFound):
+		return newEAPDispatchAuthError(app.MetricsRadiusRejectOther, "eap session state not found", err)
+	case stderrs.Is(err, eap.ErrUnsupportedEAPType):
+		return newEAPDispatchAuthError(app.MetricsRadiusRejectOther, "eap type not supported", err)
+	case stderrs.Is(err, eap.ErrInvalidEAPMessage):
+		return newEAPDispatchAuthError(app.MetricsRadiusRejectOther, "invalid eap message", err)
+	default:
+		return newEAPDispatchAuthError(app.MetricsRadiusRejectOther, "eap authentication failed", err)
+	}
+}
+
+func newEAPDispatchAuthError(metricsType, message string, cause error) error {
+	return &radiuserrors.AuthError{
+		MetricsType: metricsType,
+		Message:     message,
+		ErrorStage:  StageEAPDispatch,
+		Cause:       cause,
+	}
+}
+
+func (s *AuthService) logEAPFailure(ctx *AuthPipelineContext, err error) {
+	metricsKey := app.MetricsRadiusRejectOther
+	stage := StageEAPDispatch
+	if radiusErr, ok := radiuserrors.GetRadiusError(err); ok {
+		metricsKey = radiusErr.MetricsKey()
+		if radiusErr.Stage() != "" {
+			stage = radiusErr.Stage()
+		}
+	}
+
+	zap.L().Warn("radius eap auth rejected",
+		zap.String("namespace", "radius"),
+		zap.String("stage", stage),
+		zap.String("username", ctx.Username),
+		zap.String("nasip", ctx.RemoteIP),
+		zap.String("metrics", metricsKey),
+		zap.Error(err),
+	)
 }
 
 func (s *AuthService) stagePluginAuth(ctx *AuthPipelineContext) error {

--- a/internal/radiusd/auth_stages.go
+++ b/internal/radiusd/auth_stages.go
@@ -232,8 +232,18 @@ func (s *AuthService) logEAPFailure(ctx *AuthPipelineContext, err error) {
 		zap.String("username", ctx.Username),
 		zap.String("nasip", ctx.RemoteIP),
 		zap.String("metrics", metricsKey),
-		zap.Error(err),
+		zap.String("reason", safeEAPFailureReason(err)),
 	)
+}
+
+func safeEAPFailureReason(err error) string {
+	if authErr, ok := radiuserrors.GetAuthError(err); ok {
+		return authErr.Message
+	}
+	if err == nil {
+		return "eap authentication failed"
+	}
+	return "eap authentication failed"
 }
 
 func (s *AuthService) stagePluginAuth(ctx *AuthPipelineContext) error {

--- a/internal/radiusd/auth_stages_test.go
+++ b/internal/radiusd/auth_stages_test.go
@@ -1,0 +1,82 @@
+package radiusd
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/talkincode/toughradius/v9/internal/app"
+	radiuserrors "github.com/talkincode/toughradius/v9/internal/radiusd/errors"
+	eap "github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap"
+)
+
+func TestMapEAPDispatchError(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       error
+		metricsType string
+		stage       string
+		contains    string
+	}{
+		{
+			name:        "password mismatch maps to passwd metric",
+			input:       eap.ErrPasswordMismatch,
+			metricsType: app.MetricsRadiusRejectPasswdError,
+			stage:       StageEAPDispatch,
+			contains:    "eap password validation failed",
+		},
+		{
+			name:        "tls identity mismatch maps to unauthorized metric",
+			input:       eap.ErrTLSIdentityMismatch,
+			metricsType: app.MetricsRadiusRejectUnauthorized,
+			stage:       StageEAPDispatch,
+			contains:    "identity mismatch",
+		},
+		{
+			name:        "wrapped tls not configured maps to tls config reason",
+			input:       fmt.Errorf("wrap: %w", eap.ErrTLSNotConfigured),
+			metricsType: app.MetricsRadiusRejectOther,
+			stage:       StageEAPDispatch,
+			contains:    "eap-tls trust configuration missing",
+		},
+		{
+			name:        "unknown eap error falls back to reject-other metric",
+			input:       errors.New("boom"),
+			metricsType: app.MetricsRadiusRejectOther,
+			stage:       StageEAPDispatch,
+			contains:    "eap authentication failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := mapEAPDispatchError(tt.input)
+			authErr, ok := radiuserrors.GetAuthError(out)
+			assert.True(t, ok)
+			assert.Equal(t, tt.metricsType, authErr.MetricsType)
+			assert.Equal(t, tt.stage, authErr.ErrorStage)
+			assert.Contains(t, authErr.Error(), tt.contains)
+		})
+	}
+}
+
+func TestMapEAPDispatchError_UsesWrappedSentinel(t *testing.T) {
+	input := errors.Join(errors.New("failed handshake"), eap.ErrTLSHandshakeFailed)
+	out := mapEAPDispatchError(input)
+	authErr, ok := radiuserrors.GetAuthError(out)
+	assert.True(t, ok)
+	assert.Equal(t, app.MetricsRadiusRejectOther, authErr.MetricsType)
+	assert.Equal(t, StageEAPDispatch, authErr.ErrorStage)
+	assert.Contains(t, authErr.Error(), "eap-tls handshake failed")
+}
+
+func TestMapEAPDispatchError_PreservesExistingAuthErrorMetric(t *testing.T) {
+	input := radiuserrors.NewAuthError(app.MetricsRadiusRejectLimit, "rate limited")
+	out := mapEAPDispatchError(input)
+	authErr, ok := radiuserrors.GetAuthError(out)
+	assert.True(t, ok)
+	assert.Equal(t, app.MetricsRadiusRejectLimit, authErr.MetricsType)
+	assert.Equal(t, StageEAPDispatch, authErr.ErrorStage)
+	assert.Equal(t, "rate limited", authErr.Message)
+}

--- a/internal/radiusd/auth_stages_test.go
+++ b/internal/radiusd/auth_stages_test.go
@@ -80,3 +80,10 @@ func TestMapEAPDispatchError_PreservesExistingAuthErrorMetric(t *testing.T) {
 	assert.Equal(t, StageEAPDispatch, authErr.ErrorStage)
 	assert.Equal(t, "rate limited", authErr.Message)
 }
+
+func TestSafeEAPFailureReason_DoesNotExposeCause(t *testing.T) {
+	err := radiuserrors.NewAuthErrorWithCause(app.MetricsRadiusRejectOther, "eap-tls handshake failed", errors.New("sensitive password leak"))
+	reason := safeEAPFailureReason(err)
+	assert.Equal(t, "eap-tls handshake failed", reason)
+	assert.NotContains(t, reason, "sensitive")
+}

--- a/internal/radiusd/eap_integration_test.go
+++ b/internal/radiusd/eap_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -375,6 +376,9 @@ func TestEAPMD5IntegrationWrongPassword(t *testing.T) {
 	if eapAttr[0] != eap.CodeFailure {
 		t.Fatalf("expected EAP-Failure (code %d), got code %d", eap.CodeFailure, eapAttr[0])
 	}
+	if reply := rfc2865.ReplyMessage_GetString(resp); reply == "" {
+		t.Fatal("expected Reply-Message to contain EAP failure reason")
+	}
 }
 
 func TestEAPMD5IntegrationNakUnsupportedMethod(t *testing.T) {
@@ -443,6 +447,10 @@ func TestEAPTLSIntegrationStartThenSafeReject(t *testing.T) {
 	}
 	if resp.Code != radius.CodeAccessReject {
 		t.Fatalf("expected Access-Reject from EAP-TLS skeleton, got %v", resp.Code)
+	}
+	reply := strings.ToLower(rfc2865.ReplyMessage_GetString(resp))
+	if !strings.Contains(reply, "eap-tls trust configuration missing") {
+		t.Fatalf("expected explicit EAP-TLS failure reason, got %q", reply)
 	}
 }
 

--- a/internal/radiusd/plugins/eap/coordinator.go
+++ b/internal/radiusd/plugins/eap/coordinator.go
@@ -202,6 +202,13 @@ func (c *Coordinator) SendEAPFailure(w radius.ResponseWriter, r *radius.Request,
 
 	// Create RADIUS Reject response
 	response := r.Response(radius.CodeAccessReject)
+	if reason != nil {
+		reply := reason.Error()
+		if len(reply) > 253 {
+			reply = reply[:253]
+		}
+		_ = rfc2865.ReplyMessage_SetString(response, reply) //nolint:errcheck
+	}
 
 	// Set the EAP-Message and Message-Authenticator
 	SetEAPMessageAndAuth(response, eapFailure, secret)

--- a/internal/radiusd/plugins/eap/coordinator.go
+++ b/internal/radiusd/plugins/eap/coordinator.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/talkincode/toughradius/v9/internal/domain"
+	radiuserrors "github.com/talkincode/toughradius/v9/internal/radiusd/errors"
 	"go.uber.org/zap"
 	"layeh.com/radius"
 	"layeh.com/radius/rfc2865"
@@ -203,7 +204,7 @@ func (c *Coordinator) SendEAPFailure(w radius.ResponseWriter, r *radius.Request,
 	// Create RADIUS Reject response
 	response := r.Response(radius.CodeAccessReject)
 	if reason != nil {
-		reply := reason.Error()
+		reply := safeReplyMessage(reason)
 		if len(reply) > 253 {
 			reply = reply[:253]
 		}
@@ -219,6 +220,18 @@ func (c *Coordinator) SendEAPFailure(w radius.ResponseWriter, r *radius.Request,
 		zap.Error(reason))
 
 	return w.Write(response)
+}
+
+func safeReplyMessage(reason error) string {
+	if reason == nil {
+		return ""
+	}
+	if authErr, ok := radiuserrors.GetAuthError(reason); ok {
+		if authErr.Message != "" {
+			return authErr.Message
+		}
+	}
+	return reason.Error()
 }
 
 // CleanupState Cleanup EAP Status

--- a/internal/radiusd/plugins/eap/coordinator_test.go
+++ b/internal/radiusd/plugins/eap/coordinator_test.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/talkincode/toughradius/v9/internal/app"
 	"github.com/talkincode/toughradius/v9/internal/domain"
+	radiuserrors "github.com/talkincode/toughradius/v9/internal/radiusd/errors"
 	"layeh.com/radius"
 	"layeh.com/radius/rfc2865"
 	"layeh.com/radius/rfc2869"
@@ -657,6 +659,23 @@ func TestSendEAPFailure_WithNilReason(t *testing.T) {
 	assert.NotNil(t, writer.response)
 	assert.Equal(t, radius.CodeAccessReject, writer.response.Code)
 	assert.Equal(t, "", rfc2865.ReplyMessage_GetString(writer.response))
+}
+
+func TestSendEAPFailure_SanitizesAuthErrorCauseInReply(t *testing.T) {
+	coordinator := NewCoordinator(newMockStateManager(), &mockPasswordProvider{}, newMockHandlerRegistry(), false)
+	writer := &mockResponseWriter{}
+
+	packet := createEAPIdentityResponse(2, "testuser")
+	req := &radius.Request{Packet: packet}
+
+	reason := radiuserrors.NewAuthErrorWithCause(app.MetricsRadiusRejectOther, "eap-tls handshake failed", errors.New("password=super-secret"))
+	err := coordinator.SendEAPFailure(writer, req, "secret", reason)
+
+	require.NoError(t, err)
+	assert.NotNil(t, writer.response)
+	reply := rfc2865.ReplyMessage_GetString(writer.response)
+	assert.Equal(t, "eap-tls handshake failed", reply)
+	assert.NotContains(t, reply, "super-secret")
 }
 
 // Tests for CleanupState

--- a/internal/radiusd/plugins/eap/coordinator_test.go
+++ b/internal/radiusd/plugins/eap/coordinator_test.go
@@ -639,6 +639,9 @@ func TestSendEAPFailure(t *testing.T) {
 	assert.Equal(t, uint8(CodeFailure), eapMsg[0])
 	assert.Equal(t, uint8(7), eapMsg[1]) // Identifier should match
 	assert.Equal(t, uint16(4), uint16(eapMsg[2])<<8|uint16(eapMsg[3]))
+
+	reply := rfc2865.ReplyMessage_GetString(writer.response)
+	assert.Contains(t, reply, "auth failed")
 }
 
 func TestSendEAPFailure_WithNilReason(t *testing.T) {
@@ -653,6 +656,7 @@ func TestSendEAPFailure_WithNilReason(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, writer.response)
 	assert.Equal(t, radius.CodeAccessReject, writer.response.Code)
+	assert.Equal(t, "", rfc2865.ReplyMessage_GetString(writer.response))
 }
 
 // Tests for CleanupState


### PR DESCRIPTION
## Summary
- map EAP dispatch failures to typed AuthError values with explicit metrics keys and `stage=eap_dispatch`
- preserve existing EAP-Failure packet behavior while adding explicit Reply-Message failure reason text for EAP rejects
- add unit/integration coverage for TLS and non-TLS EAP failure mapping and failure response payloads

## Scope Alignment
- Milestone: M1.4
- Feature: TR-F004
- Protocol references: RFC 5216 (EAP-TLS failure paths), RFC 3748 (EAP failure signaling), RFC 3579 (RADIUS/EAP carriage)

## Verification
- `go build ./...`
- `go test ./...`
- `go test ./internal/radiusd/...`
- `go test ./internal/radiusd/plugins/eap/...`

## Notes
- `golangci-lint run` could not be executed locally in this worktree because golangci-lint is not installed (`command not found`).
