### PR TITLE
feat(radiusd): parse & issue RFC 6911 Framed-IPv6-Address (M3.1)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -28,7 +28,7 @@
 | --- | --- | --- | --- | --- |
 | M1 | EAP-TLS 认证支持 | TR-F004 | P1 | 已交付 |
 | M2 | CoA 动态授权支持 | TR-F010 / TR-F012 / TR-F013 | P1 | 已交付 |
-| M3 | IPv6 能力增强闭环 | TR-F007 / TR-F011 / TR-F015 | P1 | 计划中 |
+| M3 | IPv6 能力增强闭环 | TR-F007 / TR-F011 / TR-F015 | P1 | 进行中 |
 | M4 | Agent 开发体系与质量门禁 | TR-F022 | P2 | 进行中 |
 | M5 | 厂商 VSA 覆盖扩展 | TR-F005 | P2 | 计划中 |
 | M6 | 可观测性与运维增强 | TR-F015 | P3 | 计划中 |
@@ -110,11 +110,12 @@
 - **协议规范**：`docs/rfcs/rfc3162-radius-ipv6.txt`、`rfc4818-ipv6-prefix-delegation.txt`（Delegated-IPv6-Prefix）、`rfc6911-ipv6-access-networks.txt`。
 
 子任务：
-- [ ] M3.1 协议层解析 / 下发 Delegated-IPv6-Prefix 等属性
+- [x] M3.1 协议层解析 / 下发 IPv6 访问属性（计费侧解析 Framed-IPv6-Address(RFC 6911)、修正 Framed/Delegated-IPv6-Prefix 缺省值落库；Access-Accept 下发 Framed-IPv6-Address）
 - [ ] M3.2 数据库字段与迁移（PostgreSQL + SQLite 双兼容）
 - [ ] M3.3 用户 / 会话 / 计费的 IPv6 过滤与展示
 - [ ] M3.4 Dashboard IPv6 维度统计
 - [ ] M3.5 端到端测试与字段一致性校验（`test/integration/`，CI 自动执行）
+- [ ] M3.6 下发 Delegated-IPv6-Prefix / Delegated-IPv6-Prefix-Pool（依赖 M3.2 新增用户/Profile 配置字段；RFC 4818 / RFC 6911，按 RFC 6911 §2.4 与 Framed-IPv6-Pool 区分用途，禁止混用同一字段）
 
 验收口径：IPv6 全链路可查询、可过滤、可审计，双数据库一致；**验收由 `test/integration/` 的 CI 用例背书**。
 

--- a/internal/radiusd/plugins/accounting/handlers/ipv6.go
+++ b/internal/radiusd/plugins/accounting/handlers/ipv6.go
@@ -1,0 +1,30 @@
+package handlers
+
+import (
+	"net"
+
+	"github.com/talkincode/toughradius/v9/pkg/common"
+)
+
+// ipv6PrefixOrNA renders an IPv6 prefix attribute (RFC 3162 Framed-IPv6-Prefix,
+// RFC 4818 Delegated-IPv6-Prefix) as a CIDR string, returning common.NA when the
+// attribute is absent. A nil *net.IPNet stringifies to "<nil>", which is
+// meaningless to persist for later filtering and display, so it is normalized to
+// the project's not-available sentinel.
+func ipv6PrefixOrNA(prefix *net.IPNet) string {
+	if prefix == nil {
+		return common.NA
+	}
+	return prefix.String()
+}
+
+// ipv6AddrOrNA renders an IPv6 host-address attribute (RFC 6911
+// Framed-IPv6-Address) as a string, returning common.NA when the attribute is
+// absent or the unspecified address. A nil net.IP stringifies to "<nil>", which
+// is normalized to the project's not-available sentinel.
+func ipv6AddrOrNA(ip net.IP) string {
+	if len(ip) == 0 || ip.IsUnspecified() {
+		return common.NA
+	}
+	return ip.String()
+}

--- a/internal/radiusd/plugins/accounting/handlers/ipv6_test.go
+++ b/internal/radiusd/plugins/accounting/handlers/ipv6_test.go
@@ -1,0 +1,83 @@
+package handlers
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/talkincode/toughradius/v9/pkg/common"
+	"layeh.com/radius/rfc2866"
+	"layeh.com/radius/rfc3162"
+	"layeh.com/radius/rfc4818"
+	"layeh.com/radius/rfc6911"
+)
+
+// TestStartHandler_Handle_ParsesIPv6Attributes verifies that the Accounting-Start
+// handler decodes the standard IPv6 attributes into the online session and
+// accounting records: Framed-IPv6-Address (RFC 6911), Framed-IPv6-Prefix
+// (RFC 3162), and Delegated-IPv6-Prefix (RFC 4818).
+func TestStartHandler_Handle_ParsesIPv6Attributes(t *testing.T) {
+	sessionRepo := newMockSessionRepo()
+	acctRepo := newMockAccountingRepo()
+	handler := NewStartHandler(sessionRepo, acctRepo)
+
+	ctx := createMockAccountingContext(int(rfc2866.AcctStatusType_Value_Start))
+	pkt := ctx.Request.Packet
+
+	require.NoError(t, rfc6911.FramedIPv6Address_Set(pkt, net.ParseIP("2001:db8::1")))
+	_, framedPrefix, err := net.ParseCIDR("2001:db8:1::/64")
+	require.NoError(t, err)
+	require.NoError(t, rfc3162.FramedIPv6Prefix_Set(pkt, framedPrefix))
+	_, delegatedPrefix, err := net.ParseCIDR("2001:db8:dead::/48")
+	require.NoError(t, err)
+	require.NoError(t, rfc4818.DelegatedIPv6Prefix_Set(pkt, delegatedPrefix))
+
+	require.NoError(t, handler.Handle(ctx))
+
+	online := sessionRepo.sessions["test-session-123"]
+	require.NotNil(t, online)
+	assert.Equal(t, "2001:db8::1", online.FramedIpv6Address)
+	assert.Equal(t, "2001:db8:1::/64", online.FramedIpv6Prefix)
+	assert.Equal(t, "2001:db8:dead::/48", online.DelegatedIpv6Prefix)
+
+	acct := acctRepo.records["test-session-123"]
+	require.NotNil(t, acct)
+	assert.Equal(t, "2001:db8::1", acct.FramedIpv6Address)
+	assert.Equal(t, "2001:db8:1::/64", acct.FramedIpv6Prefix)
+	assert.Equal(t, "2001:db8:dead::/48", acct.DelegatedIpv6Prefix)
+}
+
+// TestStartHandler_Handle_AbsentIPv6AttributesStoreNA verifies that when a NAS
+// omits the IPv6 attributes, the persisted fields fall back to the not-available
+// sentinel instead of the literal "<nil>" that a nil net.IP / *net.IPNet would
+// otherwise stringify to.
+func TestStartHandler_Handle_AbsentIPv6AttributesStoreNA(t *testing.T) {
+	sessionRepo := newMockSessionRepo()
+	acctRepo := newMockAccountingRepo()
+	handler := NewStartHandler(sessionRepo, acctRepo)
+
+	ctx := createMockAccountingContext(int(rfc2866.AcctStatusType_Value_Start))
+	require.NoError(t, handler.Handle(ctx))
+
+	online := sessionRepo.sessions["test-session-123"]
+	require.NotNil(t, online)
+	assert.Equal(t, common.NA, online.FramedIpv6Address)
+	assert.Equal(t, common.NA, online.FramedIpv6Prefix)
+	assert.Equal(t, common.NA, online.DelegatedIpv6Prefix)
+}
+
+// TestIPv6AddrOrNA exercises the host-address normalization helper directly.
+func TestIPv6AddrOrNA(t *testing.T) {
+	assert.Equal(t, common.NA, ipv6AddrOrNA(nil))
+	assert.Equal(t, common.NA, ipv6AddrOrNA(net.IPv6unspecified))
+	assert.Equal(t, "2001:db8::1", ipv6AddrOrNA(net.ParseIP("2001:db8::1")))
+}
+
+// TestIPv6PrefixOrNA exercises the prefix normalization helper directly.
+func TestIPv6PrefixOrNA(t *testing.T) {
+	assert.Equal(t, common.NA, ipv6PrefixOrNA(nil))
+	_, prefix, err := net.ParseCIDR("2001:db8::/32")
+	require.NoError(t, err)
+	assert.Equal(t, "2001:db8::/32", ipv6PrefixOrNA(prefix))
+}

--- a/internal/radiusd/plugins/accounting/handlers/start_handler.go
+++ b/internal/radiusd/plugins/accounting/handlers/start_handler.go
@@ -16,6 +16,7 @@ import (
 	"layeh.com/radius/rfc2869"
 	"layeh.com/radius/rfc3162"
 	"layeh.com/radius/rfc4818"
+	"layeh.com/radius/rfc6911"
 ) // StartHandler Accounting Start handler
 type StartHandler struct {
 	sessionRepo    repository.SessionRepository
@@ -122,9 +123,9 @@ func (h *StartHandler) buildRadiusOnline(r *radius.Request, vr *vendorparserspkg
 		SessionTimeout:      int(rfc2865.SessionTimeout_Get(r.Packet)),
 		FramedIpaddr:        common.IfEmptyStr(rfc2865.FramedIPAddress_Get(r.Packet).String(), common.NA),
 		FramedNetmask:       common.IfEmptyStr(rfc2865.FramedIPNetmask_Get(r.Packet).String(), common.NA),
-		FramedIpv6Address:   common.NA, // Set based on vendor-specific logic
-		FramedIpv6Prefix:    common.IfEmptyStr(rfc3162.FramedIPv6Prefix_Get(r.Packet).String(), common.NA),
-		DelegatedIpv6Prefix: common.IfEmptyStr(rfc4818.DelegatedIPv6Prefix_Get(r.Packet).String(), common.NA),
+		FramedIpv6Address:   ipv6AddrOrNA(rfc6911.FramedIPv6Address_Get(r.Packet)),
+		FramedIpv6Prefix:    ipv6PrefixOrNA(rfc3162.FramedIPv6Prefix_Get(r.Packet)),
+		DelegatedIpv6Prefix: ipv6PrefixOrNA(rfc4818.DelegatedIPv6Prefix_Get(r.Packet)),
 		MacAddr:             common.IfEmptyStr(vr.MacAddr, common.NA),
 		NasPort:             0,
 		NasClass:            common.NA,

--- a/internal/radiusd/plugins/auth/enhancers/default_enhancer.go
+++ b/internal/radiusd/plugins/auth/enhancers/default_enhancer.go
@@ -13,6 +13,7 @@ import (
 	"layeh.com/radius/rfc2865"
 	"layeh.com/radius/rfc2869"
 	"layeh.com/radius/rfc3162"
+	"layeh.com/radius/rfc6911"
 )
 
 // DefaultAcceptEnhancer sets standard RADIUS attributes
@@ -75,6 +76,16 @@ func (e *DefaultAcceptEnhancer) Enhance(ctx context.Context, authCtx *auth.AuthC
 		if _, ipnet, err := net.ParseCIDR(ipv6Prefix); err == nil {
 			_ = rfc3162.FramedIPv6Prefix_Set(response, ipnet) //nolint:errcheck
 		}
+
+		// Set Framed-IPv6-Address (RFC 6911, Section 2.1) when the user has a
+		// single static host address (bare address or an explicit /128). RFC 6911
+		// defines this attribute to assign a complete IPv6 address, which is more
+		// natural for DHCPv6 than the RFC 3162 Framed-Interface-Id +
+		// Framed-IPv6-Prefix split, and permits it to coexist with
+		// Framed-IPv6-Prefix in the same Access-Accept.
+		if ip, ok := singleIPv6Host(user.IpV6Addr); ok {
+			_ = rfc6911.FramedIPv6Address_Set(response, ip) //nolint:errcheck
+		}
 	}
 
 	// Use getter method for IPv6PrefixPool
@@ -98,4 +109,24 @@ func getIntConfig(authCtx *auth.AuthContext, name string, def int64) int64 {
 		}
 	}
 	return def
+}
+
+// singleIPv6Host reports whether value designates a single IPv6 host address and
+// returns the parsed address. It accepts either a bare IPv6 address
+// ("2001:db8::1") or an explicit /128 prefix ("2001:db8::1/128"). It returns
+// ok=false for IPv4 values, multi-host prefixes (for example /64, which are
+// advertised as Framed-IPv6-Prefix instead), and unparseable input.
+func singleIPv6Host(value string) (net.IP, bool) {
+	addr := value
+	if idx := strings.IndexByte(value, '/'); idx >= 0 {
+		if value[idx+1:] != "128" {
+			return nil, false
+		}
+		addr = value[:idx]
+	}
+	ip := net.ParseIP(addr)
+	if ip == nil || ip.To4() != nil {
+		return nil, false
+	}
+	return ip, true
 }

--- a/internal/radiusd/plugins/auth/enhancers/ipv6_test.go
+++ b/internal/radiusd/plugins/auth/enhancers/ipv6_test.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/talkincode/toughradius/v9/internal/domain"
 	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/auth"
 	"layeh.com/radius"
 	"layeh.com/radius/rfc3162"
+	"layeh.com/radius/rfc6911"
 )
 
 // TestDefaultAcceptEnhancer_IPv6Prefix tests IPv6 prefix setting
@@ -83,6 +86,69 @@ func TestDefaultAcceptEnhancer_IPv6Prefix(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestDefaultAcceptEnhancer_FramedIPv6Address verifies that a static single-host
+// IPv6 address is advertised as a Framed-IPv6-Address attribute (RFC 6911),
+// while multi-host prefixes, IPv4, empty, and N/A values are not.
+func TestDefaultAcceptEnhancer_FramedIPv6Address(t *testing.T) {
+	tests := []struct {
+		name       string
+		ipv6Addr   string
+		expectSet  bool
+		expectedIP string
+	}{
+		{name: "bare host address", ipv6Addr: "2001:db8::1", expectSet: true, expectedIP: "2001:db8::1"},
+		{name: "explicit /128 host", ipv6Addr: "2001:db8::2/128", expectSet: true, expectedIP: "2001:db8::2"},
+		{name: "network prefix /64 is not a host", ipv6Addr: "2001:db8::1/64", expectSet: false},
+		{name: "empty", ipv6Addr: "", expectSet: false},
+		{name: "NA value", ipv6Addr: "N/A", expectSet: false},
+		{name: "invalid", ipv6Addr: "not-an-ip", expectSet: false},
+		{name: "ipv4 ignored", ipv6Addr: "192.0.2.1", expectSet: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			enhancer := NewDefaultAcceptEnhancer()
+			response := radius.New(radius.CodeAccessAccept, []byte("secret"))
+			user := &domain.RadiusUser{IpV6Addr: tt.ipv6Addr}
+			authCtx := &auth.AuthContext{Response: response, User: user}
+
+			require.NoError(t, enhancer.Enhance(context.Background(), authCtx))
+
+			ip := rfc6911.FramedIPv6Address_Get(response)
+			if tt.expectSet {
+				require.NotNil(t, ip)
+				assert.Equal(t, tt.expectedIP, ip.String())
+			} else {
+				assert.Nil(t, ip)
+			}
+		})
+	}
+}
+
+// TestSingleIPv6Host exercises the host-address classifier directly.
+func TestSingleIPv6Host(t *testing.T) {
+	tests := []struct {
+		value   string
+		wantOK  bool
+		wantStr string
+	}{
+		{"2001:db8::1", true, "2001:db8::1"},
+		{"2001:db8::1/128", true, "2001:db8::1"},
+		{"2001:db8::/64", false, ""},
+		{"192.0.2.1", false, ""},
+		{"192.0.2.1/128", false, ""},
+		{"not-an-ip", false, ""},
+		{"", false, ""},
+	}
+	for _, tt := range tests {
+		ip, ok := singleIPv6Host(tt.value)
+		assert.Equal(t, tt.wantOK, ok, "value=%q", tt.value)
+		if tt.wantOK {
+			assert.Equal(t, tt.wantStr, ip.String(), "value=%q", tt.value)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Delivers **M3.1** of the IPv6 closure milestone (**M3**, P1): the protocol layer now parses the standard IPv6 access attributes from accounting and issues a host IPv6 address in Access-Accept, using the existing data model (no DB migration).

This anchors on `TR-F007` / `TR-F011` and cites RFC 6911 / RFC 3162 / RFC 4818.

## What changed

### Accounting (parse) — `start_handler.go`, `ipv6.go`
- **Decode `Framed-IPv6-Address` (RFC 6911, attr 168)** into the existing `radius_online` / `radius_accounting` columns. It was previously hardcoded to `N/A` (`// Set based on vendor-specific logic`).
- **Fix absent-value persistence**: `Framed-IPv6-Prefix` (RFC 3162) and `Delegated-IPv6-Prefix` (RFC 4818) were stored via `IfEmptyStr(getter.String(), NA)`, but a nil `*net.IPNet` / `net.IP` stringifies to the literal `"<nil>"` (non-empty), so absent attributes were persisted as `"<nil>"` rather than `N/A`. New `ipv6PrefixOrNA` / `ipv6AddrOrNA` helpers normalize this, keeping the columns clean for the M3.3 filter/display work.

### Authorization (issue) — `default_enhancer.go`
- **Advertise `Framed-IPv6-Address` (RFC 6911, §2.1)** when the user has a single static host address (bare or explicit `/128`). RFC 6911 §2.1 defines this attribute to assign a complete IPv6 address (more natural for DHCPv6 than the RFC 3162 Framed-Interface-Id + Framed-IPv6-Prefix split) and permits it to coexist with `Framed-IPv6-Prefix` in the same Access-Accept. Multi-host prefixes (e.g. `/64`), IPv4, empty and `N/A` are correctly ignored.

### Why static Delegated-IPv6-Prefix issuance is deferred (split to M3.6)
Issuing a static `Delegated-IPv6-Prefix` (RFC 4818) or `Delegated-IPv6-Prefix-Pool` (RFC 6911 #171) needs a **dedicated config field**: there is no such field on the user/profile today, and **RFC 6911 §2.4 explicitly forbids conflating the delegated-prefix pool with `Framed-IPv6-Pool`** (DHCPv6-PD vs SLAAC). Reusing the single `IPv6PrefixPool` field for both would violate the spec. The accounting parse for Delegated-IPv6-Prefix already exists (and is hardened here); the **issuance** is split out as new subtask **M3.6**, blocked on the **M3.2** migration that adds the config field.

## Roadmap grooming (in this PR)
- `M3.1` checked off with wording refined to the delivered protocol-layer scope.
- New `M3.6` added for Delegated-IPv6-Prefix / -Pool issuance (depends on M3.2; RFC 4818/6911, no pool conflation).
- `M3` milestone status `计划中` → `进行中`.

## Tests (CI-executable, `go test -short ./...`)
- `internal/radiusd/plugins/accounting/handlers/ipv6_test.go` — parse of all three IPv6 attributes into online + accounting records; absent attributes → `N/A`; helper unit tests.
- `internal/radiusd/plugins/auth/enhancers/ipv6_test.go` — `Framed-IPv6-Address` issuance matrix (host / `/128` / `/64` prefix / IPv4 / empty / `N/A`) + `singleIPv6Host` classifier.

## Quality gates
- `go build ./...` ✅
- `go test -short ./...` ✅
- `golangci-lint` v2.12.2 on touched packages ✅ 0 issues

Refs: `TR-F007`, `TR-F011`, milestone **M3.1**
Specs: `docs/rfcs/rfc6911-ipv6-access-networks.txt` (§2.1, §2.4), `rfc3162-radius-ipv6.txt`, `rfc4818-ipv6-prefix-delegation.txt`
