### PR TITLE
test(ipv6): M3.5 E2E field-consistency suite + fix dropped profile inheritance in Access-Accept

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -28,7 +28,7 @@
 | --- | --- | --- | --- | --- |
 | M1 | EAP-TLS 认证支持 | TR-F004 | P1 | 已交付 |
 | M2 | CoA 动态授权支持 | TR-F010 / TR-F012 / TR-F013 | P1 | 已交付 |
-| M3 | IPv6 能力增强闭环 | TR-F007 / TR-F011 / TR-F015 | P1 | 进行中 |
+| M3 | IPv6 能力增强闭环 | TR-F007 / TR-F011 / TR-F015 | P1 | 已完成 |
 | M4 | Agent 开发体系与质量门禁 | TR-F022 | P2 | 进行中 |
 | M5 | 厂商 VSA 覆盖扩展 | TR-F005 | P2 | 计划中 |
 | M6 | 可观测性与运维增强 | TR-F015 | P3 | 计划中 |
@@ -114,7 +114,7 @@
 - [x] M3.2 数据库字段与迁移（PostgreSQL + SQLite 双兼容）：新增 `RadiusUser.DelegatedIpv6Prefix`（静态 RFC 4818 #123，按用户）、`RadiusUser.DelegatedIpv6PrefixPool` 与 `RadiusProfile.DelegatedIpv6PrefixPool`（RFC 6911 #171 DHCPv6-PD 池，按 §2.4 与 Framed-IPv6-Pool 区分）；GORM AutoMigrate 双库建列，Admin API 用户/套餐增改可持久化并支持 Profile 继承
 - [x] M3.3 用户 / 会话 / 计费的 IPv6 过滤与展示（会话/计费侧 IPv6 过滤与展示此前已闭环；本轮补齐用户侧：Admin API 用户列表新增 `ipv6_addr`(RFC 6911)/`delegated_ipv6_prefix`(RFC 4818) 过滤，前端用户编辑表单与详情页展示 `ipv6_prefix_pool`/`delegated_ipv6_prefix`/`delegated_ipv6_prefix_pool`（zh/en 双语），并修复用户静态 IPv6 地址更新写入幽灵列 `ipv6_addr` 导致从不落库的历史缺陷（正确列名 `ip_v6_addr`））
 - [x] M3.4 Dashboard IPv6 维度统计（在线会话 IPv6 占比/地址/Framed 前缀/委派前缀此前已闭环但缺测试；本轮新增用户库静态 IPv6 配置维度（已配置静态 IPv6 地址 / 委派前缀用户数），补齐 `TestGetDashboardIPv6Stats` 回归测试覆盖在线与用户两个维度，前端 IPv6 覆盖面板新增用户维度卡片（zh/en 双语））
-- [ ] M3.5 端到端测试与字段一致性校验（`test/integration/`，CI 自动执行）
+- [x] M3.5 端到端测试与字段一致性校验（`test/integration/ipv6_test.go`，CI `integration` job 自动执行）：真实 PostgreSQL + 在线 RADIUS auth/acct 服务驱动 IPv6 全链路——为用户配置静态 IPv6 主机地址、SLAAC 前缀池、静态 Delegated-IPv6-Prefix 与 DHCPv6-PD 委派池后，PAP 认证断言 Access-Accept 同时携带 Framed-IPv6-Prefix(RFC 3162)/Framed-IPv6-Address(RFC 6911 §2.1)/Framed-IPv6-Pool(RFC 3162)/Delegated-IPv6-Prefix(RFC 4818 #123)/Delegated-IPv6-Prefix-Pool(RFC 6911 #171)，再以 NAS 回显的属性发起 Accounting-Start 并断言 RadiusOnline 与 RadiusAccounting 落库的 IPv6 字段与下发值逐一一致（auth→acct→DB 字段一致性）；另含动态 link 模式下从 Profile 继承 Framed/Delegated IPv6 池的端到端用例。**该用例发现并修复了真实缺陷**：`ApplyAcceptEnhancers` 构造的 `AuthContext` 缺失 `Metadata`，导致全部 Accept 增强器拿到 nil `profile_cache`/`config_mgr`，动态 link 模式下 Profile 继承的地址/IPv6 池、速率、domain 等属性被静默丢弃、且计费 interim 间隔退化为硬编码缺省值——现已注入 `profile_cache` 与 `config_mgr`，并补充 `TestApplyAcceptEnhancersWiresProfileCacheMetadata` 单元回归
 - [x] M3.6 下发 Delegated-IPv6-Prefix / Delegated-IPv6-Prefix-Pool（先于 M3.5 实现：M3.5 的端到端一致性校验需覆盖下发环节，故按依赖关系前置）：default Access-Accept enhancer 从 `RadiusUser.DelegatedIpv6Prefix` 下发 Delegated-IPv6-Prefix（RFC 4818 #123，裸地址归一为 /128，IPv4/非法值跳过避免畸形 4 字节前缀），并经 `GetDelegatedIPv6PrefixPool` 下发 Delegated-IPv6-Prefix-Pool（RFC 6911 #171，支持 Profile 继承，按 §2.4 与 Framed-IPv6-Pool 区分）；含单元测试覆盖网络前缀/裸地址归一/继承/跳过
 
 验收口径：IPv6 全链路可查询、可过滤、可审计，双数据库一致；**验收由 `test/integration/` 的 CI 用例背书**。

--- a/internal/radiusd/radius.go
+++ b/internal/radiusd/radius.go
@@ -327,11 +327,24 @@ func (s *AuthService) ApplyAcceptEnhancers(
 	vendorReq *vendorparsers.VendorRequest,
 	radAccept *radius.Packet,
 ) {
+	// Response enhancers resolve profile-inherited attributes (address pools,
+	// IPv6 prefix/delegated pools, rates, domain) for dynamic-link-mode users and
+	// read tunable defaults such as the accounting interim interval. Both depend
+	// on the profile cache and config manager being available via metadata; an
+	// empty map here would silently drop every dynamically inherited attribute
+	// from the Access-Accept.
+	metadata := map[string]interface{}{}
+	if appCtx := s.AppContext(); appCtx != nil {
+		metadata["profile_cache"] = appCtx.ProfileCache()
+		metadata["config_mgr"] = appCtx.ConfigMgr()
+	}
+
 	authCtx := &auth.AuthContext{
 		User:          user,
 		Nas:           nas,
 		VendorRequest: vendorReq,
 		Response:      radAccept,
+		Metadata:      metadata,
 	}
 
 	ctx := context.Background()

--- a/internal/radiusd/radius_auth_test.go
+++ b/internal/radiusd/radius_auth_test.go
@@ -96,6 +96,69 @@ func TestApplyAcceptEnhancersInvokesRegisteredEnhancers(t *testing.T) {
 	}
 }
 
+// metadataCapturingEnhancer records the AuthContext it receives so a test can
+// assert what metadata ApplyAcceptEnhancers wires into the enhancer pipeline.
+type metadataCapturingEnhancer struct {
+	captured *auth.AuthContext
+}
+
+func (e *metadataCapturingEnhancer) Name() string { return "metadata-capture" }
+
+func (e *metadataCapturingEnhancer) Enhance(ctx context.Context, authCtx *auth.AuthContext) error {
+	e.captured = authCtx
+	return nil
+}
+
+// profileCacheAppContext is a mockAppContext that returns real profile-cache and
+// config-manager handles, so a test can verify they are propagated to enhancers.
+type profileCacheAppContext struct {
+	*mockAppContext
+	cache *app.ProfileCache
+}
+
+func (m *profileCacheAppContext) ProfileCache() *app.ProfileCache { return m.cache }
+
+// TestApplyAcceptEnhancersWiresProfileCacheMetadata is a regression guard for a
+// bug where ApplyAcceptEnhancers built an AuthContext with no Metadata map, so
+// every response enhancer received a nil profile_cache and silently dropped all
+// dynamic-link-mode profile inheritance (address/IPv6 pools, rates, domain) from
+// the Access-Accept. The enhancers read these handles from AuthContext.Metadata,
+// so they must be populated from the application context.
+func TestApplyAcceptEnhancersWiresProfileCacheMetadata(t *testing.T) {
+	registry.ResetForTest()
+	t.Cleanup(registry.ResetForTest)
+
+	enh := &metadataCapturingEnhancer{}
+	registry.RegisterResponseEnhancer(enh)
+
+	cache := app.NewProfileCache(nil, time.Minute)
+	t.Cleanup(cache.Stop)
+	appCtx := &profileCacheAppContext{mockAppContext: &mockAppContext{}, cache: cache}
+	authSvc := &AuthService{RadiusService: &RadiusService{appCtx: appCtx}}
+
+	user := &domain.RadiusUser{
+		Username:        "alice",
+		ProfileLinkMode: domain.ProfileLinkModeDynamic,
+		ExpireTime:      time.Now().Add(time.Hour),
+	}
+	nas := &domain.NetNas{ID: 1, Identifier: "NAS-1"}
+	resp := radius.New(radius.CodeAccessAccept, []byte("secret"))
+	vendorReq := &vendorparsers.VendorRequest{}
+
+	authSvc.ApplyAcceptEnhancers(user, nas, vendorReq, resp)
+
+	if enh.captured == nil {
+		t.Fatal("enhancer was not invoked")
+	}
+	if enh.captured.Metadata == nil {
+		t.Fatal("ApplyAcceptEnhancers must populate AuthContext.Metadata")
+	}
+	got, ok := enh.captured.Metadata["profile_cache"].(*app.ProfileCache)
+	if !ok || got != cache {
+		t.Fatalf("profile_cache metadata = %v (ok=%v); want the application profile cache", got, ok)
+	}
+}
+
 func TestProcessAuthErrorInvokesGuards(t *testing.T) {
 	registry.ResetForTest()
 	t.Cleanup(registry.ResetForTest)

--- a/test/integration/ipv6_test.go
+++ b/test/integration/ipv6_test.go
@@ -1,0 +1,244 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"layeh.com/radius"
+	"layeh.com/radius/rfc2865"
+	"layeh.com/radius/rfc2866"
+	"layeh.com/radius/rfc3162"
+	"layeh.com/radius/rfc4818"
+	"layeh.com/radius/rfc6911"
+
+	"github.com/talkincode/toughradius/v9/internal/domain"
+	"github.com/talkincode/toughradius/v9/pkg/common"
+)
+
+// TestRadiusIPv6ProvisioningEndToEnd drives the full IPv6 provisioning chain
+// against the live RADIUS auth and accounting servers (backed by PostgreSQL):
+//
+//  1. A user is provisioned with a static IPv6 host address, a SLAAC prefix
+//     pool, a statically delegated DHCPv6-PD prefix, and a delegated prefix
+//     pool.
+//  2. A PAP Access-Request is authenticated and the resulting Access-Accept is
+//     asserted to carry every IPv6 attribute the enhancer is responsible for:
+//     Framed-IPv6-Prefix (RFC 3162), Framed-IPv6-Address (RFC 6911 §2.1),
+//     Framed-IPv6-Pool (RFC 3162), Delegated-IPv6-Prefix (RFC 4818 #123, M3.6)
+//     and Delegated-IPv6-Prefix-Pool (RFC 6911 #171, M3.6).
+//  3. The attributes the NAS would echo are replayed in an Accounting-Start, and
+//     the persisted RadiusOnline and RadiusAccounting rows are asserted to carry
+//     the identical IPv6 values, proving field consistency across the
+//     auth -> accounting -> database path.
+//
+// It is intentionally serial (no t.Parallel) because the RADIUS plugin registry
+// and rate limiter are process-global shared state.
+func TestRadiusIPv6ProvisioningEndToEnd(t *testing.T) {
+	const secret = "it-ipv6-secret"
+	suffix := uniqueSuffix()
+	nasIP := "10.203.0.1"
+	nasID := "it-ipv6-nas-" + suffix
+
+	require.NoError(t, h.appCtx.DB().Create(&domain.NetNas{
+		ID:         common.UUIDint64(),
+		Identifier: nasID,
+		Ipaddr:     nasIP,
+		Secret:     secret,
+		VendorCode: "0",
+		Status:     common.ENABLED,
+	}).Error)
+
+	// Provision values. The user keeps its own pool values (static link mode) so
+	// issuance does not depend on profile inheritance, which the inheritance test
+	// below exercises separately.
+	const (
+		staticHost    = "2001:db8:a::5"
+		wantPrefix    = "2001:db8:a::5/128"
+		wantDelegated = "2001:db8:1234::/48"
+	)
+	slaacPool := "it-slaac-" + suffix
+	pdPool := "it-pd-" + suffix
+
+	profileID := seedProfile(t, "it-ipv6-profile-"+suffix)
+	username := "it-ipv6-" + suffix
+	const password = "ipv6-Pw-123"
+	require.NoError(t, h.appCtx.DB().Create(&domain.RadiusUser{
+		ID:                      common.UUIDint64(),
+		ProfileId:               profileID,
+		Username:                username,
+		Password:                password,
+		Status:                  common.ENABLED,
+		ProfileLinkMode:         domain.ProfileLinkModeStatic,
+		IpV6Addr:                staticHost,
+		IPv6PrefixPool:          slaacPool,
+		DelegatedIpv6Prefix:     wantDelegated,
+		DelegatedIpv6PrefixPool: pdPool,
+		ExpireTime:              time.Now().AddDate(1, 0, 0),
+		CreatedAt:               time.Now(),
+		UpdatedAt:               time.Now(),
+	}).Error)
+
+	authAddr := fmt.Sprintf("127.0.0.1:%d", h.cfg.Radiusd.AuthPort)
+	acctAddr := fmt.Sprintf("127.0.0.1:%d", h.cfg.Radiusd.AcctPort)
+
+	// Step 1+2: authenticate and assert the Access-Accept carries every IPv6
+	// attribute with the provisioned values.
+	resp := exchange(t, authAddr, secret, username, password, nasID, nasIP)
+	h.radiusSvc.ReleaseAuthRateLimit(username)
+	require.Equalf(t, radius.CodeAccessAccept, resp.Code, "expected Access-Accept, got %v", resp.Code)
+
+	framedPrefix := rfc3162.FramedIPv6Prefix_Get(resp)
+	require.NotNil(t, framedPrefix, "Access-Accept must carry Framed-IPv6-Prefix")
+	assert.Equal(t, wantPrefix, framedPrefix.String())
+
+	framedAddr := rfc6911.FramedIPv6Address_Get(resp)
+	require.NotEmpty(t, framedAddr, "Access-Accept must carry Framed-IPv6-Address")
+	assert.Equal(t, staticHost, framedAddr.String())
+
+	assert.Equal(t, slaacPool, rfc3162.FramedIPv6Pool_GetString(resp),
+		"Access-Accept must carry Framed-IPv6-Pool")
+
+	delegated := rfc4818.DelegatedIPv6Prefix_Get(resp)
+	require.NotNil(t, delegated, "Access-Accept must carry Delegated-IPv6-Prefix")
+	assert.Equal(t, wantDelegated, delegated.String())
+
+	assert.Equal(t, pdPool, rfc6911.DelegatedIPv6PrefixPool_GetString(resp),
+		"Access-Accept must carry Delegated-IPv6-Prefix-Pool")
+
+	// Step 3: replay the attributes the NAS echoes in an Accounting-Start and
+	// assert the persisted records carry the identical IPv6 values.
+	sessionID := "it-ipv6-sess-" + suffix
+	acctResp := acctStartIPv6(t, acctAddr, secret, username, nasID, nasIP, sessionID,
+		framedPrefix, framedAddr, delegated)
+	require.Equalf(t, radius.CodeAccountingResponse, acctResp.Code,
+		"expected Accounting-Response, got %v", acctResp.Code)
+
+	online := waitForOnline(t, sessionID)
+	assert.Equal(t, wantPrefix, online.FramedIpv6Prefix, "online Framed-IPv6-Prefix consistency")
+	assert.Equal(t, staticHost, online.FramedIpv6Address, "online Framed-IPv6-Address consistency")
+	assert.Equal(t, wantDelegated, online.DelegatedIpv6Prefix, "online Delegated-IPv6-Prefix consistency")
+
+	var acct domain.RadiusAccounting
+	require.NoError(t, h.appCtx.DB().Where("acct_session_id = ?", sessionID).First(&acct).Error)
+	assert.Equal(t, wantPrefix, acct.FramedIpv6Prefix, "accounting Framed-IPv6-Prefix consistency")
+	assert.Equal(t, staticHost, acct.FramedIpv6Address, "accounting Framed-IPv6-Address consistency")
+	assert.Equal(t, wantDelegated, acct.DelegatedIpv6Prefix, "accounting Delegated-IPv6-Prefix consistency")
+}
+
+// TestRadiusIPv6PoolInheritanceEndToEnd proves that a user with empty pool
+// fields in dynamic link mode inherits both the Framed-IPv6-Pool and the
+// Delegated-IPv6-Prefix-Pool from its linked profile, resolved live through the
+// running auth server's profile cache (RFC 6911 §2.4 keeps the two pools
+// distinct).
+func TestRadiusIPv6PoolInheritanceEndToEnd(t *testing.T) {
+	const secret = "it-ipv6-inherit-secret"
+	suffix := uniqueSuffix()
+	nasIP := "10.203.0.2"
+	nasID := "it-ipv6-inh-nas-" + suffix
+
+	require.NoError(t, h.appCtx.DB().Create(&domain.NetNas{
+		ID:         common.UUIDint64(),
+		Identifier: nasID,
+		Ipaddr:     nasIP,
+		Secret:     secret,
+		VendorCode: "0",
+		Status:     common.ENABLED,
+	}).Error)
+
+	profileSlaacPool := "it-prof-slaac-" + suffix
+	profilePDPool := "it-prof-pd-" + suffix
+	require.NoError(t, h.appCtx.DB().Create(&domain.RadiusProfile{
+		ID:                      common.UUIDint64(),
+		Name:                    "it-ipv6-inh-profile-" + suffix,
+		Status:                  common.ENABLED,
+		ActiveNum:               1,
+		UpRate:                  1000,
+		DownRate:                2000,
+		IPv6PrefixPool:          profileSlaacPool,
+		DelegatedIpv6PrefixPool: profilePDPool,
+		CreatedAt:               time.Now(),
+		UpdatedAt:               time.Now(),
+	}).Error)
+	var profile domain.RadiusProfile
+	require.NoError(t, h.appCtx.DB().Where("name = ?", "it-ipv6-inh-profile-"+suffix).First(&profile).Error)
+
+	username := "it-ipv6-inh-" + suffix
+	const password = "ipv6-inh-Pw-123"
+	require.NoError(t, h.appCtx.DB().Create(&domain.RadiusUser{
+		ID:              common.UUIDint64(),
+		ProfileId:       profile.ID,
+		Username:        username,
+		Password:        password,
+		Status:          common.ENABLED,
+		ProfileLinkMode: domain.ProfileLinkModeDynamic,
+		IpV6Addr:        "2001:db8:b::9",
+		ExpireTime:      time.Now().AddDate(1, 0, 0),
+		CreatedAt:       time.Now(),
+		UpdatedAt:       time.Now(),
+	}).Error)
+
+	authAddr := fmt.Sprintf("127.0.0.1:%d", h.cfg.Radiusd.AuthPort)
+	resp := exchange(t, authAddr, secret, username, password, nasID, nasIP)
+	h.radiusSvc.ReleaseAuthRateLimit(username)
+	require.Equalf(t, radius.CodeAccessAccept, resp.Code, "expected Access-Accept, got %v", resp.Code)
+
+	assert.Equal(t, profileSlaacPool, rfc3162.FramedIPv6Pool_GetString(resp),
+		"Framed-IPv6-Pool must be inherited from the profile")
+	assert.Equal(t, profilePDPool, rfc6911.DelegatedIPv6PrefixPool_GetString(resp),
+		"Delegated-IPv6-Prefix-Pool must be inherited from the profile")
+}
+
+// acctStartIPv6 sends a single Accounting-Start carrying the supplied IPv6
+// attributes (as a NAS would echo them from an Access-Accept) and returns the
+// Accounting-Response. radius.Exchange signs the request authenticator with the
+// shared secret, which the server validates before persisting the session.
+func acctStartIPv6(t *testing.T, serverAddr, secret, username, nasID, nasIP, sessionID string,
+	framedPrefix *net.IPNet, framedAddr net.IP, delegated *net.IPNet) *radius.Packet {
+	t.Helper()
+	packet := radius.New(radius.CodeAccountingRequest, []byte(secret))
+	_ = rfc2866.AcctStatusType_Set(packet, rfc2866.AcctStatusType_Value_Start)
+	_ = rfc2866.AcctSessionID_SetString(packet, sessionID)
+	_ = rfc2865.UserName_SetString(packet, username)
+	_ = rfc2865.NASIdentifier_SetString(packet, nasID)
+	_ = rfc2865.NASIPAddress_Set(packet, net.ParseIP(nasIP))
+	if framedPrefix != nil {
+		_ = rfc3162.FramedIPv6Prefix_Set(packet, framedPrefix)
+	}
+	if len(framedAddr) > 0 {
+		_ = rfc6911.FramedIPv6Address_Set(packet, framedAddr)
+	}
+	if delegated != nil {
+		_ = rfc4818.DelegatedIPv6Prefix_Set(packet, delegated)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	resp, err := radius.Exchange(ctx, packet, serverAddr)
+	require.NoError(t, err)
+	return resp
+}
+
+// waitForOnline polls for the RadiusOnline row created by the asynchronous
+// accounting pipeline, failing the test if it does not appear within the
+// deadline instead of racing a fixed sleep.
+func waitForOnline(t *testing.T, sessionID string) domain.RadiusOnline {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	var online domain.RadiusOnline
+	for time.Now().Before(deadline) {
+		err := h.appCtx.DB().Where("acct_session_id = ?", sessionID).First(&online).Error
+		if err == nil {
+			return online
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	require.FailNowf(t, "online session not persisted", "no RadiusOnline row for acct_session_id=%s", sessionID)
+	return online
+}


### PR DESCRIPTION
## What & why

Delivers **M3.5** (the last open subtask of milestone **M3 — IPv6 能力增强闭环**): a CI-executed end-to-end **field-consistency** acceptance suite, and fixes a real defect it uncovered.

Anchored to `TR-F022` (CI acceptance) and `TR-F007/TR-F011/TR-F015` (M3 IPv6).

## New integration suite — `test/integration/ipv6_test.go`

Runs in the CI `integration` job (real PostgreSQL + live RADIUS auth/acct servers):

- **`TestRadiusIPv6ProvisioningEndToEnd`** — provision a user with a static IPv6 host address, SLAAC prefix pool, a static `Delegated-IPv6-Prefix` and a DHCPv6-PD pool; authenticate via PAP and assert the Access-Accept carries all five IPv6 attributes:
  - Framed-IPv6-Prefix (RFC 3162), Framed-IPv6-Address (RFC 6911 §2.1), Framed-IPv6-Pool (RFC 3162), Delegated-IPv6-Prefix (RFC 4818 #123), Delegated-IPv6-Prefix-Pool (RFC 6911 #171).
  - Then replay the NAS-echoed attributes in an **Accounting-Start** and assert the persisted `RadiusOnline` **and** `RadiusAccounting` rows carry identical IPv6 values — i.e. **auth → accounting → DB field consistency**.
- **`TestRadiusIPv6PoolInheritanceEndToEnd`** — dynamic-link-mode user with empty pool fields inherits both Framed-IPv6-Pool and Delegated-IPv6-Prefix-Pool from its linked profile, resolved live through the running server's profile cache (RFC 6911 §2.4 keeps the two pools distinct).

## Bug found & fixed by the suite

`ApplyAcceptEnhancers` built an `AuthContext` with **no `Metadata`**, so every Accept enhancer (default + all vendor enhancers) received a **nil `profile_cache`/`config_mgr`**. Consequences:

- Dynamic-link-mode **profile inheritance was silently dropped** from the Access-Accept (address pool, IPv6 prefix/delegated pools, up/down rate, domain).
- The accounting **interim interval fell back to a hardcoded default** instead of the configured value.

Fix: inject `profile_cache` and `config_mgr` into the enhancer metadata. Added `TestApplyAcceptEnhancersWiresProfileCacheMetadata` as a fast-job unit regression guard.

## Roadmap

- Check off **M3.5**; flip **M3** overview status to **已完成** (M3.1–M3.6 all delivered).

## Quality gates

- [x] `go build ./...`
- [x] `go test ./...` (full unit suite, incl. new regression test)
- [x] `make test-integration-pg` (full integration suite green; both new E2E tests pass)
- [x] `golangci-lint run` (v2.12.2) on `internal/radiusd/...` → 0 issues; new integration file clean under `--build-tags=integration`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
