### PR TITLE
feat(eap): M8.1 register PEAPv0 handler skeleton + EapMethod config

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -33,7 +33,7 @@
 | M5 | 厂商 VSA 覆盖扩展 | TR-F005 | P2 | 计划中 |
 | M6 | 可观测性与运维增强 | TR-F015 | P3 | 计划中 |
 | M7 | 上游 RADIUS 库跟踪与协议合规 | TR-F021 / TR-F022 | P2 | 进行中 |
-| M8 | PEAPv0 / EAP-MSCHAPv2 认证支持 | TR-F004 | P1 | 计划中 |
+| M8 | PEAPv0 / EAP-MSCHAPv2 认证支持 | TR-F004 | P1 | 进行中 |
 | M9 | EAP-TTLS 隧道认证支持 | TR-F004 | P1 | 计划中 |
 | M10 | EAP-TLS 1.3 / RFC 9190 升级 | TR-F004 | P2 | 计划中 |
 | M11 | TEAP 隧道认证（中长期） | TR-F004 | P3 | 计划中 |
@@ -185,7 +185,7 @@
 - **协议规范**：`docs/rfcs/rfc3748-eap.txt`（EAP）、`rfc2759-mschapv2.txt`（MS-CHAP-V2）、`rfc2548-microsoft-vsa.txt`（MS-MPPE 密钥）、`rfc3579-radius-eap-support.txt`；PEAPv0 无正式 RFC，参考 Microsoft `[MS-PEAP]` 与 IETF `draft-kamath-pppext-peapv0`（本地缺失，按 `reference-rfc` 登记）。
 
 子任务：
-- [ ] M8.1 注册 PEAP handler 骨架与启用列表配置（`EapMethod`）
+- [x] M8.1 注册 PEAP handler 骨架与启用列表配置（`EapMethod`）<br/>已交付：新增 `eap.TypePEAP=25` 常量与 `ErrPEAPNotImplemented` 安全护栏；`peap_handler.go` 骨架（`Name/EAPType/CanHandle`，`HandleIdentity` 下发 PEAPv0 Start（S 位 + version 0，复用 EAP-TLS Flags/分片帧格式），`HandleResponse` 在外层隧道（M8.2）落地前一律以 `ErrPEAPNotImplemented` 拒绝，永不放行）；coordinator 选择分支与 `plugins/init.go` 注册接入；`config_schemas.json` 与硬编码兜底 `EapMethod` 枚举加入 `eap-peap`。单测覆盖 handler、coordinator 方法选择与枚举。引用 RFC 3748/3579、RFC 5216 §3.1 帧格式与 PEAPv0 [MS-PEAP]/draft-kamath-pppext-peapv0。
 - [ ] M8.2 PEAP 外层 TLS 隧道建立与分片重组（复用 EAP-TLS 状态机）
 - [ ] M8.3 隧道内 EAP-MSCHAPv2 交换（复用 mschapv2 校验）与 MPPE 密钥导出
 - [ ] M8.4 明确失败原因 + AuthError 指标 + 单元测试；配置项与默认值（含安全风险说明）

--- a/internal/app/config_manager.go
+++ b/internal/app/config_manager.go
@@ -151,7 +151,7 @@ func (cm *ConfigManager) registerHardcodedSchemas() {
 		Key:         "radius.EapMethod",
 		Type:        TypeString,
 		Default:     "eap-md5",
-		Enum:        []string{"eap-md5", "eap-mschapv2", "eap-tls"},
+		Enum:        []string{"eap-md5", "eap-mschapv2", "eap-tls", "eap-peap"},
 		Description: "EAP authentication method",
 	})
 

--- a/internal/app/config_manager_test.go
+++ b/internal/app/config_manager_test.go
@@ -159,6 +159,7 @@ func TestConfigManagerJSON(t *testing.T) {
 	assert.Equal(t, "eap-md5", radiusEapSchema.Default, "radius.EapMethod default should be eap-md5")
 	assert.Contains(t, radiusEapSchema.Enum, "eap-md5", "Enum values should include eap-md5")
 	assert.Contains(t, radiusEapSchema.Enum, "eap-mschapv2", "Enum values should include eap-mschapv2")
+	assert.Contains(t, radiusEapSchema.Enum, "eap-peap", "Enum values should include eap-peap")
 	assert.Equal(t, "EAP Method", radiusEapSchema.Title)
 	assert.Equal(t, "config.radius.eap_method.title", radiusEapSchema.TitleI18n)
 	assert.Equal(t, "config.radius.eap_method.description", radiusEapSchema.DescI18n)

--- a/internal/app/config_schemas.json
+++ b/internal/app/config_schemas.json
@@ -4,7 +4,7 @@
       "key": "radius.EapMethod",
       "type": "string",
       "default": "eap-md5",
-      "enum": ["eap-md5", "eap-mschapv2", "eap-tls"],
+      "enum": ["eap-md5", "eap-mschapv2", "eap-tls", "eap-peap"],
       "title": "EAP Method",
       "title_i18n": "config.radius.eap_method.title",
       "description": "EAP authentication method",

--- a/internal/radiusd/plugins/eap/coordinator.go
+++ b/internal/radiusd/plugins/eap/coordinator.go
@@ -102,6 +102,8 @@ func (c *Coordinator) handleIdentityResponse(ctx *EAPContext, configuredMethod s
 		handler, _ = c.handlerRegistry.GetHandler(TypeOTP)
 	case "eap-tls":
 		handler, _ = c.handlerRegistry.GetHandler(TypeTLS)
+	case "eap-peap":
+		handler, _ = c.handlerRegistry.GetHandler(TypePEAP)
 	default:
 		// Default to MD5
 		handler, _ = c.handlerRegistry.GetHandler(TypeMD5Challenge)

--- a/internal/radiusd/plugins/eap/coordinator_test.go
+++ b/internal/radiusd/plugins/eap/coordinator_test.go
@@ -332,6 +332,31 @@ func TestHandleEAPRequest_IdentityResponse_OTP(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestHandleEAPRequest_IdentityResponse_PEAP(t *testing.T) {
+	registry := newMockHandlerRegistry()
+	registry.Register(&mockEAPHandler{
+		name:             "eap-peap",
+		eapType:          TypePEAP,
+		canHandle:        true,
+		handleIdentityOk: true,
+	})
+
+	coordinator := NewCoordinator(newMockStateManager(), &mockPasswordProvider{}, registry, false)
+	writer := &mockResponseWriter{}
+
+	packet := createEAPIdentityResponse(1, "peapuser")
+	req := &radius.Request{Packet: packet}
+	response := req.Response(radius.CodeAccessAccept)
+
+	handled, success, err := coordinator.HandleEAPRequest(
+		writer, req, &domain.RadiusUser{}, &domain.NetNas{}, response, "secret", false, "eap-peap",
+	)
+
+	assert.True(t, handled)
+	assert.False(t, success)
+	assert.NoError(t, err)
+}
+
 func TestHandleEAPRequest_IdentityResponse_DefaultToMD5(t *testing.T) {
 	registry := newMockHandlerRegistry()
 	registry.Register(&mockEAPHandler{

--- a/internal/radiusd/plugins/eap/errors.go
+++ b/internal/radiusd/plugins/eap/errors.go
@@ -34,4 +34,9 @@ var (
 	// EAP-TLS fragmentation exchange (e.g. a non-ACK arrives while the server is
 	// still sending fragments, RFC 5216 §2.1.5).
 	ErrTLSUnexpectedFragment = errors.New("EAP-TLS unexpected fragment in handshake exchange")
+	// ErrPEAPNotImplemented is returned by the PEAPv0 handler skeleton until the
+	// outer TLS tunnel and fragmentation are implemented (milestone M8.2). Like
+	// the EAP-TLS skeleton's guard, it guarantees the skeleton can never grant
+	// access before the tunnel exists.
+	ErrPEAPNotImplemented = errors.New("PEAP outer TLS tunnel is not implemented yet")
 )

--- a/internal/radiusd/plugins/eap/handlers/peap_handler.go
+++ b/internal/radiusd/plugins/eap/handlers/peap_handler.go
@@ -1,0 +1,129 @@
+package handlers
+
+import (
+	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap/tlsfragment"
+	"github.com/talkincode/toughradius/v9/pkg/common"
+	"layeh.com/radius"
+	"layeh.com/radius/rfc2865"
+)
+
+const (
+	// EAPMethodPEAP is the configuration / handler name for PEAPv0.
+	EAPMethodPEAP = "eap-peap"
+
+	// peapVersion0 is the PEAP version advertised in the low two bits of the
+	// PEAP Flags octet. PEAP repurposes EAP-TLS's two Reserved bits (RFC 5216
+	// §3.1) as a Version field; PEAPv0 is version 0 (Microsoft [MS-PEAP] §2.2.2,
+	// draft-kamath-pppext-peapv0 §1.1). Encoding version 0 makes the PEAPv0
+	// Start byte-identical to an EAP-TLS Start, so the shared tlsfragment
+	// framing applies unchanged.
+	peapVersion0 = 0x00
+)
+
+// PEAPHandler is the PEAPv0 (Protected EAP) authentication handler.
+//
+// PEAP establishes a TLS tunnel using only a server certificate (no client
+// certificate is required) and then runs an inner EAP method — for ToughRADIUS,
+// EAP-MSCHAPv2 — inside that tunnel, exporting MPPE keys from the TLS master
+// secret. The outer tunnel reuses the EAP-TLS Flags/fragmentation framing
+// (RFC 5216 §3.1) carried over RADIUS EAP-Message attributes (RFC 3579).
+//
+// PEAPv0 has no formal IETF RFC; it is specified by Microsoft [MS-PEAP] and
+// IETF draft-kamath-pppext-peapv0. It is a compatibility-first method for
+// Windows / Active Directory estates: the inner MS-CHAPv2 exchange carries the
+// same NTLMv1-class weaknesses Microsoft documents, so PEAP is appropriate for
+// "must serve legacy devices and AD users" deployments, not as a security
+// selling point.
+//
+// Milestone scope:
+//   - M8.1 (this skeleton): registers the method (EAP type 25, name
+//     "eap-peap"), answers EAP-Response/Identity with a PEAPv0 Start, and
+//     rejects every handshake response with eap.ErrPEAPNotImplemented so it can
+//     never authenticate before the tunnel exists.
+//   - M8.2: outer TLS tunnel establishment and fragmentation reassembly,
+//     reusing the EAP-TLS state machine.
+//   - M8.3: inner EAP-MSCHAPv2 exchange and MPPE key derivation.
+type PEAPHandler struct{}
+
+// NewPEAPHandler creates a PEAPv0 handler skeleton. It accepts the PEAP Start
+// exchange but rejects handshake attempts with eap.ErrPEAPNotImplemented until
+// the outer TLS tunnel is delivered (milestone M8.2).
+func NewPEAPHandler() *PEAPHandler {
+	return &PEAPHandler{}
+}
+
+// Name returns the handler name ("eap-peap").
+func (h *PEAPHandler) Name() string {
+	return EAPMethodPEAP
+}
+
+// EAPType returns the EAP method type code handled (25, PEAP).
+func (h *PEAPHandler) EAPType() uint8 {
+	return eap.TypePEAP
+}
+
+// CanHandle reports whether this handler can process the EAP message.
+func (h *PEAPHandler) CanHandle(ctx *eap.EAPContext) bool {
+	if ctx == nil || ctx.EAPMessage == nil {
+		return false
+	}
+	return ctx.EAPMessage.Type == eap.TypePEAP
+}
+
+// HandleIdentity handles EAP-Response/Identity by sending a PEAPv0 Start request
+// (an EAP-Request with EAP-Type=PEAP, the Start (S) bit set, version bits 0, and
+// no TLS data; Microsoft [MS-PEAP] §3.1.5.1, framing per RFC 5216 §3.1). It
+// persists handshake state keyed by the RADIUS State attribute so subsequent
+// rounds (milestone M8.2) can correlate the tunnel.
+func (h *PEAPHandler) HandleIdentity(ctx *eap.EAPContext) (bool, error) {
+	eapData := h.buildStartRequest(ctx.EAPMessage.Identifier)
+
+	stateID := common.UUID()
+	username := rfc2865.UserName_GetString(ctx.Request.Packet)
+
+	state := &eap.EAPState{
+		Username: username,
+		StateID:  stateID,
+		Method:   EAPMethodPEAP,
+		Success:  false,
+	}
+
+	if err := ctx.StateManager.SetState(stateID, state); err != nil {
+		return false, err
+	}
+
+	return true, h.writeChallenge(ctx, stateID, eapData)
+}
+
+// HandleResponse rejects every PEAP handshake response with
+// eap.ErrPEAPNotImplemented. The outer TLS tunnel is delivered in milestone
+// M8.2; until then the skeleton must never authenticate a client.
+func (h *PEAPHandler) HandleResponse(_ *eap.EAPContext) (bool, error) {
+	return false, eap.ErrPEAPNotImplemented
+}
+
+// buildStartRequest constructs a PEAPv0 Start request: an EAP-Request with
+// EAP-Type=PEAP and a single Flags octet carrying the Start (S) bit and PEAP
+// version 0. No TLS data is included, so the L bit is clear and the TLS Message
+// Length field is absent.
+func (h *PEAPHandler) buildStartRequest(identifier uint8) []byte {
+	frag := &tlsfragment.Packet{Flags: tlsfragment.FlagStart | peapVersion0}
+	msg := &eap.EAPMessage{
+		Code:       eap.CodeRequest,
+		Identifier: identifier,
+		Type:       eap.TypePEAP,
+		Data:       frag.Encode(),
+	}
+	return msg.Encode()
+}
+
+// writeChallenge sends eapData inside a RADIUS Access-Challenge, echoing the
+// handshake State attribute and protecting the response with a
+// Message-Authenticator (RFC 3579 §3.2).
+func (h *PEAPHandler) writeChallenge(ctx *eap.EAPContext, stateID string, eapData []byte) error {
+	response := ctx.Request.Response(radius.CodeAccessChallenge)
+	_ = rfc2865.State_SetString(response, stateID) //nolint:errcheck
+	eap.SetEAPMessageAndAuth(response, eapData, ctx.Secret)
+	return ctx.ResponseWriter.Write(response)
+}

--- a/internal/radiusd/plugins/eap/handlers/peap_handler_test.go
+++ b/internal/radiusd/plugins/eap/handlers/peap_handler_test.go
@@ -1,0 +1,148 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap/statemanager"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap/tlsfragment"
+	"layeh.com/radius"
+	"layeh.com/radius/rfc2865"
+	"layeh.com/radius/rfc2869"
+)
+
+func TestNewPEAPHandler(t *testing.T) {
+	assert.NotNil(t, NewPEAPHandler())
+}
+
+func TestPEAPHandler_Name(t *testing.T) {
+	assert.Equal(t, "eap-peap", NewPEAPHandler().Name())
+}
+
+func TestPEAPHandler_EAPType(t *testing.T) {
+	assert.Equal(t, uint8(eap.TypePEAP), NewPEAPHandler().EAPType())
+	assert.Equal(t, uint8(25), NewPEAPHandler().EAPType(), "PEAP is IANA EAP method type 25")
+}
+
+func TestPEAPHandler_CanHandle(t *testing.T) {
+	h := NewPEAPHandler()
+
+	tests := []struct {
+		name     string
+		ctx      *eap.EAPContext
+		expected bool
+	}{
+		{
+			name:     "can handle PEAP type",
+			ctx:      &eap.EAPContext{EAPMessage: &eap.EAPMessage{Type: eap.TypePEAP}},
+			expected: true,
+		},
+		{
+			name:     "cannot handle EAP-TLS type",
+			ctx:      &eap.EAPContext{EAPMessage: &eap.EAPMessage{Type: eap.TypeTLS}},
+			expected: false,
+		},
+		{
+			name:     "cannot handle nil message",
+			ctx:      &eap.EAPContext{EAPMessage: nil},
+			expected: false,
+		},
+		{
+			name:     "cannot handle nil context",
+			ctx:      nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, h.CanHandle(tt.ctx))
+		})
+	}
+}
+
+// TestPEAPHandler_HandleIdentity verifies a PEAPv0 Start (S bit set, version 0,
+// no data) is sent in an Access-Challenge with handshake state stored
+// (Microsoft [MS-PEAP] §3.1.5.1, framing per RFC 5216 §3.1).
+func TestPEAPHandler_HandleIdentity(t *testing.T) {
+	h := NewPEAPHandler()
+	stateManager := statemanager.NewMemoryStateManager()
+	writer := &mockResponseWriter{}
+
+	packet := radius.New(radius.CodeAccessRequest, []byte("secret"))
+	require.NoError(t, rfc2865.UserName_SetString(packet, "peapuser"))
+
+	ctx := &eap.EAPContext{
+		Context:        context.Background(),
+		Request:        &radius.Request{Packet: packet},
+		ResponseWriter: writer,
+		EAPMessage:     &eap.EAPMessage{Code: eap.CodeResponse, Identifier: 9, Type: eap.TypeIdentity},
+		StateManager:   stateManager,
+		Secret:         "secret",
+	}
+
+	handled, err := h.HandleIdentity(ctx)
+	require.NoError(t, err)
+	assert.True(t, handled)
+	require.NotNil(t, writer.response)
+	assert.Equal(t, radius.CodeAccessChallenge, writer.response.Code)
+
+	// A State attribute must be present so the client can echo it.
+	stateID := rfc2865.State_GetString(writer.response)
+	require.NotEmpty(t, stateID)
+	storedState, err := stateManager.GetState(stateID)
+	require.NoError(t, err)
+	assert.Equal(t, EAPMethodPEAP, storedState.Method)
+	assert.Equal(t, "peapuser", storedState.Username)
+	assert.False(t, storedState.Success)
+
+	// Verify the PEAPv0 Start payload.
+	eapData, err := rfc2869.EAPMessage_Lookup(writer.response)
+	require.NoError(t, err)
+	require.Len(t, eapData, 6)
+	assert.Equal(t, byte(eap.CodeRequest), eapData[0])
+	assert.Equal(t, byte(9), eapData[1])
+	assert.Equal(t, byte(eap.TypePEAP), eapData[4])
+	assert.Equal(t, byte(tlsfragment.FlagStart), eapData[5], "Start (S) bit must be set, version 0")
+	assert.Zero(t, eapData[5]&tlsfragment.FlagLengthIncluded, "L bit must be clear for a Start with no data")
+	assert.Zero(t, eapData[5]&0x03, "PEAPv0 version bits must be 0")
+}
+
+func TestPEAPHandler_buildStartRequest(t *testing.T) {
+	result := NewPEAPHandler().buildStartRequest(4)
+
+	require.Len(t, result, 6)
+	assert.Equal(t, byte(eap.CodeRequest), result[0], "Code should be Request")
+	assert.Equal(t, byte(4), result[1], "Identifier should match")
+	actualLen := (int(result[2]) << 8) | int(result[3])
+	assert.Equal(t, 6, actualLen, "Length should be 6")
+	assert.Equal(t, byte(eap.TypePEAP), result[4], "Type should be PEAP")
+	assert.Equal(t, byte(tlsfragment.FlagStart), result[5], "Flags should have only the Start bit set (version 0)")
+}
+
+// TestPEAPHandler_HandleResponse_NeverAuthenticates ensures the M8.1 skeleton
+// can never grant access: every handshake response is rejected with
+// eap.ErrPEAPNotImplemented until the outer TLS tunnel (M8.2) exists.
+func TestPEAPHandler_HandleResponse_NeverAuthenticates(t *testing.T) {
+	h := NewPEAPHandler()
+
+	packet := radius.New(radius.CodeAccessRequest, []byte("secret"))
+	require.NoError(t, rfc2865.State_SetString(packet, "peap-state-1"))
+
+	ctx := &eap.EAPContext{
+		Context:      context.Background(),
+		Request:      &radius.Request{Packet: packet},
+		EAPMessage:   &eap.EAPMessage{Code: eap.CodeResponse, Identifier: 10, Type: eap.TypePEAP, Data: []byte{tlsfragment.FlagLengthIncluded}},
+		StateManager: statemanager.NewMemoryStateManager(),
+		Secret:       "secret",
+	}
+
+	success, err := h.HandleResponse(ctx)
+	assert.False(t, success, "skeleton must never authenticate")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, eap.ErrPEAPNotImplemented))
+}

--- a/internal/radiusd/plugins/eap/interfaces.go
+++ b/internal/radiusd/plugins/eap/interfaces.go
@@ -24,6 +24,7 @@ const (
 	TypeOTP          = 5  // One-Time Password
 	TypeGTC          = 6  // Generic Token Card
 	TypeTLS          = 13 // EAP-TLS
+	TypePEAP         = 25 // Protected EAP (PEAP), IANA EAP method type 25
 	TypeMSCHAPv2     = 26 // EAP-MSCHAPv2
 )
 

--- a/internal/radiusd/plugins/init.go
+++ b/internal/radiusd/plugins/init.go
@@ -78,5 +78,13 @@ func InitPlugins(appCtx app.ConfigManagerProvider, sessionRepo repository.Sessio
 		registry.RegisterEAPHandler(eaphandlers.NewTLSHandler())
 	}
 
+	// PEAPv0 (EAP type 25) is a compatibility-first tunneled method for
+	// Windows / Active Directory estates. Milestone M8.1 registers the handler
+	// skeleton: it answers EAP-Response/Identity with a PEAPv0 Start but rejects
+	// every handshake response with eap.ErrPEAPNotImplemented, so it can never
+	// authenticate a client until the outer TLS tunnel (M8.2) and inner
+	// EAP-MSCHAPv2 exchange (M8.3) are delivered.
+	registry.RegisterEAPHandler(eaphandlers.NewPEAPHandler())
+
 	// Vendor parsers under vendor/parsers register themselves via init()
 }


### PR DESCRIPTION
## What & why

Delivers **M8.1** — the first subtask of milestone **M8 (PEAPv0 / EAP-MSCHAPv2 认证支持)**: register the **PEAPv0** (IANA EAP method type **25**, name `eap-peap`) handler **skeleton** plus its `EapMethod` enable-list config, within the existing EAP plugin system. This wires the method end-to-end **without yet establishing the tunnel** — the outer TLS tunnel is M8.2 and the inner EAP-MSCHAPv2 exchange is M8.3.

Anchored to `TR-F004`. PEAP is a **compatibility-first** method for Windows / Active Directory estates; it is not a security selling point (the inner MS-CHAPv2 carries NTLMv1-class weaknesses Microsoft documents). The handler doc comment states this explicitly.

## Changes

- **`eap.TypePEAP = 25`** constant + **`eap.ErrPEAPNotImplemented`** safety guard.
- **`peap_handler.go`** (new skeleton):
  - `Name()` → `eap-peap`, `EAPType()` → 25, `CanHandle()` → type check.
  - `HandleIdentity()` sends a **PEAPv0 Start** (EAP-Request/PEAP, Start `S` bit set, version bits 0), reusing the EAP-TLS Flags/fragmentation framing (RFC 5216 §3.1), and persists handshake state keyed by the RADIUS `State` attribute.
  - `HandleResponse()` rejects **every** handshake response with `ErrPEAPNotImplemented`, so the skeleton can **never authenticate** before the tunnel exists (same safety philosophy as the EAP-TLS skeleton's `ErrTLSNotConfigured`).
- **Coordinator**: select the PEAP handler for `configuredMethod == "eap-peap"`.
- **`plugins/init.go`**: register `NewPEAPHandler()`.
- **Config**: add `eap-peap` to the `radius.EapMethod` enum (`config_schemas.json` + hardcoded fallback) so operators can select it.

## Tests (CI `test` job)

- `peap_handler_test.go`: `Name`/`EAPType` (==25)/`CanHandle`, `HandleIdentity` emits a 6-byte PEAPv0 Start with the `S` bit set + version 0 + `L` clear and stores state, `buildStartRequest` framing, and a **never-authenticate** guard asserting `errors.Is(err, ErrPEAPNotImplemented)`.
- `coordinator_test.go`: `eap-peap` resolves to the PEAP handler (type 25).
- `config_manager_test.go`: the `EapMethod` enum contains `eap-peap`.

> M8.1 acceptance is unit-test backed; the PEAP-MSCHAPv2 end-to-end integration acceptance under `test/integration/` is milestone **M8.5** (after the tunnel + inner method land).

## Protocol references

PEAPv0 has no formal IETF RFC. Framing cites `docs/rfcs/rfc3748-eap.txt`, `rfc3579-radius-eap-support.txt`, and `rfc5216-eap-tls.txt` §3.1 (shared Flags/fragmentation); PEAPv0 specifics per Microsoft **[MS-PEAP]** and IETF **draft-kamath-pppext-peapv0**.

## Quality gates

- [x] `go build ./...`
- [x] `go test ./...` (full unit suite)
- [x] `golangci-lint run` (v2.12.2) on the affected packages → **0 issues**

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
