### PR TITLE
M1.5(TR-F004): wire EAP-TLS certificate config from dynamic settings

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -72,8 +72,8 @@
 - [x] M1.1 在 `internal/radiusd/plugins/eap` 注册 EAP-TLS handler 骨架与启用列表配置
 - [x] M1.2 实现 TLS 握手状态管理与分片重组（参照 RFC 5216 §3 / RFC 7499）
 - [x] M1.3 证书校验（CA 链）与用户身份映射
-- [ ] M1.4 明确失败原因 + AuthError 指标 + 单元/集成测试
-- [ ] M1.5 在 `config_schemas.json` 增加 EAP-TLS 配置项与默认值
+- [x] M1.4 明确失败原因 + AuthError 指标 + 单元/集成测试
+- [x] M1.5 在 `config_schemas.json` 增加 EAP-TLS 配置项与默认值
 - [ ] M1.6 在 `test/integration/` 增加 EAP-TLS 端到端验收用例（CI 自动执行）
 
 验收口径：EAP-TLS 客户端可完成认证；失败场景有明确拒绝原因和指标；**验收由 `test/integration/` 的 CI 用例背书**，新增逻辑全部有测试覆盖。

--- a/internal/app/config_manager_test.go
+++ b/internal/app/config_manager_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/talkincode/toughradius/v9/config"
 )
 
@@ -205,6 +206,40 @@ func TestConfigManagerJSON(t *testing.T) {
 	if assert.NotNil(t, windowSchema.Max) {
 		assert.Equal(t, int64(3600), *windowSchema.Max)
 	}
+}
+
+// TestConfigManagerJSON_EapTlsSchemas verifies the EAP-TLS runtime config items
+// (milestone M1.5, TR-F004) are present with the expected defaults so they can
+// be queried/edited/reloaded on the system config page.
+func TestConfigManagerJSON_EapTlsSchemas(t *testing.T) {
+	cm := &ConfigManager{
+		configs: make(map[string]string),
+		schemas: make(map[string]*ConfigSchema),
+	}
+	require.NoError(t, cm.loadSchemasFromJSON())
+
+	// Certificate/key/CA path items: string type, empty default (EAP-TLS
+	// disabled until configured), with i18n keys wired for the UI.
+	for _, key := range []string{"radius.EapTlsCertFile", "radius.EapTlsKeyFile", "radius.EapTlsCaFile"} {
+		schema, exists := cm.schemas[key]
+		require.Truef(t, exists, "%s configuration should exist", key)
+		assert.Equalf(t, TypeString, schema.Type, "%s should be string type", key)
+		assert.Equalf(t, "", schema.Default, "%s default should be empty", key)
+		assert.NotEmptyf(t, schema.TitleI18n, "%s should have a title i18n key", key)
+		assert.NotEmptyf(t, schema.DescI18n, "%s should have a description i18n key", key)
+	}
+
+	// Minimum TLS version: string enum constrained to 1.2 / 1.3, default 1.2.
+	minVerSchema, exists := cm.schemas["radius.EapTlsMinVersion"]
+	require.True(t, exists, "radius.EapTlsMinVersion configuration should exist")
+	assert.Equal(t, TypeString, minVerSchema.Type)
+	assert.Equal(t, "1.2", minVerSchema.Default)
+	assert.Contains(t, minVerSchema.Enum, "1.2")
+	assert.Contains(t, minVerSchema.Enum, "1.3")
+
+	// The value should validate against the enum so it is editable via Set.
+	assert.NoError(t, cm.validate(minVerSchema, "1.3"))
+	assert.Error(t, cm.validate(minVerSchema, "1.1"))
 }
 
 // Test configuration type parsing

--- a/internal/app/config_schemas.json
+++ b/internal/app/config_schemas.json
@@ -20,6 +20,43 @@
       "description_i18n": "config.radius.eap_enabled_handlers.description"
     },
     {
+      "key": "radius.EapTlsCertFile",
+      "type": "string",
+      "default": "",
+      "title": "EAP-TLS Server Certificate",
+      "title_i18n": "config.radius.eap_tls_cert_file.title",
+      "description": "Path to the PEM server certificate the RADIUS server presents during the EAP-TLS handshake (RFC 5216 §2.2). Leave empty to keep EAP-TLS disabled",
+      "description_i18n": "config.radius.eap_tls_cert_file.description"
+    },
+    {
+      "key": "radius.EapTlsKeyFile",
+      "type": "string",
+      "default": "",
+      "title": "EAP-TLS Server Private Key",
+      "title_i18n": "config.radius.eap_tls_key_file.title",
+      "description": "Path to the PEM private key matching the EAP-TLS server certificate. Leave empty to keep EAP-TLS disabled",
+      "description_i18n": "config.radius.eap_tls_key_file.description"
+    },
+    {
+      "key": "radius.EapTlsCaFile",
+      "type": "string",
+      "default": "",
+      "title": "EAP-TLS Client CA Bundle",
+      "title_i18n": "config.radius.eap_tls_ca_file.title",
+      "description": "Path to the PEM CA bundle used to verify EAP-TLS client certificate chains (RFC 5216 §2.2/§5.3). Leave empty to keep EAP-TLS disabled",
+      "description_i18n": "config.radius.eap_tls_ca_file.description"
+    },
+    {
+      "key": "radius.EapTlsMinVersion",
+      "type": "string",
+      "default": "1.2",
+      "enum": ["1.2", "1.3"],
+      "title": "EAP-TLS Minimum TLS Version",
+      "title_i18n": "config.radius.eap_tls_min_version.title",
+      "description": "Minimum TLS protocol version accepted for EAP-TLS handshakes",
+      "description_i18n": "config.radius.eap_tls_min_version.description"
+    },
+    {
       "key": "radius.IgnorePassword",
       "type": "bool",
       "default": "false",

--- a/internal/radiusd/plugins/eap/handlers/tls_config.go
+++ b/internal/radiusd/plugins/eap/handlers/tls_config.go
@@ -1,0 +1,98 @@
+package handlers
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap/tlsengine"
+)
+
+// EAP-TLS dynamic configuration keys (RADIUS settings category). They are
+// declared in internal/app/config_schemas.json and editable on the system
+// config page, so certificate material can be rotated without restarting the
+// RADIUS service (milestone M1.5, TR-F004 / TR-F014).
+const (
+	// SettingEapTlsCertFile is the PEM server-certificate path presented to the
+	// EAP-TLS peer (RFC 5216 §2.2).
+	SettingEapTlsCertFile = "EapTlsCertFile"
+	// SettingEapTlsKeyFile is the PEM private-key path matching the server
+	// certificate.
+	SettingEapTlsKeyFile = "EapTlsKeyFile"
+	// SettingEapTlsCaFile is the PEM CA bundle path used to verify the peer's
+	// client-certificate chain (RFC 5216 §2.2 / §5.3).
+	SettingEapTlsCaFile = "EapTlsCaFile"
+	// SettingEapTlsMinVersion pins the minimum negotiated TLS version.
+	SettingEapTlsMinVersion = "EapTlsMinVersion"
+)
+
+// TLSSettingsReader reads EAP-TLS runtime configuration values. It is satisfied
+// by *app.ConfigManager (its GetString method), letting the handler pick up
+// certificate/CA changes between handshakes without a restart while keeping the
+// handlers package free of an import dependency on internal/app.
+type TLSSettingsReader interface {
+	GetString(category, name string) string
+}
+
+// NewSettingsTLSConfigProvider returns a TLSConfigProvider that assembles the
+// EAP-TLS material from dynamic settings on every handshake.
+//
+// EAP-TLS requires the server to present a certificate and to authenticate the
+// peer against a trusted CA (RFC 5216 §2.2). Until the certificate, key, and CA
+// bundle paths are all configured, the provider returns a nil config so the
+// handler rejects safely with eap.ErrTLSNotConfigured and can never
+// authenticate a client without configured trust anchors. When the paths are
+// set but the material fails to load, it returns an explicit error so the
+// failure reason is surfaced rather than silently ignored.
+func NewSettingsTLSConfigProvider(reader TLSSettingsReader) TLSConfigProvider {
+	return func() (*tlsengine.Config, error) {
+		if reader == nil {
+			return nil, nil
+		}
+
+		certFile := strings.TrimSpace(reader.GetString("radius", SettingEapTlsCertFile))
+		keyFile := strings.TrimSpace(reader.GetString("radius", SettingEapTlsKeyFile))
+		caFile := strings.TrimSpace(reader.GetString("radius", SettingEapTlsCaFile))
+
+		// EAP-TLS is opt-in: treat it as not configured (safe reject) until the
+		// server certificate/key and the client CA bundle are all provided.
+		if certFile == "" || keyFile == "" || caFile == "" {
+			return nil, nil
+		}
+
+		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			return nil, fmt.Errorf("load EAP-TLS server certificate: %w", err)
+		}
+
+		caPEM, err := os.ReadFile(caFile) //nolint:gosec // G304: path is from validated config
+		if err != nil {
+			return nil, fmt.Errorf("read EAP-TLS client CA bundle: %w", err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(caPEM) {
+			return nil, fmt.Errorf("parse EAP-TLS client CA bundle %q: no PEM certificates found", caFile)
+		}
+
+		return &tlsengine.Config{
+			ServerCertificate: cert,
+			ClientCAs:         pool,
+			MinVersion:        parseTLSMinVersion(reader.GetString("radius", SettingEapTlsMinVersion)),
+		}, nil
+	}
+}
+
+// parseTLSMinVersion maps a configured minimum TLS version string to the
+// crypto/tls constant. It defaults to TLS 1.2, the interoperability floor for
+// modern EAP-TLS deployments; an unrecognized value falls back to the same
+// safe default rather than weakening the handshake.
+func parseTLSMinVersion(v string) uint16 {
+	switch strings.TrimSpace(v) {
+	case "1.3":
+		return tls.VersionTLS13
+	default:
+		return tls.VersionTLS12
+	}
+}

--- a/internal/radiusd/plugins/eap/handlers/tls_config_test.go
+++ b/internal/radiusd/plugins/eap/handlers/tls_config_test.go
@@ -1,0 +1,229 @@
+package handlers
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeSettingsReader is an in-memory TLSSettingsReader for testing the
+// settings-driven EAP-TLS config provider.
+type fakeSettingsReader struct {
+	values map[string]string
+}
+
+func (f *fakeSettingsReader) GetString(category, name string) string {
+	return f.values[category+"."+name]
+}
+
+func newFakeReader(values map[string]string) *fakeSettingsReader {
+	return &fakeSettingsReader{values: values}
+}
+
+// writeTestCertFiles generates a self-signed certificate and writes the
+// certificate, its private key, and a CA bundle (the same self-signed cert) to
+// PEM files in a temp dir, returning their paths.
+func writeTestCertFiles(t *testing.T) (certFile, keyFile, caFile string) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "toughradius-eap-tls-test"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+
+	dir := t.TempDir()
+	certFile = filepath.Join(dir, "server.crt")
+	keyFile = filepath.Join(dir, "server.key")
+	caFile = filepath.Join(dir, "ca.crt")
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	mustWrite(t, certFile, certPEM)
+	mustWrite(t, keyFile, keyPEM)
+	mustWrite(t, caFile, certPEM)
+	return certFile, keyFile, caFile
+}
+
+func mustWrite(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestNewSettingsTLSConfigProvider_NilReader(t *testing.T) {
+	provider := NewSettingsTLSConfigProvider(nil)
+	cfg, err := provider()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg != nil {
+		t.Fatalf("expected nil config for nil reader, got %#v", cfg)
+	}
+}
+
+func TestNewSettingsTLSConfigProvider_NotConfigured(t *testing.T) {
+	cases := map[string]map[string]string{
+		"all empty": {},
+		"only cert": {
+			"radius." + SettingEapTlsCertFile: "/tmp/server.crt",
+		},
+		"cert and key but no CA": {
+			"radius." + SettingEapTlsCertFile: "/tmp/server.crt",
+			"radius." + SettingEapTlsKeyFile:  "/tmp/server.key",
+		},
+		"whitespace-only values": {
+			"radius." + SettingEapTlsCertFile: "   ",
+			"radius." + SettingEapTlsKeyFile:  "\t",
+			"radius." + SettingEapTlsCaFile:   " ",
+		},
+	}
+	for name, values := range cases {
+		t.Run(name, func(t *testing.T) {
+			provider := NewSettingsTLSConfigProvider(newFakeReader(values))
+			cfg, err := provider()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cfg != nil {
+				t.Fatalf("expected nil config when not fully configured, got %#v", cfg)
+			}
+		})
+	}
+}
+
+func TestNewSettingsTLSConfigProvider_ValidMaterial(t *testing.T) {
+	certFile, keyFile, caFile := writeTestCertFiles(t)
+	reader := newFakeReader(map[string]string{
+		"radius." + SettingEapTlsCertFile: certFile,
+		"radius." + SettingEapTlsKeyFile:  keyFile,
+		"radius." + SettingEapTlsCaFile:   caFile,
+	})
+
+	cfg, err := NewSettingsTLSConfigProvider(reader)()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config for valid material")
+	}
+	if len(cfg.ServerCertificate.Certificate) == 0 || cfg.ServerCertificate.PrivateKey == nil {
+		t.Fatal("expected a usable server certificate")
+	}
+	if cfg.ClientCAs == nil {
+		t.Fatal("expected a non-nil client CA pool")
+	}
+	if cfg.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("expected default MinVersion TLS 1.2, got %#x", cfg.MinVersion)
+	}
+}
+
+func TestNewSettingsTLSConfigProvider_MinVersion(t *testing.T) {
+	certFile, keyFile, caFile := writeTestCertFiles(t)
+	base := map[string]string{
+		"radius." + SettingEapTlsCertFile: certFile,
+		"radius." + SettingEapTlsKeyFile:  keyFile,
+		"radius." + SettingEapTlsCaFile:   caFile,
+	}
+
+	tests := []struct {
+		configured string
+		want       uint16
+	}{
+		{"1.2", tls.VersionTLS12},
+		{"1.3", tls.VersionTLS13},
+		{"", tls.VersionTLS12},
+		{"bogus", tls.VersionTLS12},
+	}
+	for _, tc := range tests {
+		t.Run("min="+tc.configured, func(t *testing.T) {
+			values := make(map[string]string, len(base)+1)
+			for k, v := range base {
+				values[k] = v
+			}
+			values["radius."+SettingEapTlsMinVersion] = tc.configured
+
+			cfg, err := NewSettingsTLSConfigProvider(newFakeReader(values))()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cfg == nil {
+				t.Fatal("expected non-nil config")
+			}
+			if cfg.MinVersion != tc.want {
+				t.Fatalf("MinVersion for %q = %#x, want %#x", tc.configured, cfg.MinVersion, tc.want)
+			}
+		})
+	}
+}
+
+func TestNewSettingsTLSConfigProvider_LoadErrors(t *testing.T) {
+	certFile, keyFile, caFile := writeTestCertFiles(t)
+
+	t.Run("missing cert file", func(t *testing.T) {
+		reader := newFakeReader(map[string]string{
+			"radius." + SettingEapTlsCertFile: filepath.Join(t.TempDir(), "nope.crt"),
+			"radius." + SettingEapTlsKeyFile:  keyFile,
+			"radius." + SettingEapTlsCaFile:   caFile,
+		})
+		if _, err := NewSettingsTLSConfigProvider(reader)(); err == nil {
+			t.Fatal("expected error for missing server certificate")
+		}
+	})
+
+	t.Run("missing CA file", func(t *testing.T) {
+		reader := newFakeReader(map[string]string{
+			"radius." + SettingEapTlsCertFile: certFile,
+			"radius." + SettingEapTlsKeyFile:  keyFile,
+			"radius." + SettingEapTlsCaFile:   filepath.Join(t.TempDir(), "nope-ca.crt"),
+		})
+		if _, err := NewSettingsTLSConfigProvider(reader)(); err == nil {
+			t.Fatal("expected error for missing CA bundle")
+		}
+	})
+
+	t.Run("CA file without certificates", func(t *testing.T) {
+		emptyCA := filepath.Join(t.TempDir(), "empty-ca.crt")
+		mustWrite(t, emptyCA, []byte("not a pem certificate"))
+		reader := newFakeReader(map[string]string{
+			"radius." + SettingEapTlsCertFile: certFile,
+			"radius." + SettingEapTlsKeyFile:  keyFile,
+			"radius." + SettingEapTlsCaFile:   emptyCA,
+		})
+		_, err := NewSettingsTLSConfigProvider(reader)()
+		if err == nil {
+			t.Fatal("expected error for CA bundle with no certificates")
+		}
+		if !strings.Contains(err.Error(), "no PEM certificates") {
+			t.Fatalf("expected 'no PEM certificates' error, got %v", err)
+		}
+	})
+}

--- a/internal/radiusd/plugins/init.go
+++ b/internal/radiusd/plugins/init.go
@@ -64,11 +64,19 @@ func InitPlugins(appCtx app.ConfigManagerProvider, sessionRepo repository.Sessio
 	registry.RegisterEAPHandler(eaphandlers.NewMSCHAPv2Handler())
 	// EAP-TLS drives a full server-side TLS handshake with CA-chain
 	// certificate validation and certificate-to-User-Name identity mapping
-	// (milestone M1.3). It is registered without TLS material here, so it
-	// safely rejects handshakes with eap.ErrTLSNotConfigured until certificate
-	// configuration is wired in (milestone M1.5); it can never authenticate a
-	// client without configured trust anchors.
-	registry.RegisterEAPHandler(eaphandlers.NewTLSHandler())
+	// (milestone M1.3). Its certificate material is supplied from dynamic
+	// settings (milestone M1.5): the provider returns a nil config — so the
+	// handler rejects safely with eap.ErrTLSNotConfigured — until the
+	// certificate/key/CA paths are configured, and it can never authenticate a
+	// client without configured trust anchors. When no config manager is
+	// available (e.g. unit tests with a nil appCtx), fall back to the
+	// unconfigured handler which rejects identically.
+	if appCtx != nil && appCtx.ConfigMgr() != nil {
+		provider := eaphandlers.NewSettingsTLSConfigProvider(appCtx.ConfigMgr())
+		registry.RegisterEAPHandler(eaphandlers.NewTLSHandlerWithConfig(provider))
+	} else {
+		registry.RegisterEAPHandler(eaphandlers.NewTLSHandler())
+	}
 
 	// Vendor parsers under vendor/parsers register themselves via init()
 }

--- a/web/src/i18n/en-US.ts
+++ b/web/src/i18n/en-US.ts
@@ -599,6 +599,22 @@ const customEnglishMessages: TranslationMessages = {
         title: 'Enabled EAP Handlers',
         description: 'Comma-separated list of handler names. Use * to allow every registered handler.',
       },
+      eap_tls_cert_file: {
+        title: 'EAP-TLS Server Certificate',
+        description: 'Path to the PEM server certificate presented during the EAP-TLS handshake. Leave empty to keep EAP-TLS disabled.',
+      },
+      eap_tls_key_file: {
+        title: 'EAP-TLS Server Private Key',
+        description: 'Path to the PEM private key matching the EAP-TLS server certificate. Leave empty to keep EAP-TLS disabled.',
+      },
+      eap_tls_ca_file: {
+        title: 'EAP-TLS Client CA Bundle',
+        description: 'Path to the PEM CA bundle used to verify EAP-TLS client certificate chains. Leave empty to keep EAP-TLS disabled.',
+      },
+      eap_tls_min_version: {
+        title: 'EAP-TLS Minimum TLS Version',
+        description: 'Minimum TLS protocol version accepted for EAP-TLS handshakes (1.2 or 1.3).',
+      },
       ignore_password: {
         title: 'Ignore Password Check',
         description: 'Skips password validation during authentication. Only enable for debugging or external auth flows.',

--- a/web/src/i18n/zh-CN.ts
+++ b/web/src/i18n/zh-CN.ts
@@ -599,6 +599,22 @@ const customChineseMessages: TranslationMessages = {
         title: '启用的 EAP 处理器',
         description: '使用逗号分隔的处理器名称，* 表示允许所有已注册的处理器',
       },
+      eap_tls_cert_file: {
+        title: 'EAP-TLS 服务器证书',
+        description: 'EAP-TLS 握手时服务器出示的 PEM 证书路径，留空则不启用 EAP-TLS',
+      },
+      eap_tls_key_file: {
+        title: 'EAP-TLS 服务器私钥',
+        description: '与 EAP-TLS 服务器证书匹配的 PEM 私钥路径，留空则不启用 EAP-TLS',
+      },
+      eap_tls_ca_file: {
+        title: 'EAP-TLS 客户端 CA 证书',
+        description: '用于校验 EAP-TLS 客户端证书链的 PEM CA 证书包路径，留空则不启用 EAP-TLS',
+      },
+      eap_tls_min_version: {
+        title: 'EAP-TLS 最低 TLS 版本',
+        description: 'EAP-TLS 握手允许的最低 TLS 协议版本（1.2 或 1.3）',
+      },
       ignore_password: {
         title: '忽略密码校验',
         description: '启用后认证流程将跳过密码验证，仅用于调试或外部认证场景',


### PR DESCRIPTION
## Summary
- Milestone: **M1.5** · Feature: **TR-F004** (EAP-TLS) · Config mechanism: **TR-F014**
- Add EAP-TLS runtime config items to `internal/app/config_schemas.json` (server certificate, private key, client CA bundle, minimum TLS version) with defaults and i18n keys.
- Feed those settings into the EAP-TLS handler via a new settings-driven `TLSConfigProvider`, so certificate material is editable on the system config page and re-read between handshakes without a restart.
- EAP-TLS stays **opt-in and safe**: the provider returns a nil config (handler rejects with `eap.ErrTLSNotConfigured`) until cert/key/CA are all configured, and surfaces an explicit error when configured material fails to load. It can never authenticate a client without configured trust anchors.

## Changes
- `internal/app/config_schemas.json`: `radius.EapTlsCertFile` / `EapTlsKeyFile` / `EapTlsCaFile` (string, empty default = disabled) and `radius.EapTlsMinVersion` (enum `1.2`/`1.3`, default `1.2`). `checkSettings()` auto-initializes the DB defaults.
- `internal/radiusd/plugins/eap/handlers/tls_config.go`: `NewSettingsTLSConfigProvider` reads the settings, loads cert/key + CA pool, maps the min-version string to a `crypto/tls` constant.
- `internal/radiusd/plugins/init.go`: register the EAP-TLS handler with the settings provider when a config manager is available; keep the unconfigured handler (identical safe-reject) for nil-ctx unit tests.
- `web/src/i18n/{en-US,zh-CN}.ts`: titles/descriptions for the new config items (the system config page renders from the schema automatically).
- `docs/roadmap.md`: check off **M1.5** and the already-merged **M1.4** (delivered via #332/#333 but not previously groomed).

## Scope Alignment
- Anchored to `TR-F004` (EAP-TLS) and `TR-F014` (dynamic config). No `TR-N00x` non-goal touched.
- Minimal closed loop: schema + read path + wiring + tests. The full EAP-TLS end-to-end acceptance test remains **M1.6**.

## RFC References
- RFC 5216 §2.2 / §5.3 — EAP-TLS server certificate + mutual certificate authentication (`ClientAuth=RequireAndVerifyClientCert`).
- RFC 5216 §5.2 — certificate identity mapping (consumed by the M1.3 handler this config now feeds).

## Verification
- `CGO_ENABLED=0 go build ./...`
- `CGO_ENABLED=0 go test ./...` (all packages pass)
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run` -> **0 issues**
- `cd web && npm run build` (tsc + vite build pass)
- New tests: `internal/app` schema assertions (`TestConfigManagerJSON_EapTlsSchemas`) and provider read-path coverage (`TestNewSettingsTLSConfigProvider_*`).
