### PR TITLE
feat(domain): Delegated-IPv6-Prefix schema & migration (M3.2)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -111,7 +111,7 @@
 
 子任务：
 - [x] M3.1 协议层解析 / 下发 IPv6 访问属性（计费侧解析 Framed-IPv6-Address(RFC 6911)、修正 Framed/Delegated-IPv6-Prefix 缺省值落库；Access-Accept 下发 Framed-IPv6-Address）
-- [ ] M3.2 数据库字段与迁移（PostgreSQL + SQLite 双兼容）
+- [x] M3.2 数据库字段与迁移（PostgreSQL + SQLite 双兼容）：新增 `RadiusUser.DelegatedIpv6Prefix`（静态 RFC 4818 #123，按用户）、`RadiusUser.DelegatedIpv6PrefixPool` 与 `RadiusProfile.DelegatedIpv6PrefixPool`（RFC 6911 #171 DHCPv6-PD 池，按 §2.4 与 Framed-IPv6-Pool 区分）；GORM AutoMigrate 双库建列，Admin API 用户/套餐增改可持久化并支持 Profile 继承
 - [ ] M3.3 用户 / 会话 / 计费的 IPv6 过滤与展示
 - [ ] M3.4 Dashboard IPv6 维度统计
 - [ ] M3.5 端到端测试与字段一致性校验（`test/integration/`，CI 自动执行）

--- a/internal/adminapi/profiles.go
+++ b/internal/adminapi/profiles.go
@@ -120,31 +120,33 @@ func GetProfile(c echo.Context) error {
 
 // ProfileRequest represents the mixed-type JSON sent from the frontend
 type ProfileRequest struct {
-	Name           string      `json:"name" validate:"required,min=1,max=100"`
-	Status         interface{} `json:"status"` // Can be string or boolean
-	AddrPool       string      `json:"addr_pool" validate:"omitempty,addrpool"`
-	ActiveNum      int         `json:"active_num" validate:"gte=0,lte=100"`
-	UpRate         int         `json:"up_rate" validate:"gte=0,lte=10000000"`
-	DownRate       int         `json:"down_rate" validate:"gte=0,lte=10000000"`
-	Domain         string      `json:"domain" validate:"omitempty,max=50"`
-	IPv6PrefixPool string      `json:"ipv6_prefix_pool" validate:"omitempty"`
-	BindMac        interface{} `json:"bind_mac"`  // Can be int or boolean
-	BindVlan       interface{} `json:"bind_vlan"` // Can be int or boolean
-	Remark         string      `json:"remark" validate:"omitempty,max=500"`
-	NodeId         interface{} `json:"node_id"` // Can be int64 or string
+	Name                    string      `json:"name" validate:"required,min=1,max=100"`
+	Status                  interface{} `json:"status"` // Can be string or boolean
+	AddrPool                string      `json:"addr_pool" validate:"omitempty,addrpool"`
+	ActiveNum               int         `json:"active_num" validate:"gte=0,lte=100"`
+	UpRate                  int         `json:"up_rate" validate:"gte=0,lte=10000000"`
+	DownRate                int         `json:"down_rate" validate:"gte=0,lte=10000000"`
+	Domain                  string      `json:"domain" validate:"omitempty,max=50"`
+	IPv6PrefixPool          string      `json:"ipv6_prefix_pool" validate:"omitempty"`
+	DelegatedIpv6PrefixPool string      `json:"delegated_ipv6_prefix_pool" validate:"omitempty,max=100"` // DHCPv6-PD pool (RFC 6911 §2.4)
+	BindMac                 interface{} `json:"bind_mac"`                                                // Can be int or boolean
+	BindVlan                interface{} `json:"bind_vlan"`                                               // Can be int or boolean
+	Remark                  string      `json:"remark" validate:"omitempty,max=500"`
+	NodeId                  interface{} `json:"node_id"` // Can be int64 or string
 }
 
 // toRadiusProfile Convert ProfileRequest Convert to RadiusProfile
 func (pr *ProfileRequest) toRadiusProfile() *domain.RadiusProfile {
 	profile := &domain.RadiusProfile{
-		Name:           pr.Name,
-		AddrPool:       pr.AddrPool,
-		ActiveNum:      pr.ActiveNum,
-		UpRate:         pr.UpRate,
-		DownRate:       pr.DownRate,
-		Domain:         pr.Domain,
-		IPv6PrefixPool: pr.IPv6PrefixPool,
-		Remark:         pr.Remark,
+		Name:                    pr.Name,
+		AddrPool:                pr.AddrPool,
+		ActiveNum:               pr.ActiveNum,
+		UpRate:                  pr.UpRate,
+		DownRate:                pr.DownRate,
+		Domain:                  pr.Domain,
+		IPv6PrefixPool:          pr.IPv6PrefixPool,
+		DelegatedIpv6PrefixPool: pr.DelegatedIpv6PrefixPool,
+		Remark:                  pr.Remark,
 	}
 
 	// Handle status field: boolean true -> "enabled", false -> "disabled", string remains unchanged
@@ -199,31 +201,33 @@ func (pr *ProfileRequest) toRadiusProfile() *domain.RadiusProfile {
 
 // ProfileUpdateRequest represents the mixed-type JSON sent from the frontend for updates
 type ProfileUpdateRequest struct {
-	Name           string      `json:"name" validate:"omitempty,min=1,max=100"`
-	Status         interface{} `json:"status"` // Can be string or boolean
-	AddrPool       string      `json:"addr_pool" validate:"omitempty,addrpool"`
-	ActiveNum      int         `json:"active_num" validate:"gte=0,lte=100"`
-	UpRate         int         `json:"up_rate" validate:"gte=0,lte=10000000"`
-	DownRate       int         `json:"down_rate" validate:"gte=0,lte=10000000"`
-	Domain         string      `json:"domain" validate:"omitempty,max=50"`
-	IPv6PrefixPool string      `json:"ipv6_prefix_pool" validate:"omitempty"`
-	BindMac        interface{} `json:"bind_mac"`  // Can be int or boolean
-	BindVlan       interface{} `json:"bind_vlan"` // Can be int or boolean
-	Remark         string      `json:"remark" validate:"omitempty,max=500"`
-	NodeId         interface{} `json:"node_id"` // Can be int64 or string
+	Name                    string      `json:"name" validate:"omitempty,min=1,max=100"`
+	Status                  interface{} `json:"status"` // Can be string or boolean
+	AddrPool                string      `json:"addr_pool" validate:"omitempty,addrpool"`
+	ActiveNum               int         `json:"active_num" validate:"gte=0,lte=100"`
+	UpRate                  int         `json:"up_rate" validate:"gte=0,lte=10000000"`
+	DownRate                int         `json:"down_rate" validate:"gte=0,lte=10000000"`
+	Domain                  string      `json:"domain" validate:"omitempty,max=50"`
+	IPv6PrefixPool          string      `json:"ipv6_prefix_pool" validate:"omitempty"`
+	DelegatedIpv6PrefixPool string      `json:"delegated_ipv6_prefix_pool" validate:"omitempty,max=100"` // DHCPv6-PD pool (RFC 6911 §2.4)
+	BindMac                 interface{} `json:"bind_mac"`                                                // Can be int or boolean
+	BindVlan                interface{} `json:"bind_vlan"`                                               // Can be int or boolean
+	Remark                  string      `json:"remark" validate:"omitempty,max=500"`
+	NodeId                  interface{} `json:"node_id"` // Can be int64 or string
 }
 
 // toRadiusProfile Convert ProfileUpdateRequest Convert to RadiusProfile
 func (pr *ProfileUpdateRequest) toRadiusProfile() *domain.RadiusProfile {
 	profile := &domain.RadiusProfile{
-		Name:           pr.Name,
-		AddrPool:       pr.AddrPool,
-		ActiveNum:      pr.ActiveNum,
-		UpRate:         pr.UpRate,
-		DownRate:       pr.DownRate,
-		Domain:         pr.Domain,
-		IPv6PrefixPool: pr.IPv6PrefixPool,
-		Remark:         pr.Remark,
+		Name:                    pr.Name,
+		AddrPool:                pr.AddrPool,
+		ActiveNum:               pr.ActiveNum,
+		UpRate:                  pr.UpRate,
+		DownRate:                pr.DownRate,
+		Domain:                  pr.Domain,
+		IPv6PrefixPool:          pr.IPv6PrefixPool,
+		DelegatedIpv6PrefixPool: pr.DelegatedIpv6PrefixPool,
+		Remark:                  pr.Remark,
 	}
 
 	// Handle status field: boolean true -> "enabled", false -> "disabled", string remains unchanged
@@ -379,6 +383,9 @@ func UpdateProfile(c echo.Context) error {
 	}
 	if updateData.IPv6PrefixPool != "" {
 		updates["ipv6_prefix_pool"] = updateData.IPv6PrefixPool
+	}
+	if updateData.DelegatedIpv6PrefixPool != "" {
+		updates["delegated_ipv6_prefix_pool"] = updateData.DelegatedIpv6PrefixPool
 	}
 	if updateData.BindMac >= 0 {
 		updates["bind_mac"] = updateData.BindMac

--- a/internal/adminapi/profiles_test.go
+++ b/internal/adminapi/profiles_test.go
@@ -270,6 +270,19 @@ func TestCreateProfile(t *testing.T) {
 			},
 		},
 		{
+			name: "Create profile with delegated IPv6 prefix pool",
+			requestBody: `{
+				"name": "pd-profile",
+				"status": "enabled",
+				"delegated_ipv6_prefix_pool": "pd-pool-profile"
+			}`,
+			expectedStatus: http.StatusOK,
+			checkResult: func(t *testing.T, profile *domain.RadiusProfile) {
+				assert.Equal(t, "pd-profile", profile.Name)
+				assert.Equal(t, "pd-pool-profile", profile.DelegatedIpv6PrefixPool)
+			},
+		},
+		{
 			name: "Missing status on create - use default",
 			requestBody: `{
 				"name": "default-status-profile",

--- a/internal/adminapi/users.go
+++ b/internal/adminapi/users.go
@@ -40,26 +40,26 @@ func escapeUserLikePattern(s string) string {
 
 // UserRequest Used to handle user data sent from frontend
 type UserRequest struct {
-	NodeID     interface{} `json:"node_id"`                                     // Can be int64 or string
-	ProfileID  interface{} `json:"profile_id" validate:"required"`              // Can be int64 or string
-	LegacyProfileID interface{} `json:"profileid"`                              // Legacy fallback field from older clients, used when profile_id is missing
-	Realname   string      `json:"realname" validate:"omitempty,max=100"`       // Real name
-	Email      string      `json:"email" validate:"omitempty,email,max=100"`    // Email
-	Mobile     string      `json:"mobile" validate:"omitempty,max=20"`          // Mobile number (optional, max 20 characters)
-	Address    string      `json:"address" validate:"omitempty,max=255"`        // addresses
-	Username   string      `json:"username" validate:"required,min=3,max=50"`   // Username
-	Password   string      `json:"password" validate:"omitempty,min=6,max=128"` // Password
-	AddrPool   string      `json:"addr_pool" validate:"omitempty,max=50"`       // Address pool
-	Vlanid1    int         `json:"vlanid1" validate:"gte=0,lte=4096"`           // VLAN ID 1
-	Vlanid2    int         `json:"vlanid2" validate:"gte=0,lte=4096"`           // VLAN ID 2
-	IpAddr     string      `json:"ip_addr" validate:"omitempty,ipv4"`           // IPv4addresses
-	Ipv6Addr   string      `json:"ipv6_addr" validate:"omitempty"`              // IPv6addresses
-	MacAddr    string      `json:"mac_addr" validate:"omitempty,mac"`           // MACaddresses
-	BindVlan   interface{} `json:"bind_vlan"`                                   // Can be int or boolean
-	BindMac    interface{} `json:"bind_mac"`                                    // Can be int or boolean
-	ExpireTime string      `json:"expire_time" validate:"omitempty"`            // Expiration time
-	Status     interface{} `json:"status"`                                      // Can be string or boolean
-	Remark     string      `json:"remark" validate:"omitempty,max=500"`         // Remark
+	NodeID          interface{} `json:"node_id"`                                     // Can be int64 or string
+	ProfileID       interface{} `json:"profile_id" validate:"required"`              // Can be int64 or string
+	LegacyProfileID interface{} `json:"profileid"`                                   // Legacy fallback field from older clients, used when profile_id is missing
+	Realname        string      `json:"realname" validate:"omitempty,max=100"`       // Real name
+	Email           string      `json:"email" validate:"omitempty,email,max=100"`    // Email
+	Mobile          string      `json:"mobile" validate:"omitempty,max=20"`          // Mobile number (optional, max 20 characters)
+	Address         string      `json:"address" validate:"omitempty,max=255"`        // addresses
+	Username        string      `json:"username" validate:"required,min=3,max=50"`   // Username
+	Password        string      `json:"password" validate:"omitempty,min=6,max=128"` // Password
+	AddrPool        string      `json:"addr_pool" validate:"omitempty,max=50"`       // Address pool
+	Vlanid1         int         `json:"vlanid1" validate:"gte=0,lte=4096"`           // VLAN ID 1
+	Vlanid2         int         `json:"vlanid2" validate:"gte=0,lte=4096"`           // VLAN ID 2
+	IpAddr          string      `json:"ip_addr" validate:"omitempty,ipv4"`           // IPv4addresses
+	Ipv6Addr        string      `json:"ipv6_addr" validate:"omitempty"`              // IPv6addresses
+	MacAddr         string      `json:"mac_addr" validate:"omitempty,mac"`           // MACaddresses
+	BindVlan        interface{} `json:"bind_vlan"`                                   // Can be int or boolean
+	BindMac         interface{} `json:"bind_mac"`                                    // Can be int or boolean
+	ExpireTime      string      `json:"expire_time" validate:"omitempty"`            // Expiration time
+	Status          interface{} `json:"status"`                                      // Can be string or boolean
+	Remark          string      `json:"remark" validate:"omitempty,max=500"`         // Remark
 }
 
 // toRadiusUser Convert UserRequest Convert to RadiusUser
@@ -140,48 +140,52 @@ func (ur *UserRequest) toRadiusUser() *domain.RadiusUser {
 
 // UserUpdateRequest Used to handle user update data
 type UserUpdateRequest struct {
-	NodeID          interface{} `json:"node_id"`                                       // Can be int64 or string
-	ProfileID       interface{} `json:"profile_id"`                                    // Can be int64 or string
-	LegacyProfileID interface{} `json:"profileid"`                                     // Legacy fallback field from older clients, used when profile_id is missing
-	Realname        string      `json:"realname" validate:"omitempty,max=100"`         // Real name
-	Email           string      `json:"email" validate:"omitempty,email,max=100"`      // Email
-	Mobile          string      `json:"mobile" validate:"omitempty,max=20"`            // Mobile number (optional, max 20 characters)
-	Address         string      `json:"address" validate:"omitempty,max=255"`          // addresses
-	Username        string      `json:"username" validate:"omitempty,min=3,max=50"`    // Username
-	Password        string      `json:"password" validate:"omitempty,min=6,max=128"`   // Password
-	AddrPool        string      `json:"addr_pool" validate:"omitempty,max=50"`         // Address pool
-	Vlanid1         int         `json:"vlanid1" validate:"gte=0,lte=4096"`             // VLAN ID 1
-	Vlanid2         int         `json:"vlanid2" validate:"gte=0,lte=4096"`             // VLAN ID 2
-	IpAddr          string      `json:"ip_addr" validate:"omitempty,ipv4"`             // IPv4addresses
-	Ipv6Addr        string      `json:"ipv6_addr" validate:"omitempty"`                // IPv6addresses
-	MacAddr         string      `json:"mac_addr" validate:"omitempty,mac"`             // MACaddresses
-	BindVlan        interface{} `json:"bind_vlan"`                                     // Can be int or boolean
-	BindMac         interface{} `json:"bind_mac"`                                      // Can be int or boolean
-	ExpireTime      string      `json:"expire_time" validate:"omitempty"`              // Expiration time
-	Status          interface{} `json:"status"`                                        // Can be string or boolean
-	Remark          string      `json:"remark" validate:"omitempty,max=500"`           // Remark
-	IPv6PrefixPool  string      `json:"ipv6_prefix_pool" validate:"omitempty,max=100"` // IPv6 prefix pool name
-	Domain          string      `json:"domain" validate:"omitempty,max=100"`           // User domain
-	ProfileLinkMode int         `json:"profile_link_mode" validate:"gte=0,lte=1"`      // Profile link mode (0=static, 1=dynamic)
+	NodeID                  interface{} `json:"node_id"`                                                 // Can be int64 or string
+	ProfileID               interface{} `json:"profile_id"`                                              // Can be int64 or string
+	LegacyProfileID         interface{} `json:"profileid"`                                               // Legacy fallback field from older clients, used when profile_id is missing
+	Realname                string      `json:"realname" validate:"omitempty,max=100"`                   // Real name
+	Email                   string      `json:"email" validate:"omitempty,email,max=100"`                // Email
+	Mobile                  string      `json:"mobile" validate:"omitempty,max=20"`                      // Mobile number (optional, max 20 characters)
+	Address                 string      `json:"address" validate:"omitempty,max=255"`                    // addresses
+	Username                string      `json:"username" validate:"omitempty,min=3,max=50"`              // Username
+	Password                string      `json:"password" validate:"omitempty,min=6,max=128"`             // Password
+	AddrPool                string      `json:"addr_pool" validate:"omitempty,max=50"`                   // Address pool
+	Vlanid1                 int         `json:"vlanid1" validate:"gte=0,lte=4096"`                       // VLAN ID 1
+	Vlanid2                 int         `json:"vlanid2" validate:"gte=0,lte=4096"`                       // VLAN ID 2
+	IpAddr                  string      `json:"ip_addr" validate:"omitempty,ipv4"`                       // IPv4addresses
+	Ipv6Addr                string      `json:"ipv6_addr" validate:"omitempty"`                          // IPv6addresses
+	MacAddr                 string      `json:"mac_addr" validate:"omitempty,mac"`                       // MACaddresses
+	BindVlan                interface{} `json:"bind_vlan"`                                               // Can be int or boolean
+	BindMac                 interface{} `json:"bind_mac"`                                                // Can be int or boolean
+	ExpireTime              string      `json:"expire_time" validate:"omitempty"`                        // Expiration time
+	Status                  interface{} `json:"status"`                                                  // Can be string or boolean
+	Remark                  string      `json:"remark" validate:"omitempty,max=500"`                     // Remark
+	IPv6PrefixPool          string      `json:"ipv6_prefix_pool" validate:"omitempty,max=100"`           // IPv6 prefix pool name
+	DelegatedIpv6Prefix     string      `json:"delegated_ipv6_prefix" validate:"omitempty,max=100"`      // Static Delegated-IPv6-Prefix (RFC 4818)
+	DelegatedIpv6PrefixPool string      `json:"delegated_ipv6_prefix_pool" validate:"omitempty,max=100"` // Delegated-IPv6-Prefix-Pool (RFC 6911 §2.4)
+	Domain                  string      `json:"domain" validate:"omitempty,max=100"`                     // User domain
+	ProfileLinkMode         int         `json:"profile_link_mode" validate:"gte=0,lte=1"`                // Profile link mode (0=static, 1=dynamic)
 }
 
 // toRadiusUser Convert UserUpdateRequest Convert to RadiusUser
 func (ur *UserUpdateRequest) toRadiusUser() *domain.RadiusUser {
 	user := &domain.RadiusUser{
-		Realname:        ur.Realname,
-		Mobile:          ur.Mobile,
-		Username:        strings.TrimSpace(ur.Username),
-		Password:        ur.Password,
-		AddrPool:        ur.AddrPool,
-		Vlanid1:         ur.Vlanid1,
-		Vlanid2:         ur.Vlanid2,
-		IpAddr:          ur.IpAddr,
-		IpV6Addr:        ur.Ipv6Addr,
-		IPv6PrefixPool:  ur.IPv6PrefixPool,
-		MacAddr:         ur.MacAddr,
-		Domain:          ur.Domain,
-		ProfileLinkMode: ur.ProfileLinkMode,
-		Remark:          ur.Remark,
+		Realname:                ur.Realname,
+		Mobile:                  ur.Mobile,
+		Username:                strings.TrimSpace(ur.Username),
+		Password:                ur.Password,
+		AddrPool:                ur.AddrPool,
+		Vlanid1:                 ur.Vlanid1,
+		Vlanid2:                 ur.Vlanid2,
+		IpAddr:                  ur.IpAddr,
+		IpV6Addr:                ur.Ipv6Addr,
+		IPv6PrefixPool:          ur.IPv6PrefixPool,
+		DelegatedIpv6Prefix:     ur.DelegatedIpv6Prefix,
+		DelegatedIpv6PrefixPool: ur.DelegatedIpv6PrefixPool,
+		MacAddr:                 ur.MacAddr,
+		Domain:                  ur.Domain,
+		ProfileLinkMode:         ur.ProfileLinkMode,
+		Remark:                  ur.Remark,
 	}
 
 	// Handle profile_id
@@ -375,6 +379,7 @@ func createRadiusUser(c echo.Context) error {
 	user.DownRate = profile.DownRate
 	user.Domain = common.If(user.Domain != "", user.Domain, profile.Domain).(string)
 	user.IPv6PrefixPool = common.If(user.IPv6PrefixPool != "", user.IPv6PrefixPool, profile.IPv6PrefixPool).(string)
+	user.DelegatedIpv6PrefixPool = common.If(user.DelegatedIpv6PrefixPool != "", user.DelegatedIpv6PrefixPool, profile.DelegatedIpv6PrefixPool).(string)
 	user.BindMac = common.If(user.BindMac > 0, user.BindMac, profile.BindMac).(int)
 	user.BindVlan = common.If(user.BindVlan > 0, user.BindVlan, profile.BindVlan).(int)
 	// Default to static mode (snapshot behavior)
@@ -453,6 +458,7 @@ func updateRadiusUser(c echo.Context) error {
 		updates["addr_pool"] = profile.AddrPool
 		updates["domain"] = profile.Domain
 		updates["ipv6_prefix_pool"] = profile.IPv6PrefixPool
+		updates["delegated_ipv6_prefix_pool"] = profile.DelegatedIpv6PrefixPool
 		updates["bind_mac"] = profile.BindMac
 		updates["bind_vlan"] = profile.BindVlan
 
@@ -493,6 +499,12 @@ func updateRadiusUser(c echo.Context) error {
 	}
 	if updateData.IPv6PrefixPool != "" {
 		updates["ipv6_prefix_pool"] = updateData.IPv6PrefixPool
+	}
+	if updateData.DelegatedIpv6Prefix != "" {
+		updates["delegated_ipv6_prefix"] = updateData.DelegatedIpv6Prefix
+	}
+	if updateData.DelegatedIpv6PrefixPool != "" {
+		updates["delegated_ipv6_prefix_pool"] = updateData.DelegatedIpv6PrefixPool
 	}
 	if updateData.MacAddr != "" {
 		updates["mac_addr"] = updateData.MacAddr
@@ -546,6 +558,9 @@ func updateRadiusUser(c echo.Context) error {
 				}
 				if user.IPv6PrefixPool == "" || user.IPv6PrefixPool == "NA" {
 					updates["ipv6_prefix_pool"] = profile.IPv6PrefixPool
+				}
+				if user.DelegatedIpv6PrefixPool == "" || user.DelegatedIpv6PrefixPool == "NA" {
+					updates["delegated_ipv6_prefix_pool"] = profile.DelegatedIpv6PrefixPool
 				}
 				if user.BindMac == 0 && user.MacAddr == "" {
 					updates["bind_mac"] = profile.BindMac

--- a/internal/adminapi/users_test.go
+++ b/internal/adminapi/users_test.go
@@ -644,6 +644,19 @@ func TestUpdateUser(t *testing.T) {
 				assert.Equal(t, 1, u.BindVlan)        // true -> 1
 			},
 		},
+		{
+			name:   "Delegated IPv6 prefix and pool persist",
+			userID: fmt.Sprintf("%d", user.ID),
+			requestBody: `{
+				"delegated_ipv6_prefix": "2001:db8:abcd::/48",
+				"delegated_ipv6_prefix_pool": "pd-pool-x"
+			}`,
+			expectedStatus: http.StatusOK,
+			checkResult: func(t *testing.T, u *domain.RadiusUser) {
+				assert.Equal(t, "2001:db8:abcd::/48", u.DelegatedIpv6Prefix)
+				assert.Equal(t, "pd-pool-x", u.DelegatedIpv6PrefixPool)
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/app/ipv6_migration_test.go
+++ b/internal/app/ipv6_migration_test.go
@@ -1,0 +1,45 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/talkincode/toughradius/v9/internal/domain"
+	"github.com/talkincode/toughradius/v9/pkg/common"
+)
+
+// TestMigrateDelegatedIPv6Columns verifies that AutoMigrate provisions the
+// Delegated-IPv6-Prefix columns (M3.2) on both the user and profile tables. The
+// in-memory backend exercises the SQLite path; the PostgreSQL path is covered by
+// the integration harness, which runs the same AutoMigrate at startup.
+func TestMigrateDelegatedIPv6Columns(t *testing.T) {
+	app := newTestApplication(t)
+	m := app.gormDB.Migrator()
+
+	assert.True(t, m.HasColumn(&domain.RadiusUser{}, "DelegatedIpv6Prefix"),
+		"radius_user.delegated_ipv6_prefix should exist after migration")
+	assert.True(t, m.HasColumn(&domain.RadiusUser{}, "DelegatedIpv6PrefixPool"),
+		"radius_user.delegated_ipv6_prefix_pool should exist after migration")
+	assert.True(t, m.HasColumn(&domain.RadiusProfile{}, "DelegatedIpv6PrefixPool"),
+		"radius_profile.delegated_ipv6_prefix_pool should exist after migration")
+}
+
+// TestDelegatedIPv6RoundTrip confirms the new columns persist and reload intact,
+// proving the migration produces usable storage rather than just a schema entry.
+func TestDelegatedIPv6RoundTrip(t *testing.T) {
+	app := newTestApplication(t)
+
+	user := &domain.RadiusUser{
+		ID:                      common.UUIDint64(),
+		Username:                "ipv6-delegated-user",
+		DelegatedIpv6Prefix:     "2001:db8:1234::/48",
+		DelegatedIpv6PrefixPool: "pd-pool-a",
+	}
+	require.NoError(t, app.gormDB.Create(user).Error)
+
+	var got domain.RadiusUser
+	require.NoError(t, app.gormDB.Where("username = ?", "ipv6-delegated-user").First(&got).Error)
+	assert.Equal(t, "2001:db8:1234::/48", got.DelegatedIpv6Prefix)
+	assert.Equal(t, "pd-pool-a", got.DelegatedIpv6PrefixPool)
+}

--- a/internal/domain/radius.go
+++ b/internal/domain/radius.go
@@ -8,21 +8,26 @@ import (
 
 // RadiusProfile RADIUS billing profile
 type RadiusProfile struct {
-	ID             int64     `json:"id,string" form:"id"`                      // Primary key ID
-	NodeId         int64     `json:"node_id,string" form:"node_id"`            // Node ID
-	Name           string    `json:"name" form:"name"`                         // Profile name
-	Status         string    `gorm:"index" json:"status" form:"status"`        // Profile status: 0=disabled 1=enabled
-	AddrPool       string    `json:"addr_pool" form:"addr_pool"`               // Address pool
-	ActiveNum      int       `json:"active_num" form:"active_num"`             // Concurrent sessions
-	UpRate         int       `json:"up_rate" form:"up_rate"`                   // Upload rate in Kb
-	DownRate       int       `json:"down_rate" form:"down_rate"`               // Download rate in Kb
-	Domain         string    `json:"domain" form:"domain"`                     // Domain, corresponds to NAS device domain attribute, e.g., Huawei domain_code
-	IPv6PrefixPool string    `json:"ipv6_prefix_pool" form:"ipv6_prefix_pool"` // IPv6 prefix pool name for NAS-side allocation
-	BindMac        int       `json:"bind_mac" form:"bind_mac"`                 // Bind MAC
-	BindVlan       int       `json:"bind_vlan" form:"bind_vlan"`               // Bind VLAN
-	Remark         string    `json:"remark" form:"remark"`                     // Remark
-	CreatedAt      time.Time `json:"created_at" form:"created_at"`
-	UpdatedAt      time.Time `json:"updated_at" form:"updated_at"`
+	ID             int64  `json:"id,string" form:"id"`                      // Primary key ID
+	NodeId         int64  `json:"node_id,string" form:"node_id"`            // Node ID
+	Name           string `json:"name" form:"name"`                         // Profile name
+	Status         string `gorm:"index" json:"status" form:"status"`        // Profile status: 0=disabled 1=enabled
+	AddrPool       string `json:"addr_pool" form:"addr_pool"`               // Address pool
+	ActiveNum      int    `json:"active_num" form:"active_num"`             // Concurrent sessions
+	UpRate         int    `json:"up_rate" form:"up_rate"`                   // Upload rate in Kb
+	DownRate       int    `json:"down_rate" form:"down_rate"`               // Download rate in Kb
+	Domain         string `json:"domain" form:"domain"`                     // Domain, corresponds to NAS device domain attribute, e.g., Huawei domain_code
+	IPv6PrefixPool string `json:"ipv6_prefix_pool" form:"ipv6_prefix_pool"` // IPv6 prefix pool name for NAS-side allocation
+	// DelegatedIpv6PrefixPool names the DHCPv6 Prefix-Delegation pool the NAS uses
+	// to allocate a Delegated-IPv6-Prefix (RFC 6911 Delegated-IPv6-Prefix-Pool,
+	// attribute 171). Per RFC 6911 §2.4 it is distinct from IPv6PrefixPool
+	// (Framed-IPv6-Pool, used for SLAAC) and must not reuse the same value.
+	DelegatedIpv6PrefixPool string    `json:"delegated_ipv6_prefix_pool" form:"delegated_ipv6_prefix_pool"`
+	BindMac                 int       `json:"bind_mac" form:"bind_mac"`   // Bind MAC
+	BindVlan                int       `json:"bind_vlan" form:"bind_vlan"` // Bind VLAN
+	Remark                  string    `json:"remark" form:"remark"`       // Remark
+	CreatedAt               time.Time `json:"created_at" form:"created_at"`
+	UpdatedAt               time.Time `json:"updated_at" form:"updated_at"`
 }
 
 // TableName Specify table name
@@ -32,36 +37,46 @@ func (RadiusProfile) TableName() string {
 
 // RadiusUser RADIUS Authentication account
 type RadiusUser struct {
-	ID              int64     `json:"id,string" form:"id"`                              // Primary key ID
-	NodeId          int64     `json:"node_id,string" form:"node_id"`                    // Node ID
-	ProfileId       int64     `gorm:"index" json:"profile_id,string" form:"profile_id"` // RADIUS profile ID
-	Realname        string    `json:"realname" form:"realname"`                         // Contact name
-	Email           string    `json:"email" form:"email"`                               // Email address
-	Mobile          string    `json:"mobile" form:"mobile"`                             // Contact phone
-	Address         string    `json:"address" form:"address"`                           // Contact address
-	Username        string    `json:"username" gorm:"uniqueIndex" form:"username"`      // Account name
-	Password        string    `json:"password" form:"password"`                         // Password
-	AddrPool        string    `json:"addr_pool" form:"addr_pool"`                       // Address pool
-	ActiveNum       int       `gorm:"index" json:"active_num" form:"active_num"`        // Concurrent sessions
-	UpRate          int       `json:"up_rate" form:"up_rate"`                           // Upload rate
-	DownRate        int       `json:"down_rate" form:"down_rate"`                       // Download rate
-	Vlanid1         int       `json:"vlanid1" form:"vlanid1"`                           // VLAN ID 1
-	Vlanid2         int       `json:"vlanid2" form:"vlanid2"`                           // VLAN ID 2
-	IpAddr          string    `json:"ip_addr" form:"ip_addr"`                           // Static IP
-	IpV6Addr        string    `json:"ipv6_addr" form:"ipv6_addr"`                       // Static IPv6 address
-	MacAddr         string    `json:"mac_addr" form:"mac_addr"`                         // MAC address
-	Domain          string    `json:"domain" form:"domain"`                             // Domain name for vendor-specific features (e.g., Huawei domain)
-	IPv6PrefixPool  string    `json:"ipv6_prefix_pool" form:"ipv6_prefix_pool"`         // IPv6 prefix pool name (inherited from profile or user-specific)
-	BindVlan        int       `json:"bind_vlan" form:"bind_vlan"`                       // Bind VLAN
-	BindMac         int       `json:"bind_mac" form:"bind_mac"`                         // Bind MAC
-	ProfileLinkMode int       `json:"profile_link_mode" form:"profile_link_mode"`       // 0=static (snapshot), 1=dynamic (real-time from profile)
-	ExpireTime      time.Time `gorm:"index" json:"expire_time"`                         // Expiration time
-	Status          string    `gorm:"index" json:"status" form:"status"`                // Status: enabled | disabled
-	Remark          string    `json:"remark" form:"remark"`                             // Remark
-	OnlineCount     int       `json:"online_count" gorm:"-:migration;<-:false"`
-	LastOnline      time.Time `json:"last_online"`
-	CreatedAt       time.Time `gorm:"index" json:"created_at"`
-	UpdatedAt       time.Time `json:"updated_at"`
+	ID             int64  `json:"id,string" form:"id"`                              // Primary key ID
+	NodeId         int64  `json:"node_id,string" form:"node_id"`                    // Node ID
+	ProfileId      int64  `gorm:"index" json:"profile_id,string" form:"profile_id"` // RADIUS profile ID
+	Realname       string `json:"realname" form:"realname"`                         // Contact name
+	Email          string `json:"email" form:"email"`                               // Email address
+	Mobile         string `json:"mobile" form:"mobile"`                             // Contact phone
+	Address        string `json:"address" form:"address"`                           // Contact address
+	Username       string `json:"username" gorm:"uniqueIndex" form:"username"`      // Account name
+	Password       string `json:"password" form:"password"`                         // Password
+	AddrPool       string `json:"addr_pool" form:"addr_pool"`                       // Address pool
+	ActiveNum      int    `gorm:"index" json:"active_num" form:"active_num"`        // Concurrent sessions
+	UpRate         int    `json:"up_rate" form:"up_rate"`                           // Upload rate
+	DownRate       int    `json:"down_rate" form:"down_rate"`                       // Download rate
+	Vlanid1        int    `json:"vlanid1" form:"vlanid1"`                           // VLAN ID 1
+	Vlanid2        int    `json:"vlanid2" form:"vlanid2"`                           // VLAN ID 2
+	IpAddr         string `json:"ip_addr" form:"ip_addr"`                           // Static IP
+	IpV6Addr       string `json:"ipv6_addr" form:"ipv6_addr"`                       // Static IPv6 address
+	MacAddr        string `json:"mac_addr" form:"mac_addr"`                         // MAC address
+	Domain         string `json:"domain" form:"domain"`                             // Domain name for vendor-specific features (e.g., Huawei domain)
+	IPv6PrefixPool string `json:"ipv6_prefix_pool" form:"ipv6_prefix_pool"`         // IPv6 prefix pool name (inherited from profile or user-specific)
+	// DelegatedIpv6Prefix is a static IPv6 prefix delegated to the subscriber via
+	// DHCPv6-PD and issued as the RADIUS Delegated-IPv6-Prefix attribute (RFC 4818,
+	// attribute 123), e.g. "2001:db8:1234::/48". It is per-user because a delegated
+	// prefix routes to a single subscriber; an empty value means "not assigned".
+	DelegatedIpv6Prefix string `json:"delegated_ipv6_prefix" form:"delegated_ipv6_prefix"`
+	// DelegatedIpv6PrefixPool names the DHCPv6 Prefix-Delegation pool the NAS uses
+	// to allocate a Delegated-IPv6-Prefix (RFC 6911 Delegated-IPv6-Prefix-Pool,
+	// attribute 171). An empty value inherits from the linked RadiusProfile in
+	// dynamic link mode; per RFC 6911 §2.4 it is distinct from IPv6PrefixPool.
+	DelegatedIpv6PrefixPool string    `json:"delegated_ipv6_prefix_pool" form:"delegated_ipv6_prefix_pool"`
+	BindVlan                int       `json:"bind_vlan" form:"bind_vlan"`                 // Bind VLAN
+	BindMac                 int       `json:"bind_mac" form:"bind_mac"`                   // Bind MAC
+	ProfileLinkMode         int       `json:"profile_link_mode" form:"profile_link_mode"` // 0=static (snapshot), 1=dynamic (real-time from profile)
+	ExpireTime              time.Time `gorm:"index" json:"expire_time"`                   // Expiration time
+	Status                  string    `gorm:"index" json:"status" form:"status"`          // Status: enabled | disabled
+	Remark                  string    `json:"remark" form:"remark"`                       // Remark
+	OnlineCount             int       `json:"online_count" gorm:"-:migration;<-:false"`
+	LastOnline              time.Time `json:"last_online"`
+	CreatedAt               time.Time `gorm:"index" json:"created_at"`
+	UpdatedAt               time.Time `json:"updated_at"`
 }
 
 // TableName Specify table name

--- a/internal/domain/radius_user_getters.go
+++ b/internal/domain/radius_user_getters.go
@@ -169,7 +169,38 @@ func (u *RadiusUser) GetIPv6PrefixPool(cache interface{}) string {
 	return u.IPv6PrefixPool
 }
 
-// GetBindMac returns the MAC binding flag, respecting profile link mode
+// GetDelegatedIPv6PrefixPool returns the DHCPv6-PD Delegated-IPv6-Prefix-Pool
+// name (RFC 6911 attribute 171), respecting profile link mode. A non-empty
+// user-specific value takes precedence; otherwise, in dynamic link mode, the
+// value is read from the linked profile via cache. It returns the empty string
+// when unset.
+//
+// Per RFC 6911 §2.4 this pool is distinct from the Framed-IPv6-Pool returned by
+// GetIPv6PrefixPool (SLAAC) and must not be conflated with it.
+func (u *RadiusUser) GetDelegatedIPv6PrefixPool(cache interface{}) string {
+	// User-specific override has highest priority
+	if u.DelegatedIpv6PrefixPool != "" && u.DelegatedIpv6PrefixPool != "NA" {
+		return u.DelegatedIpv6PrefixPool
+	}
+
+	// Dynamic mode: fetch from profile
+	if u.ProfileLinkMode == ProfileLinkModeDynamic && cache != nil {
+		if cacheGetter, ok := cache.(ProfileCacheGetter); ok {
+			profile, err := cacheGetter.Get(u.ProfileId)
+			if err != nil {
+				zap.L().Error("failed to get profile from cache",
+					zap.Int64("user_id", u.ID),
+					zap.Int64("profile_id", u.ProfileId),
+					zap.Error(err))
+				return u.DelegatedIpv6PrefixPool
+			}
+			return profile.DelegatedIpv6PrefixPool
+		}
+	}
+
+	return u.DelegatedIpv6PrefixPool
+}
+
 // Note: User-specific binding always applies (e.g., specific MAC address in MacAddr field)
 func (u *RadiusUser) GetBindMac(cache interface{}) int {
 	// User-specific override has priority

--- a/internal/domain/radius_user_getters.go
+++ b/internal/domain/radius_user_getters.go
@@ -201,6 +201,7 @@ func (u *RadiusUser) GetDelegatedIPv6PrefixPool(cache interface{}) string {
 	return u.DelegatedIpv6PrefixPool
 }
 
+// GetBindMac returns the MAC binding flag, respecting profile link mode.
 // Note: User-specific binding always applies (e.g., specific MAC address in MacAddr field)
 func (u *RadiusUser) GetBindMac(cache interface{}) int {
 	// User-specific override has priority

--- a/internal/domain/radius_user_getters_test.go
+++ b/internal/domain/radius_user_getters_test.go
@@ -421,6 +421,69 @@ func TestGetIPv6PrefixPool(t *testing.T) {
 	}
 }
 
+func TestGetDelegatedIPv6PrefixPool(t *testing.T) {
+	cache := newMockCache()
+	cache.SetProfile(1, &RadiusProfile{
+		ID:                      1,
+		DelegatedIpv6PrefixPool: "pd-pool-from-profile",
+	})
+
+	tests := []struct {
+		name     string
+		user     *RadiusUser
+		cache    interface{}
+		expected string
+	}{
+		{
+			name: "user override takes priority",
+			user: &RadiusUser{
+				DelegatedIpv6PrefixPool: "user-pd-pool",
+				ProfileId:               1,
+				ProfileLinkMode:         ProfileLinkModeDynamic,
+			},
+			cache:    cache,
+			expected: "user-pd-pool",
+		},
+		{
+			name: "dynamic mode fetches from profile",
+			user: &RadiusUser{
+				DelegatedIpv6PrefixPool: "",
+				ProfileId:               1,
+				ProfileLinkMode:         ProfileLinkModeDynamic,
+			},
+			cache:    cache,
+			expected: "pd-pool-from-profile",
+		},
+		{
+			name: "NA treated as empty",
+			user: &RadiusUser{
+				DelegatedIpv6PrefixPool: "NA",
+				ProfileId:               1,
+				ProfileLinkMode:         ProfileLinkModeDynamic,
+			},
+			cache:    cache,
+			expected: "pd-pool-from-profile",
+		},
+		{
+			name: "static mode keeps user value (no profile lookup)",
+			user: &RadiusUser{
+				DelegatedIpv6PrefixPool: "",
+				ProfileId:               1,
+				ProfileLinkMode:         ProfileLinkModeStatic,
+			},
+			cache:    cache,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.user.GetDelegatedIPv6PrefixPool(tt.cache)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestGetBindMac(t *testing.T) {
 	cache := newMockCache()
 	cache.SetProfile(1, &RadiusProfile{


### PR DESCRIPTION
## M3.2 — IPv6 Delegated-Prefix schema & migration

Milestone **M3** (IPv6 能力增强闭环) · subtask **M3.2** · `TR-F007` / `TR-F011` / `TR-F015`.

Adds the database fields + dual-DB migration that back DHCPv6 Prefix Delegation — the prerequisite that unblocks **M3.6** (static Delegated-IPv6-Prefix issuance).

### New columns (GORM AutoMigrate — PostgreSQL + SQLite)
| Model | Field | Maps to | RFC |
|-------|-------|---------|-----|
| `RadiusUser` | `DelegatedIpv6Prefix` | Delegated-IPv6-Prefix (static value, per-user) | RFC 4818 #123 |
| `RadiusUser` | `DelegatedIpv6PrefixPool` | Delegated-IPv6-Prefix-Pool (DHCPv6-PD) | RFC 6911 #171 |
| `RadiusProfile` | `DelegatedIpv6PrefixPool` | Delegated-IPv6-Prefix-Pool (profile default) | RFC 6911 #171 |

Per **RFC 6911 §2.4** the Delegated-IPv6-Prefix-Pool (DHCPv6-PD) is deliberately kept distinct from `IPv6PrefixPool` (Framed-IPv6-Pool / SLAAC) — separate columns, no conflation. The static prefix lives only on the user because a delegated prefix routes to a single subscriber.

### Wiring
- `RadiusUser.GetDelegatedIPv6PrefixPool(cache)` mirrors `GetIPv6PrefixPool` (user override → dynamic-mode profile inheritance).
- Admin user **and** profile create/update DTOs persist the new fields, including the profile→user snapshot inheritance for the pool (matching the existing `IPv6PrefixPool` flow exactly).

### Tests
- `internal/app/ipv6_migration_test.go`: SQLite `AutoMigrate` `HasColumn` assertions + a persistence round-trip. PostgreSQL is covered by the integration harness, which runs the same `AutoMigrate` at startup.
- `internal/adminapi`: update/create round-trip for the new fields (proves the GORM column names match the `updates` map keys).
- `internal/domain`: getter inheritance matrix.

### Quality gates
- `go build ./...` ✅
- `go test ./...` ✅
- golangci-lint v2.12.2 (domain / adminapi / app) ✅ 0 issues

### Scope
Schema + migration + persistence only. Issuance in Access-Accept is **M3.6**; filter/display is **M3.3**; the dedicated field-consistency E2E is **M3.5**.

Roadmap groomed: M3.2 checked off in `docs/roadmap.md`.
