### PR TITLE
M1.4(TR-F004): emit EAP AuthError reject metrics

### DIFF
--- a/internal/radiusd/auth_stages.go
+++ b/internal/radiusd/auth_stages.go
@@ -225,6 +225,7 @@ func (s *AuthService) logEAPFailure(ctx *AuthPipelineContext, err error) {
 			stage = radiusErr.Stage()
 		}
 	}
+	app.IncRadiusMetric(metricsKey)
 
 	zap.L().Warn("radius eap auth rejected",
 		zap.String("namespace", "radius"),

--- a/internal/radiusd/auth_stages_test.go
+++ b/internal/radiusd/auth_stages_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/talkincode/toughradius/v9/internal/app"
 	radiuserrors "github.com/talkincode/toughradius/v9/internal/radiusd/errors"
 	eap "github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap"
+	"github.com/talkincode/toughradius/v9/pkg/metrics"
 )
 
 func TestMapEAPDispatchError(t *testing.T) {
@@ -86,4 +87,37 @@ func TestSafeEAPFailureReason_DoesNotExposeCause(t *testing.T) {
 	reason := safeEAPFailureReason(err)
 	assert.Equal(t, "eap-tls handshake failed", reason)
 	assert.NotContains(t, reason, "sensitive")
+}
+
+func TestLogEAPFailure_IncrementsMappedMetric(t *testing.T) {
+	assert.NoError(t, metrics.InitMetrics(""))
+
+	s := &AuthService{}
+	ctx := &AuthPipelineContext{
+		Username: "alice",
+		RemoteIP: "10.0.0.1",
+	}
+	err := radiuserrors.NewAuthErrorWithStage(app.MetricsRadiusRejectUnauthorized, "eap-tls certificate identity mismatch", StageEAPDispatch)
+
+	before := app.GetRadiusMetrics(app.MetricsRadiusRejectUnauthorized)
+	s.logEAPFailure(ctx, err)
+	after := app.GetRadiusMetrics(app.MetricsRadiusRejectUnauthorized)
+
+	assert.Equal(t, before+1, after)
+}
+
+func TestLogEAPFailure_UsesRejectOtherForUnknownError(t *testing.T) {
+	assert.NoError(t, metrics.InitMetrics(""))
+
+	s := &AuthService{}
+	ctx := &AuthPipelineContext{
+		Username: "alice",
+		RemoteIP: "10.0.0.1",
+	}
+
+	before := app.GetRadiusMetrics(app.MetricsRadiusRejectOther)
+	s.logEAPFailure(ctx, errors.New("unexpected failure"))
+	after := app.GetRadiusMetrics(app.MetricsRadiusRejectOther)
+
+	assert.Equal(t, before+1, after)
 }

--- a/internal/radiusd/eap_integration_test.go
+++ b/internal/radiusd/eap_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/talkincode/toughradius/v9/internal/app"
 	"github.com/talkincode/toughradius/v9/internal/domain"
 	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins"
 	eap "github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap"
@@ -361,6 +362,7 @@ func TestEAPMD5IntegrationWrongPassword(t *testing.T) {
 	client, rs := startEAPTestServer(t)
 	seedEAPUser(t, rs, "eapuser", "eappass")
 	client.username = "eapuser"
+	beforeRejectPassword := app.GetRadiusMetrics(app.MetricsRadiusRejectPasswdError)
 
 	challenge, state := client.sendIdentity(t)
 	resp := client.sendMD5Response(t, challenge, state, "wrong-password")
@@ -378,6 +380,10 @@ func TestEAPMD5IntegrationWrongPassword(t *testing.T) {
 	}
 	if reply := rfc2865.ReplyMessage_GetString(resp); reply == "" {
 		t.Fatal("expected Reply-Message to contain EAP failure reason")
+	}
+	afterRejectPassword := app.GetRadiusMetrics(app.MetricsRadiusRejectPasswdError)
+	if afterRejectPassword != beforeRejectPassword+1 {
+		t.Fatalf("expected password reject metric to increment by 1 (before=%d after=%d)", beforeRejectPassword, afterRejectPassword)
 	}
 }
 
@@ -421,6 +427,7 @@ func TestEAPTLSIntegrationStartThenSafeReject(t *testing.T) {
 	seedEAPUser(t, rs, "eapuser", "eappass")
 	setEapMethod(t, rs, "eap-tls")
 	client.username = "eapuser"
+	beforeRejectOther := app.GetRadiusMetrics(app.MetricsRadiusRejectOther)
 
 	challenge, state := client.sendIdentity(t)
 	if challenge.Type != eap.TypeTLS {
@@ -451,6 +458,10 @@ func TestEAPTLSIntegrationStartThenSafeReject(t *testing.T) {
 	reply := strings.ToLower(rfc2865.ReplyMessage_GetString(resp))
 	if !strings.Contains(reply, "eap-tls trust configuration missing") {
 		t.Fatalf("expected explicit EAP-TLS failure reason, got %q", reply)
+	}
+	afterRejectOther := app.GetRadiusMetrics(app.MetricsRadiusRejectOther)
+	if afterRejectOther != beforeRejectOther+1 {
+		t.Fatalf("expected reject-other metric to increment by 1 (before=%d after=%d)", beforeRejectOther, afterRejectOther)
 	}
 }
 


### PR DESCRIPTION
## Summary
- milestone: `M1.4`
- feature: `TR-F004`
- ensure EAP dispatch failure path increments the mapped reject metric key (`AuthError.MetricsType`)
- keep explicit reject reasons in Reply-Message and add assertions that reject metrics increase in real EAP failure flows

## Why
`M1.4` requires explicit failure reasons plus AuthError metrics. Existing EAP dispatch mapped errors and reasons correctly, but did not increment reject metrics on EAP failure path.

## RFC References
- RFC 5216 §2.2 / §5.3 (EAP-TLS handshake and certificate validation failure semantics)
- RFC 5216 §5.2 (certificate identity mapping failure semantics)
- RFC 3748 §4.2 / §4.3 (EAP Failure signaling behavior)

## Changes
- `internal/radiusd/auth_stages.go`
  - add `app.IncRadiusMetric(metricsKey)` in `logEAPFailure`
- `internal/radiusd/auth_stages_test.go`
  - add unit tests verifying mapped metric increment and fallback-to-reject-other increment
- `internal/radiusd/eap_integration_test.go`
  - assert password mismatch increments `MetricsRadiusRejectPasswdError`
  - assert EAP-TLS safe reject increments `MetricsRadiusRejectOther`

## Validation
- `go build ./...`
- `go test ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`
