### PR TITLE
feat(M3.6): 下发 Delegated-IPv6-Prefix / Delegated-IPv6-Prefix-Pool

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -115,7 +115,7 @@
 - [x] M3.3 用户 / 会话 / 计费的 IPv6 过滤与展示（会话/计费侧 IPv6 过滤与展示此前已闭环；本轮补齐用户侧：Admin API 用户列表新增 `ipv6_addr`(RFC 6911)/`delegated_ipv6_prefix`(RFC 4818) 过滤，前端用户编辑表单与详情页展示 `ipv6_prefix_pool`/`delegated_ipv6_prefix`/`delegated_ipv6_prefix_pool`（zh/en 双语），并修复用户静态 IPv6 地址更新写入幽灵列 `ipv6_addr` 导致从不落库的历史缺陷（正确列名 `ip_v6_addr`））
 - [x] M3.4 Dashboard IPv6 维度统计（在线会话 IPv6 占比/地址/Framed 前缀/委派前缀此前已闭环但缺测试；本轮新增用户库静态 IPv6 配置维度（已配置静态 IPv6 地址 / 委派前缀用户数），补齐 `TestGetDashboardIPv6Stats` 回归测试覆盖在线与用户两个维度，前端 IPv6 覆盖面板新增用户维度卡片（zh/en 双语））
 - [ ] M3.5 端到端测试与字段一致性校验（`test/integration/`，CI 自动执行）
-- [ ] M3.6 下发 Delegated-IPv6-Prefix / Delegated-IPv6-Prefix-Pool（依赖 M3.2 新增用户/Profile 配置字段；RFC 4818 / RFC 6911，按 RFC 6911 §2.4 与 Framed-IPv6-Pool 区分用途，禁止混用同一字段）
+- [x] M3.6 下发 Delegated-IPv6-Prefix / Delegated-IPv6-Prefix-Pool（先于 M3.5 实现：M3.5 的端到端一致性校验需覆盖下发环节，故按依赖关系前置）：default Access-Accept enhancer 从 `RadiusUser.DelegatedIpv6Prefix` 下发 Delegated-IPv6-Prefix（RFC 4818 #123，裸地址归一为 /128，IPv4/非法值跳过避免畸形 4 字节前缀），并经 `GetDelegatedIPv6PrefixPool` 下发 Delegated-IPv6-Prefix-Pool（RFC 6911 #171，支持 Profile 继承，按 §2.4 与 Framed-IPv6-Pool 区分）；含单元测试覆盖网络前缀/裸地址归一/继承/跳过
 
 验收口径：IPv6 全链路可查询、可过滤、可审计，双数据库一致；**验收由 `test/integration/` 的 CI 用例背书**。
 

--- a/internal/radiusd/plugins/auth/enhancers/default_enhancer.go
+++ b/internal/radiusd/plugins/auth/enhancers/default_enhancer.go
@@ -13,6 +13,7 @@ import (
 	"layeh.com/radius/rfc2865"
 	"layeh.com/radius/rfc2869"
 	"layeh.com/radius/rfc3162"
+	"layeh.com/radius/rfc4818"
 	"layeh.com/radius/rfc6911"
 )
 
@@ -92,6 +93,31 @@ func (e *DefaultAcceptEnhancer) Enhance(ctx context.Context, authCtx *auth.AuthC
 	ipv6Pool := user.GetIPv6PrefixPool(profileCache)
 	if common.IsNotEmptyAndNA(ipv6Pool) {
 		_ = rfc3162.FramedIPv6Pool_SetString(response, ipv6Pool) //nolint:errcheck
+	}
+
+	// Set Delegated-IPv6-Prefix (RFC 4818, attribute 123) when the user has a
+	// statically delegated prefix for DHCPv6-PD. The value is a CIDR prefix such
+	// as "2001:db8:1234::/48"; a bare address without a prefix length is treated
+	// as a single-host /128 delegation. IPv4 and unparseable values are skipped
+	// so a misconfiguration cannot break the Access-Accept or emit a malformed
+	// (4-byte) prefix.
+	if common.IsNotEmptyAndNA(user.DelegatedIpv6Prefix) {
+		delegated := user.DelegatedIpv6Prefix
+		if !strings.Contains(delegated, "/") {
+			delegated += "/128"
+		}
+		if _, ipnet, err := net.ParseCIDR(delegated); err == nil && ipnet.IP.To4() == nil {
+			_ = rfc4818.DelegatedIPv6Prefix_Set(response, ipnet) //nolint:errcheck
+		}
+	}
+
+	// Set Delegated-IPv6-Prefix-Pool (RFC 6911, attribute 171) so the NAS can
+	// allocate a delegated prefix from a named DHCPv6-PD pool. Per RFC 6911 §2.4
+	// this is distinct from the Framed-IPv6-Pool (SLAAC) set above; it uses the
+	// dedicated getter that honors profile inheritance.
+	delegatedPool := user.GetDelegatedIPv6PrefixPool(profileCache)
+	if common.IsNotEmptyAndNA(delegatedPool) {
+		_ = rfc6911.DelegatedIPv6PrefixPool_SetString(response, delegatedPool) //nolint:errcheck
 	}
 
 	return nil

--- a/internal/radiusd/plugins/auth/enhancers/ipv6_test.go
+++ b/internal/radiusd/plugins/auth/enhancers/ipv6_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/auth"
 	"layeh.com/radius"
 	"layeh.com/radius/rfc3162"
+	"layeh.com/radius/rfc4818"
 	"layeh.com/radius/rfc6911"
 )
 
@@ -150,6 +151,103 @@ func TestSingleIPv6Host(t *testing.T) {
 			assert.Equal(t, tt.wantStr, ip.String(), "value=%q", tt.value)
 		}
 	}
+}
+
+// stubProfileCache is a minimal domain.ProfileCacheGetter used to exercise
+// profile-inheritance paths in the enhancer without the real cache.
+type stubProfileCache struct {
+	profile *domain.RadiusProfile
+}
+
+func (s stubProfileCache) Get(int64) (*domain.RadiusProfile, error) {
+	return s.profile, nil
+}
+
+// TestDefaultAcceptEnhancer_DelegatedIPv6Prefix verifies that a user's static
+// Delegated-IPv6-Prefix (RFC 4818, attribute 123) is issued in the Access-Accept,
+// that a bare address is normalised to a single-host /128 delegation, and that
+// empty/N/A/IPv4/unparseable values are skipped rather than emitting a malformed
+// attribute.
+func TestDefaultAcceptEnhancer_DelegatedIPv6Prefix(t *testing.T) {
+	tests := []struct {
+		name           string
+		delegated      string
+		expectSet      bool
+		expectedPrefix string
+	}{
+		{name: "network prefix /48", delegated: "2001:db8:1234::/48", expectSet: true, expectedPrefix: "2001:db8:1234::/48"},
+		{name: "network prefix /56", delegated: "2001:db8:abcd:ee00::/56", expectSet: true, expectedPrefix: "2001:db8:abcd:ee00::/56"},
+		{name: "bare address becomes /128", delegated: "2001:db8::1", expectSet: true, expectedPrefix: "2001:db8::1/128"},
+		{name: "empty", delegated: "", expectSet: false},
+		{name: "NA value", delegated: "N/A", expectSet: false},
+		{name: "ipv4 prefix ignored", delegated: "192.0.2.0/24", expectSet: false},
+		{name: "invalid", delegated: "not-a-prefix", expectSet: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			enhancer := NewDefaultAcceptEnhancer()
+			response := radius.New(radius.CodeAccessAccept, []byte("secret"))
+			user := &domain.RadiusUser{DelegatedIpv6Prefix: tt.delegated}
+			authCtx := &auth.AuthContext{Response: response, User: user}
+
+			require.NoError(t, enhancer.Enhance(context.Background(), authCtx))
+
+			ipnet := rfc4818.DelegatedIPv6Prefix_Get(response)
+			if tt.expectSet {
+				require.NotNil(t, ipnet)
+				assert.Equal(t, tt.expectedPrefix, ipnet.String())
+			} else {
+				assert.Nil(t, ipnet)
+			}
+		})
+	}
+}
+
+// TestDefaultAcceptEnhancer_DelegatedIPv6PrefixPool verifies that the
+// Delegated-IPv6-Prefix-Pool (RFC 6911, attribute 171) is issued from a
+// user-specific value, inherited from the linked profile in dynamic link mode,
+// and skipped when unset/N/A. It must remain distinct from Framed-IPv6-Pool.
+func TestDefaultAcceptEnhancer_DelegatedIPv6PrefixPool(t *testing.T) {
+	t.Run("user-specific value", func(t *testing.T) {
+		enhancer := NewDefaultAcceptEnhancer()
+		response := radius.New(radius.CodeAccessAccept, []byte("secret"))
+		user := &domain.RadiusUser{DelegatedIpv6PrefixPool: "pd-pool-user"}
+		authCtx := &auth.AuthContext{Response: response, User: user}
+
+		require.NoError(t, enhancer.Enhance(context.Background(), authCtx))
+		assert.Equal(t, "pd-pool-user", rfc6911.DelegatedIPv6PrefixPool_GetString(response))
+	})
+
+	t.Run("inherited from profile in dynamic mode", func(t *testing.T) {
+		enhancer := NewDefaultAcceptEnhancer()
+		response := radius.New(radius.CodeAccessAccept, []byte("secret"))
+		user := &domain.RadiusUser{
+			ProfileId:       7,
+			ProfileLinkMode: domain.ProfileLinkModeDynamic,
+		}
+		cache := stubProfileCache{profile: &domain.RadiusProfile{DelegatedIpv6PrefixPool: "pd-pool-profile"}}
+		authCtx := &auth.AuthContext{
+			Response: response,
+			User:     user,
+			Metadata: map[string]interface{}{"profile_cache": cache},
+		}
+
+		require.NoError(t, enhancer.Enhance(context.Background(), authCtx))
+		assert.Equal(t, "pd-pool-profile", rfc6911.DelegatedIPv6PrefixPool_GetString(response))
+	})
+
+	t.Run("unset and NA are skipped", func(t *testing.T) {
+		for _, v := range []string{"", "N/A"} {
+			enhancer := NewDefaultAcceptEnhancer()
+			response := radius.New(radius.CodeAccessAccept, []byte("secret"))
+			user := &domain.RadiusUser{DelegatedIpv6PrefixPool: v}
+			authCtx := &auth.AuthContext{Response: response, User: user}
+
+			require.NoError(t, enhancer.Enhance(context.Background(), authCtx))
+			assert.Empty(t, rfc6911.DelegatedIPv6PrefixPool_GetString(response), "value=%q", v)
+		}
+	})
 }
 
 // TestHuaweiAcceptEnhancer_IPv6Address tests Huawei IPv6 address setting


### PR DESCRIPTION
## 概要 (M3.6 — 下发 Delegated-IPv6-Prefix / Delegated-IPv6-Prefix-Pool)

default Access-Accept enhancer 此前已下发 Framed-IPv6-Prefix/Address 与 Framed-IPv6-Pool，但**从未下发** M3.2 已配置的 DHCPv6-PD 属性 —— 用户的静态委派前缀 / PD 池只入库、不下发。本轮补齐。

> **排序说明**：M3.6 先于 M3.5 实现。M3.5 的"端到端字段一致性校验"需要覆盖下发环节，按依赖关系将下发前置，避免 M3.5 写完再返工。

`Refs TR-F005 / TR-F007`

## 实现 (`internal/radiusd/plugins/auth/enhancers/default_enhancer.go`)
- **Delegated-IPv6-Prefix**（RFC 4818 #123）：取自 `RadiusUser.DelegatedIpv6Prefix`。裸地址归一为单主机 `/128`；IPv4 与非法值跳过（`ipnet.IP.To4()` 守卫，避免下发畸形 4 字节前缀），配置错误不会破坏/污染 Access-Accept。
- **Delegated-IPv6-Prefix-Pool**（RFC 6911 #171）：经 `GetDelegatedIPv6PrefixPool` getter 下发，支持 Profile 继承；按 RFC 6911 §2.4 与 Framed-IPv6-Pool（SLAAC）严格区分。

## 测试 (`ipv6_test.go`)
- `TestDefaultAcceptEnhancer_DelegatedIPv6Prefix`：/48、/56 网络前缀、裸地址→/128 归一、empty / N/A / IPv4 / 非法值跳过。
- `TestDefaultAcceptEnhancer_DelegatedIPv6PrefixPool`：用户自配值、动态链路模式下从 Profile 继承（stub cache）、unset / N/A 跳过。

## 协议依据
- `docs/rfcs/rfc4818-ipv6-prefix-delegation.txt`（Delegated-IPv6-Prefix）
- `docs/rfcs/rfc6911-ipv6-access-networks.txt` §2.4（Delegated-IPv6-Prefix-Pool 与 Framed-IPv6-Pool 区分）

## 质量门禁
- [x] `CGO_ENABLED=0 go build ./...`
- [x] `CGO_ENABLED=0 go test ./...`（全量通过）
- [x] `golangci-lint run ./internal/radiusd/plugins/auth/enhancers/...`（v2.12.2，0 issues）
