### PR TITLE
M2.3(TR-F010/TR-F022): persist CoA session action audit records

### DIFF
--- a/internal/adminapi/session_actions.go
+++ b/internal/adminapi/session_actions.go
@@ -160,6 +160,10 @@ func DisconnectOnlineSession(c echo.Context) error {
 	}
 
 	logSessionAction(c, result)
+	if err := persistSessionActionAudit(c, id, identity, result); err != nil {
+		return fail(c, http.StatusInternalServerError, "AUDIT_PERSIST_FAILED",
+			"Disconnect request completed but failed to persist audit record", err.Error())
+	}
 	return ok(c, newCoAActionResponse(result))
 }
 
@@ -210,12 +214,57 @@ func ChangeOnlineSessionAuthorization(c echo.Context) error {
 	}
 
 	logSessionAction(c, result)
+	if err := persistSessionActionAudit(c, id, identity, result); err != nil {
+		return fail(c, http.StatusInternalServerError, "AUDIT_PERSIST_FAILED",
+			"CoA request completed but failed to persist audit record", err.Error())
+	}
 	return ok(c, newCoAActionResponse(result))
+}
+
+// persistSessionActionAudit writes a durable per-action record required by M2.3,
+// capturing who triggered the action, which session was targeted, and the
+// structured CoA/Disconnect outcome.
+func persistSessionActionAudit(c echo.Context, sessionID int64, identity radiusd.SessionIdentity, r *radiusd.CoAResult) error {
+	operatorID := int64(0)
+	operatorName := "unknown"
+	if op, err := resolveOperatorFromContext(c); err == nil && op != nil {
+		operatorID = op.ID
+		operatorName = op.Username
+	}
+
+	triggeredAt := r.SentAt
+	if triggeredAt.IsZero() {
+		triggeredAt = time.Now()
+	}
+
+	record := domain.RadiusSessionActionAudit{
+		SessionID:      sessionID,
+		AcctSessionID:  r.AcctSessionID,
+		Action:         string(r.Action),
+		Username:       r.Username,
+		NasAddr:        identity.NasIP,
+		Target:         r.Target,
+		OperatorID:     operatorID,
+		OperatorName:   operatorName,
+		OperatorIP:     c.RealIP(),
+		Success:        r.Success,
+		ResponseCode:   r.ResponseCode,
+		ErrorCause:     r.ErrorCause,
+		ErrorCauseText: r.ErrorCauseText,
+		Attempts:       r.Attempts,
+		RTTMillis:      r.RTT.Milliseconds(),
+		TimedOut:       r.TimedOut,
+		Error:          r.Err,
+		TriggeredAt:    triggeredAt,
+	}
+
+	return GetDB(c).Create(&record).Error
 }
 
 // logSessionAction emits an audit log line recording which operator triggered a
 // CoA/Disconnect and its outcome. Durable, queryable audit persistence is
-// delivered separately (M2.3); this provides immediate operational traceability.
+// additionally written via persistSessionActionAudit; this log line provides
+// immediate operational traceability.
 func logSessionAction(c echo.Context, r *radiusd.CoAResult) {
 	operator := "unknown"
 	if op, err := resolveOperatorFromContext(c); err == nil && op != nil {

--- a/internal/adminapi/session_actions_test.go
+++ b/internal/adminapi/session_actions_test.go
@@ -182,6 +182,13 @@ func decodeErr(t *testing.T, rec *httptest.ResponseRecorder) ErrorResponse {
 	return errResp
 }
 
+func listSessionActionAudits(t *testing.T, db *gorm.DB) []domain.RadiusSessionActionAudit {
+	t.Helper()
+	var audits []domain.RadiusSessionActionAudit
+	require.NoError(t, db.Order("id asc").Find(&audits).Error)
+	return audits
+}
+
 func TestDisconnectOnlineSession_ACK(t *testing.T) {
 	db := setupTestDB(t)
 	appCtx := setupTestApp(t, db)
@@ -204,6 +211,15 @@ func TestDisconnectOnlineSession_ACK(t *testing.T) {
 	require.Len(t, got, 1)
 	assert.Equal(t, radius.CodeDisconnectRequest, got[0].code)
 	assert.Equal(t, "alice", got[0].username)
+
+	audits := listSessionActionAudits(t, db)
+	require.Len(t, audits, 1)
+	assert.Equal(t, id, audits[0].SessionID)
+	assert.Equal(t, "disconnect", audits[0].Action)
+	assert.Equal(t, "alice", audits[0].Username)
+	assert.Equal(t, "superadmin", audits[0].OperatorName)
+	assert.True(t, audits[0].Success)
+	assert.Equal(t, "Disconnect-ACK", audits[0].ResponseCode)
 }
 
 func TestDisconnectOnlineSession_NAK(t *testing.T) {
@@ -221,6 +237,13 @@ func TestDisconnectOnlineSession_NAK(t *testing.T) {
 	assert.Equal(t, "Disconnect-NAK", action.ResponseCode)
 	assert.Equal(t, int(rfc3576.ErrorCause_Value_SessionContextNotFound), action.ErrorCause)
 	assert.Equal(t, "Session-Context-Not-Found", action.ErrorCauseText)
+
+	audits := listSessionActionAudits(t, db)
+	require.Len(t, audits, 1)
+	assert.Equal(t, "disconnect", audits[0].Action)
+	assert.False(t, audits[0].Success)
+	assert.Equal(t, "Disconnect-NAK", audits[0].ResponseCode)
+	assert.Equal(t, int(rfc3576.ErrorCause_Value_SessionContextNotFound), audits[0].ErrorCause)
 }
 
 func TestChangeOnlineSessionAuthorization_ACK(t *testing.T) {
@@ -244,6 +267,12 @@ func TestChangeOnlineSessionAuthorization_ACK(t *testing.T) {
 	assert.True(t, got[0].hasTimeout)
 	assert.Equal(t, uint32(3600), got[0].sessionTimeout)
 	assert.Equal(t, "throttled", got[0].filterID)
+
+	audits := listSessionActionAudits(t, db)
+	require.Len(t, audits, 1)
+	assert.Equal(t, "coa", audits[0].Action)
+	assert.True(t, audits[0].Success)
+	assert.Equal(t, "CoA-ACK", audits[0].ResponseCode)
 }
 
 func TestChangeOnlineSessionAuthorization_NoChanges(t *testing.T) {
@@ -279,6 +308,13 @@ func TestDisconnectOnlineSession_Timeout(t *testing.T) {
 	assert.False(t, action.Success)
 	assert.True(t, action.TimedOut)
 	assert.Equal(t, 2, action.Attempts) // initial + 1 retry
+
+	audits := listSessionActionAudits(t, db)
+	require.Len(t, audits, 1)
+	assert.Equal(t, "disconnect", audits[0].Action)
+	assert.False(t, audits[0].Success)
+	assert.True(t, audits[0].TimedOut)
+	assert.Equal(t, 2, audits[0].Attempts)
 }
 
 func TestSessionAction_SessionNotFound(t *testing.T) {

--- a/internal/adminapi/test_helpers_test.go
+++ b/internal/adminapi/test_helpers_test.go
@@ -49,6 +49,7 @@ func setupTestDB(t *testing.T) *gorm.DB {
 		&domain.NetNas{},
 		&domain.RadiusAccounting{},
 		&domain.RadiusOnline{},
+		&domain.RadiusSessionActionAudit{},
 		&domain.SysOpr{},
 		&domain.SysConfig{},
 	)
@@ -113,6 +114,7 @@ func CreateTestAppContext(t *testing.T) (*gorm.DB, *echo.Echo, app.AppContext) {
 		&domain.NetNas{},
 		&domain.RadiusAccounting{},
 		&domain.RadiusOnline{},
+		&domain.RadiusSessionActionAudit{},
 		&domain.SysOpr{},
 		&domain.SysConfig{},
 	)

--- a/internal/domain/radius.go
+++ b/internal/domain/radius.go
@@ -104,6 +104,36 @@ func (RadiusOnline) TableName() string {
 	return "radius_online"
 }
 
+// RadiusSessionActionAudit records a durable audit trail for operator-triggered
+// dynamic-authorization actions (Disconnect / CoA) on online sessions.
+type RadiusSessionActionAudit struct {
+	ID             int64     `json:"id,string"`
+	SessionID      int64     `gorm:"index" json:"session_id,string"`
+	AcctSessionID  string    `gorm:"index" json:"acct_session_id"`
+	Action         string    `gorm:"index" json:"action"`
+	Username       string    `gorm:"index" json:"username"`
+	NasAddr        string    `gorm:"index" json:"nas_addr"`
+	Target         string    `json:"target"`
+	OperatorID     int64     `gorm:"index" json:"operator_id,string"`
+	OperatorName   string    `gorm:"index" json:"operator_name"`
+	OperatorIP     string    `json:"operator_ip"`
+	Success        bool      `gorm:"index" json:"success"`
+	ResponseCode   string    `json:"response_code"`
+	ErrorCause     int       `json:"error_cause"`
+	ErrorCauseText string    `json:"error_cause_text"`
+	Attempts       int       `json:"attempts"`
+	RTTMillis      int64     `json:"rtt_ms"`
+	TimedOut       bool      `gorm:"index" json:"timed_out"`
+	Error          string    `json:"error"`
+	TriggeredAt    time.Time `gorm:"index" json:"triggered_at"`
+	CreatedAt      time.Time `json:"created_at"`
+}
+
+// TableName specifies the CoA session action audit table name.
+func (RadiusSessionActionAudit) TableName() string {
+	return "radius_session_action_audit"
+}
+
 // RadiusAccounting
 // Radius Accounting Recode
 type RadiusAccounting struct {

--- a/internal/domain/tablename_test.go
+++ b/internal/domain/tablename_test.go
@@ -51,6 +51,11 @@ func TestRadiusAccounting_TableName(t *testing.T) {
 	assert.Equal(t, "radius_accounting", model.TableName())
 }
 
+func TestRadiusSessionActionAudit_TableName(t *testing.T) {
+	model := RadiusSessionActionAudit{}
+	assert.Equal(t, "radius_session_action_audit", model.TableName())
+}
+
 // TestAllModelsHaveTableName ensures every model listed in Tables implements TableName
 func TestAllModelsHaveTableName(t *testing.T) {
 	type tableNamer interface {
@@ -83,15 +88,16 @@ func TestTableNameUniqueness(t *testing.T) {
 
 	// Ensure all table names follow snake_case
 	expectedNames := map[string]bool{
-		"sys_config":        true,
-		"sys_opr":           true,
-		"sys_opr_log":       true,
-		"net_node":          true,
-		"net_nas":           true,
-		"radius_profile":    true,
-		"radius_user":       true,
-		"radius_online":     true,
-		"radius_accounting": true,
+		"sys_config":                  true,
+		"sys_opr":                     true,
+		"sys_opr_log":                 true,
+		"net_node":                    true,
+		"net_nas":                     true,
+		"radius_profile":              true,
+		"radius_user":                 true,
+		"radius_online":               true,
+		"radius_session_action_audit": true,
+		"radius_accounting":           true,
 	}
 
 	assert.Equal(t, len(expectedNames), len(tableNames), "Table name count should match")

--- a/internal/domain/tables.go
+++ b/internal/domain/tables.go
@@ -11,6 +11,7 @@ var Tables = []interface{}{
 	// Radius
 	&RadiusAccounting{},
 	&RadiusOnline{},
+	&RadiusSessionActionAudit{},
 	&RadiusProfile{},
 	&RadiusUser{},
 }


### PR DESCRIPTION
## Summary
- implement M2.3 durable audit persistence for operator-triggered dynamic authorization actions
- add `domain.RadiusSessionActionAudit` and include it in global AutoMigrate tables
- persist action/session/result fields for both `POST /sessions/:id/disconnect` and `POST /sessions/:id/coa`
- fail request with `AUDIT_PERSIST_FAILED` when CoA exchange succeeds but audit write fails
- extend adminapi tests to verify audit records for ACK/NAK/timeout outcomes

## Scope Mapping
- Milestone: `M2.3`
- Feature IDs: `TR-F010`, `TR-F022`
- Protocol note: no wire-behavior change to RFC 5176 exchange flow; this PR adds durable backend audit storage only

## Validation
- `go build ./...`
- `go test ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`
