### PR TITLE
feat(eap): PEAP outer TLS tunnel with server-only mode (M8.2)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -186,7 +186,7 @@
 
 子任务：
 - [x] M8.1 注册 PEAP handler 骨架与启用列表配置（`EapMethod`）<br/>已交付：新增 `eap.TypePEAP=25` 常量与 `ErrPEAPNotImplemented` 安全护栏；`peap_handler.go` 骨架（`Name/EAPType/CanHandle`，`HandleIdentity` 下发 PEAPv0 Start（S 位 + version 0，复用 EAP-TLS Flags/分片帧格式），`HandleResponse` 在外层隧道（M8.2）落地前一律以 `ErrPEAPNotImplemented` 拒绝，永不放行）；coordinator 选择分支与 `plugins/init.go` 注册接入；`config_schemas.json` 与硬编码兜底 `EapMethod` 枚举加入 `eap-peap`。单测覆盖 handler、coordinator 方法选择与枚举。引用 RFC 3748/3579、RFC 5216 §3.1 帧格式与 PEAPv0 [MS-PEAP]/draft-kamath-pppext-peapv0。
-- [ ] M8.2 PEAP 外层 TLS 隧道建立与分片重组（复用 EAP-TLS 状态机）
+- [x] M8.2 PEAP 外层 TLS 隧道建立与分片重组（复用 EAP-TLS 状态机）<br/>已交付：`tlsengine` 新增 `Config.ServerOnly`（仅服务器证书认证，不要求 `ClientCAs`，`ClientAuth=NoClientCert`；EAP-TLS 路径 `ServerOnly=false` 行为字节级不变）；抽取共享隧道驱动 `tls_tunnel.go`（`tlsTunnel` 三阶段状态机，参数化 `eapType`/`configProvider`/`onHandshakeComplete`，EAP-TLS 与 PEAP 各 `newTunnel()` 复用，握手态仍全部经 StateManager 持久化）；`tls_handler.go` 行为保持式委派到隧道（`eapType=TypeTLS`，回调 `finalizeWithEngine` 凭证身份放行）；`peap_handler.go` 新增 `NewPEAPHandlerWithConfig`/`newTunnel()`，`onHandshakeComplete` 关闭引擎并 `Success=false` 返回 `ErrPEAPInnerNotImplemented`——**隧道建成但 M8.2 永不放行**（内层 EAP-MSCHAPv2 留待 M8.3）；`tls_config.go` 新增 `NewSettingsPEAPConfigProvider`（复用 `EapTlsCertFile/KeyFile`，`ServerOnly:true`，未配置返回 nil 安全拒绝）；`init.go` 在 ConfigMgr 可用时注入 PEAP 配置 provider。测试：server-only 引擎握手 + `Identity()` 返回 `ErrNoPeerCertificate`；PEAP 完整握手（单帧 + `maxFragment=64` 分片）均断言隧道建成后以 `ErrPEAPInnerNotImplemented` 拒绝且 `state.Success=false`；未配置证书时以 `ErrTLSNotConfigured` 拒绝；既有 EAP-TLS 握手测试不变通过。引用 RFC 5216 §2.1.5/§3.1（分片与帧格式）、PEAPv0 [MS-PEAP]。
 - [ ] M8.3 隧道内 EAP-MSCHAPv2 交换（复用 mschapv2 校验）与 MPPE 密钥导出
 - [ ] M8.4 明确失败原因 + AuthError 指标 + 单元测试；配置项与默认值（含安全风险说明）
 - [ ] M8.5 在 `test/integration/` 增加 PEAP-MSCHAPv2 端到端验收用例（CI 自动执行）

--- a/internal/radiusd/plugins/eap/errors.go
+++ b/internal/radiusd/plugins/eap/errors.go
@@ -34,9 +34,8 @@ var (
 	// EAP-TLS fragmentation exchange (e.g. a non-ACK arrives while the server is
 	// still sending fragments, RFC 5216 §2.1.5).
 	ErrTLSUnexpectedFragment = errors.New("EAP-TLS unexpected fragment in handshake exchange")
-	// ErrPEAPNotImplemented is returned by the PEAPv0 handler skeleton until the
-	// outer TLS tunnel and fragmentation are implemented (milestone M8.2). Like
-	// the EAP-TLS skeleton's guard, it guarantees the skeleton can never grant
-	// access before the tunnel exists.
-	ErrPEAPNotImplemented = errors.New("PEAP outer TLS tunnel is not implemented yet")
+	// ErrPEAPInnerNotImplemented is returned after PEAP's outer TLS tunnel has
+	// been established but before the inner EAP method is implemented (milestone
+	// M8.3). It guarantees M8.2 can never grant access.
+	ErrPEAPInnerNotImplemented = errors.New("PEAP inner EAP method is not implemented yet")
 )

--- a/internal/radiusd/plugins/eap/handlers/peap_handler.go
+++ b/internal/radiusd/plugins/eap/handlers/peap_handler.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap/tlsengine"
 	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap/tlsfragment"
 	"github.com/talkincode/toughradius/v9/pkg/common"
 	"layeh.com/radius"
@@ -37,20 +38,45 @@ const (
 // selling point.
 //
 // Milestone scope:
-//   - M8.1 (this skeleton): registers the method (EAP type 25, name
-//     "eap-peap"), answers EAP-Response/Identity with a PEAPv0 Start, and
-//     rejects every handshake response with eap.ErrPEAPNotImplemented so it can
-//     never authenticate before the tunnel exists.
-//   - M8.2: outer TLS tunnel establishment and fragmentation reassembly,
-//     reusing the EAP-TLS state machine.
+//   - M8.1: registered the method (EAP type 25, name "eap-peap") and answered
+//     EAP-Response/Identity with a PEAPv0 Start.
+//   - M8.2 (current): establishes the outer TLS tunnel and fragmentation
+//     reassembly, reusing the EAP-TLS state machine, then rejects with
+//     eap.ErrPEAPInnerNotImplemented because inner authentication is not present.
 //   - M8.3: inner EAP-MSCHAPv2 exchange and MPPE key derivation.
-type PEAPHandler struct{}
+type PEAPHandler struct {
+	configProvider TLSConfigProvider
+	maxFragment    int
+}
 
-// NewPEAPHandler creates a PEAPv0 handler skeleton. It accepts the PEAP Start
-// exchange but rejects handshake attempts with eap.ErrPEAPNotImplemented until
-// the outer TLS tunnel is delivered (milestone M8.2).
+// NewPEAPHandler creates a PEAPv0 handler without TLS material configured. It
+// accepts the PEAP Start exchange but rejects handshake attempts safely until a
+// server-certificate config provider is supplied.
 func NewPEAPHandler() *PEAPHandler {
-	return &PEAPHandler{}
+	return &PEAPHandler{maxFragment: defaultMaxTLSFragment}
+}
+
+// NewPEAPHandlerWithConfig creates a PEAPv0 handler that drives the outer TLS
+// tunnel using the TLS material returned by provider.
+func NewPEAPHandlerWithConfig(provider TLSConfigProvider) *PEAPHandler {
+	return &PEAPHandler{configProvider: provider, maxFragment: defaultMaxTLSFragment}
+}
+
+func (h *PEAPHandler) newTunnel() *tlsTunnel {
+	return &tlsTunnel{
+		eapType:        eap.TypePEAP,
+		maxFragment:    h.maxFragment,
+		configProvider: h.configProvider,
+		onHandshakeComplete: func(ctx *eap.EAPContext, state *eap.EAPState, engine *tlsengine.Engine) (bool, error) {
+			defer func() { _ = engine.Close() }()
+			state.Success = false
+			clearKey(state, stateKeyEngine)
+			if err := ctx.StateManager.SetState(state.StateID, state); err != nil {
+				return false, err
+			}
+			return false, eap.ErrPEAPInnerNotImplemented
+		},
+	}
 }
 
 // Name returns the handler name ("eap-peap").
@@ -96,11 +122,12 @@ func (h *PEAPHandler) HandleIdentity(ctx *eap.EAPContext) (bool, error) {
 	return true, h.writeChallenge(ctx, stateID, eapData)
 }
 
-// HandleResponse rejects every PEAP handshake response with
-// eap.ErrPEAPNotImplemented. The outer TLS tunnel is delivered in milestone
-// M8.2; until then the skeleton must never authenticate a client.
-func (h *PEAPHandler) HandleResponse(_ *eap.EAPContext) (bool, error) {
-	return false, eap.ErrPEAPNotImplemented
+// HandleResponse drives PEAP's outer TLS tunnel and fragmentation using the
+// shared EAP-TLS state machine (RFC 5216 §2.1.5/§3.1; PEAPv0 [MS-PEAP]). M8.2
+// deliberately rejects after the tunnel completes because the inner EAP method
+// is M8.3 scope, so this handler can never authenticate yet.
+func (h *PEAPHandler) HandleResponse(ctx *eap.EAPContext) (bool, error) {
+	return h.newTunnel().HandleResponse(ctx)
 }
 
 // buildStartRequest constructs a PEAPv0 Start request: an EAP-Request with

--- a/internal/radiusd/plugins/eap/handlers/peap_handler_test.go
+++ b/internal/radiusd/plugins/eap/handlers/peap_handler_test.go
@@ -2,13 +2,16 @@ package handlers
 
 import (
 	"context"
-	"errors"
+	"crypto/tls"
+	"crypto/x509"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap"
 	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap/statemanager"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap/tlsengine"
 	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap/tlsfragment"
 	"layeh.com/radius"
 	"layeh.com/radius/rfc2865"
@@ -124,25 +127,84 @@ func TestPEAPHandler_buildStartRequest(t *testing.T) {
 	assert.Equal(t, byte(tlsfragment.FlagStart), result[5], "Flags should have only the Start bit set (version 0)")
 }
 
-// TestPEAPHandler_HandleResponse_NeverAuthenticates ensures the M8.1 skeleton
-// can never grant access: every handshake response is rejected with
-// eap.ErrPEAPNotImplemented until the outer TLS tunnel (M8.2) exists.
-func TestPEAPHandler_HandleResponse_NeverAuthenticates(t *testing.T) {
+// TestPEAPHandler_HandleResponse_NeverAuthenticatesWithoutConfig ensures PEAP
+// rejects safely before server certificate/key material is configured.
+func TestPEAPHandler_HandleResponse_NeverAuthenticatesWithoutConfig(t *testing.T) {
 	h := NewPEAPHandler()
 
 	packet := radius.New(radius.CodeAccessRequest, []byte("secret"))
 	require.NoError(t, rfc2865.State_SetString(packet, "peap-state-1"))
+	sm := statemanager.NewMemoryStateManager()
+	require.NoError(t, sm.SetState("peap-state-1", &eap.EAPState{StateID: "peap-state-1", Method: EAPMethodPEAP}))
 
 	ctx := &eap.EAPContext{
 		Context:      context.Background(),
 		Request:      &radius.Request{Packet: packet},
-		EAPMessage:   &eap.EAPMessage{Code: eap.CodeResponse, Identifier: 10, Type: eap.TypePEAP, Data: []byte{tlsfragment.FlagLengthIncluded}},
-		StateManager: statemanager.NewMemoryStateManager(),
+		EAPMessage:   &eap.EAPMessage{Code: eap.CodeResponse, Identifier: 10, Type: eap.TypePEAP, Data: []byte{0x00, 0x16, 0x03, 0x01}},
+		StateManager: sm,
 		Secret:       "secret",
 	}
 
 	success, err := h.HandleResponse(ctx)
-	assert.False(t, success, "skeleton must never authenticate")
+	assert.False(t, success, "PEAP must never authenticate without an outer TLS server certificate")
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, eap.ErrPEAPNotImplemented))
+	assert.ErrorIs(t, err, eap.ErrTLSNotConfigured)
+}
+
+func TestPEAPHandler_FullHandshake_TunnelCompletesThenRejectsInner(t *testing.T) {
+	ca := newHSTestCA(t, "PEAP Root CA")
+	cfg := peapServerEngineConfig(t, ca)
+	h := NewPEAPHandlerWithConfig(func() (*tlsengine.Config, error) { return cfg, nil })
+
+	sm := statemanager.NewMemoryStateManager()
+	defer sm.Close()
+
+	stateID := startHandshake(t, h, sm, "peapuser", "secret")
+	sup := newSupplicantForType(t, h, eap.TypePEAP, sm, stateID, "secret", peapClientCfg(ca))
+	success, err := sup.run()
+	assert.False(t, success, "PEAP M8.2 must not authenticate before inner EAP is implemented")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, eap.ErrPEAPInnerNotImplemented)
+
+	state, err := sm.GetState(stateID)
+	require.NoError(t, err)
+	assert.False(t, state.Success)
+}
+
+func TestPEAPHandler_FullHandshake_FragmentedTunnelCompletesThenRejectsInner(t *testing.T) {
+	ca := newHSTestCA(t, "PEAP Fragment Root CA")
+	cfg := peapServerEngineConfig(t, ca)
+	h := NewPEAPHandlerWithConfig(func() (*tlsengine.Config, error) { return cfg, nil })
+	h.maxFragment = 64
+
+	sm := statemanager.NewMemoryStateManager()
+	defer sm.Close()
+
+	stateID := startHandshake(t, h, sm, "peapuser", "secret")
+	sup := newSupplicantForType(t, h, eap.TypePEAP, sm, stateID, "secret", peapClientCfg(ca))
+	success, err := sup.run()
+	assert.False(t, success, "fragmented PEAP M8.2 tunnel must still reject before inner EAP")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, eap.ErrPEAPInnerNotImplemented)
+}
+
+func peapServerEngineConfig(t *testing.T, serverCA *hsTestCA) *tlsengine.Config {
+	t.Helper()
+	serverCert := serverCA.issue(t, "radius.example.com", func(c *x509.Certificate) {
+		c.DNSNames = []string{"radius.example.com"}
+	})
+	return &tlsengine.Config{
+		ServerCertificate: serverCert,
+		ServerOnly:        true,
+		MinVersion:        tls.VersionTLS12,
+		HandshakeTimeout:  5 * time.Second,
+	}
+}
+
+func peapClientCfg(serverCA *hsTestCA) *tls.Config {
+	return &tls.Config{
+		RootCAs:    serverCA.pool,
+		ServerName: "radius.example.com",
+		MinVersion: tls.VersionTLS12,
+	}
 }

--- a/internal/radiusd/plugins/eap/handlers/tls_config.go
+++ b/internal/radiusd/plugins/eap/handlers/tls_config.go
@@ -84,6 +84,39 @@ func NewSettingsTLSConfigProvider(reader TLSSettingsReader) TLSConfigProvider {
 	}
 }
 
+// NewSettingsPEAPConfigProvider returns a TLSConfigProvider for PEAP's outer
+// server-authenticated tunnel.
+//
+// PEAPv0 ([MS-PEAP]) reuses the EAP-TLS fragmentation/framing defined by
+// RFC 5216 §2.1.5 and §3.1 but authenticates the peer with an inner EAP method,
+// so no client CA is required for the outer TLS handshake. M8.2 intentionally
+// reuses the existing EAP-TLS server certificate settings; PEAP-specific
+// certificate overrides can be added in M8.4 without changing the state machine.
+func NewSettingsPEAPConfigProvider(reader TLSSettingsReader) TLSConfigProvider {
+	return func() (*tlsengine.Config, error) {
+		if reader == nil {
+			return nil, nil
+		}
+
+		certFile := strings.TrimSpace(reader.GetString("radius", SettingEapTlsCertFile))
+		keyFile := strings.TrimSpace(reader.GetString("radius", SettingEapTlsKeyFile))
+		if certFile == "" || keyFile == "" {
+			return nil, nil
+		}
+
+		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			return nil, fmt.Errorf("load PEAP server certificate: %w", err)
+		}
+
+		return &tlsengine.Config{
+			ServerCertificate: cert,
+			ServerOnly:        true,
+			MinVersion:        parseTLSMinVersion(reader.GetString("radius", SettingEapTlsMinVersion)),
+		}, nil
+	}
+}
+
 // parseTLSMinVersion maps a configured minimum TLS version string to the
 // crypto/tls constant. It defaults to TLS 1.2, the interoperability floor for
 // modern EAP-TLS deployments; an unrecognized value falls back to the same

--- a/internal/radiusd/plugins/eap/handlers/tls_config_test.go
+++ b/internal/radiusd/plugins/eap/handlers/tls_config_test.go
@@ -227,3 +227,54 @@ func TestNewSettingsTLSConfigProvider_LoadErrors(t *testing.T) {
 		}
 	})
 }
+
+func TestNewSettingsPEAPConfigProvider_ValidMaterial(t *testing.T) {
+	certFile, keyFile, _ := writeTestCertFiles(t)
+	reader := newFakeReader(map[string]string{
+		"radius." + SettingEapTlsCertFile:   certFile,
+		"radius." + SettingEapTlsKeyFile:    keyFile,
+		"radius." + SettingEapTlsMinVersion: "1.3",
+	})
+
+	cfg, err := NewSettingsPEAPConfigProvider(reader)()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config for PEAP server material")
+	}
+	if !cfg.ServerOnly {
+		t.Fatal("expected PEAP config to use server-only TLS")
+	}
+	if cfg.ClientCAs != nil {
+		t.Fatal("PEAP outer TLS must not require a client CA")
+	}
+	if cfg.MinVersion != tls.VersionTLS13 {
+		t.Fatalf("expected MinVersion TLS 1.3, got %#x", cfg.MinVersion)
+	}
+}
+
+func TestNewSettingsPEAPConfigProvider_NotConfigured(t *testing.T) {
+	cases := map[string]map[string]string{
+		"nil reader": nil,
+		"all empty":  {},
+		"only cert": {
+			"radius." + SettingEapTlsCertFile: "server.crt",
+		},
+	}
+	for name, values := range cases {
+		t.Run(name, func(t *testing.T) {
+			var reader TLSSettingsReader
+			if values != nil {
+				reader = newFakeReader(values)
+			}
+			cfg, err := NewSettingsPEAPConfigProvider(reader)()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cfg != nil {
+				t.Fatalf("expected nil config when PEAP is not configured, got %#v", cfg)
+			}
+		})
+	}
+}

--- a/internal/radiusd/plugins/eap/handlers/tls_handler.go
+++ b/internal/radiusd/plugins/eap/handlers/tls_handler.go
@@ -43,9 +43,9 @@ const (
 	defaultMaxTLSFragment = 1024
 )
 
-// TLSConfigProvider supplies the per-handshake TLS materials (server
-// certificate and client CA pool) for EAP-TLS. It returns a nil config (and nil
-// error) when EAP-TLS is not configured, in which case the handler rejects
+// TLSConfigProvider supplies the per-handshake TLS materials for EAP-TLS and
+// server-only tunneled methods such as PEAP. It returns a nil config (and nil
+// error) when the method is not configured, in which case the handler rejects
 // safely. The provider is consulted at the start of each handshake so that
 // certificate/CA changes take effect without restarting the handler.
 type TLSConfigProvider func() (*tlsengine.Config, error)
@@ -79,6 +79,17 @@ func NewTLSHandler() *TLSHandler {
 // using the TLS material returned by provider.
 func NewTLSHandlerWithConfig(provider TLSConfigProvider) *TLSHandler {
 	return &TLSHandler{configProvider: provider, maxFragment: defaultMaxTLSFragment}
+}
+
+func (h *TLSHandler) newTunnel() *tlsTunnel {
+	return &tlsTunnel{
+		eapType:        eap.TypeTLS,
+		maxFragment:    h.maxFragment,
+		configProvider: h.configProvider,
+		onHandshakeComplete: func(ctx *eap.EAPContext, state *eap.EAPState, engine *tlsengine.Engine) (bool, error) {
+			return h.finalizeWithEngine(ctx, state, engine)
+		},
+	}
 }
 
 // Name returns the handler name.
@@ -132,156 +143,10 @@ func (h *TLSHandler) HandleIdentity(ctx *eap.EAPContext) (bool, error) {
 // the verified certificate identity to the RADIUS User-Name before granting
 // access. Every failure path returns an explicit error and never authenticates.
 func (h *TLSHandler) HandleResponse(ctx *eap.EAPContext) (bool, error) {
-	stateID := rfc2865.State_GetString(ctx.Request.Packet)
-	if stateID == "" {
-		return false, eap.ErrStateNotFound
-	}
-
-	state, err := ctx.StateManager.GetState(stateID)
-	if err != nil {
-		return false, err
-	}
-
-	frag, err := tlsfragment.Parse(ctx.EAPMessage.Data)
-	if err != nil {
-		return false, err
-	}
-
-	// Phase A: the server has finished sending its final flight and is waiting
-	// for the peer's closing ACK before EAP-Success.
-	if getBool(state, stateKeyPendingSuccess) {
-		if !frag.IsACK() {
-			closeEngine(state)
-			return false, eap.ErrTLSUnexpectedFragment
-		}
-		return h.finalize(ctx, state)
-	}
-
-	// Phase B: the server is in the middle of sending a fragmented flight; the
-	// peer must ACK before the next fragment is sent (RFC 5216 §2.1.5).
-	if h.hasQueuedFragments(state) {
-		return h.sendNextFragment(ctx, state, frag)
-	}
-
-	// Phase C: accumulate the inbound flight, then feed it to the TLS engine.
-	reassembler := loadReassembler(state)
-	complete, err := reassembler.Accept(frag)
-	if err != nil {
-		closeEngine(state)
-		return false, err
-	}
-
-	if !complete {
-		// More fragments to come: persist progress and acknowledge this
-		// fragment so the peer sends the next one (RFC 5216 §2.1.5).
-		saveReassembler(state, reassembler)
-		if err := ctx.StateManager.SetState(stateID, state); err != nil {
-			closeEngine(state)
-			return false, err
-		}
-		ackData := h.buildFragmentACK(ctx.EAPMessage.Identifier + 1)
-		return false, h.writeChallenge(ctx, stateID, ackData)
-	}
-
-	tlsInput := reassembler.Buffer()
-	resetReassembler(state)
-	return h.advanceHandshake(ctx, state, tlsInput)
+	return h.newTunnel().HandleResponse(ctx)
 }
 
-// advanceHandshake feeds the assembled inbound TLS bytes to the engine and
-// dispatches the resulting outbound flight (fragmenting as needed).
-func (h *TLSHandler) advanceHandshake(ctx *eap.EAPContext, state *eap.EAPState, tlsInput []byte) (bool, error) {
-	engine, err := h.engineFor(state)
-	if err != nil {
-		return false, err
-	}
-
-	out, done, hsErr := engine.Process(tlsInput)
-	if hsErr != nil {
-		// A handshake failure (including an untrusted client certificate)
-		// rejects with an explicit, wrapped reason (RFC 5216 §2.2 / §5.3).
-		closeEngine(state)
-		return false, fmt.Errorf("%w: %v", eap.ErrTLSHandshakeFailed, hsErr)
-	}
-
-	if len(out) == 0 {
-		if done {
-			// Nothing left to transmit: authenticate immediately.
-			return h.finalize(ctx, state)
-		}
-		// A complete inbound EAP-TLS message that neither advances the TLS
-		// handshake nor completes it is a protocol violation; do not keep an
-		// unreachable engine alive after state cleanup.
-		closeEngine(state)
-		return false, eap.ErrTLSUnexpectedFragment
-	}
-
-	return h.startFlight(ctx, state, out, done)
-}
-
-// startFlight fragments an outbound TLS flight, sends the first fragment, and
-// queues the remainder for subsequent ACK-driven rounds.
-func (h *TLSHandler) startFlight(ctx *eap.EAPContext, state *eap.EAPState, tlsData []byte, done bool) (bool, error) {
-	packets, err := tlsfragment.Fragment(tlsData, h.maxFragment)
-	if err != nil {
-		return false, err
-	}
-
-	first, rest := packets[0], packets[1:]
-	setBool(state, stateKeyHandshakeDone, done)
-
-	if len(rest) > 0 {
-		setFragments(state, rest)
-	} else if done {
-		// Single-fragment final flight: the peer's next message is the closing
-		// ACK that triggers EAP-Success.
-		setBool(state, stateKeyPendingSuccess, true)
-	}
-
-	if err := ctx.StateManager.SetState(state.StateID, state); err != nil {
-		closeEngine(state)
-		return false, err
-	}
-	return false, h.writeChallenge(ctx, state.StateID, h.buildEAPRequest(ctx.EAPMessage.Identifier+1, first))
-}
-
-// sendNextFragment handles a peer ACK while the server is sending a fragmented
-// flight, transmitting the next queued fragment.
-func (h *TLSHandler) sendNextFragment(ctx *eap.EAPContext, state *eap.EAPState, frag *tlsfragment.Packet) (bool, error) {
-	if !frag.IsACK() {
-		closeEngine(state)
-		return false, eap.ErrTLSUnexpectedFragment
-	}
-
-	queue := getFragments(state)
-	next := queue[0]
-	queue = queue[1:]
-
-	if len(queue) > 0 {
-		setFragments(state, queue)
-	} else {
-		clearKey(state, stateKeyOutFrags)
-		if getBool(state, stateKeyHandshakeDone) {
-			// Last fragment of the final flight: the next peer message is the
-			// closing ACK that triggers EAP-Success.
-			setBool(state, stateKeyPendingSuccess, true)
-		}
-	}
-
-	if err := ctx.StateManager.SetState(state.StateID, state); err != nil {
-		closeEngine(state)
-		return false, err
-	}
-	return false, h.writeChallenge(ctx, state.StateID, h.buildEAPRequest(ctx.EAPMessage.Identifier+1, next))
-}
-
-// finalize completes a successful handshake by mapping the verified certificate
-// identity to the RADIUS User-Name (RFC 5216 §5.2) and granting access.
-func (h *TLSHandler) finalize(ctx *eap.EAPContext, state *eap.EAPState) (bool, error) {
-	engine, err := h.engineFor(state)
-	if err != nil {
-		return false, err
-	}
+func (h *TLSHandler) finalizeWithEngine(ctx *eap.EAPContext, state *eap.EAPState, engine *tlsengine.Engine) (bool, error) {
 	defer func() { _ = engine.Close() }()
 
 	identity, err := engine.Identity()
@@ -306,37 +171,6 @@ func (h *TLSHandler) finalize(ctx *eap.EAPContext, state *eap.EAPState) (bool, e
 	return true, nil
 }
 
-// engineFor returns the live handshake engine for this state, creating it on the
-// first handshake message from the configured TLS material.
-func (h *TLSHandler) engineFor(state *eap.EAPState) (*tlsengine.Engine, error) {
-	if state.Data != nil {
-		if e, ok := state.Data[stateKeyEngine].(*tlsengine.Engine); ok && e != nil {
-			return e, nil
-		}
-	}
-
-	if h.configProvider == nil {
-		return nil, eap.ErrTLSNotConfigured
-	}
-	cfg, err := h.configProvider()
-	if err != nil {
-		return nil, fmt.Errorf("%w: %v", eap.ErrTLSNotConfigured, err)
-	}
-	if cfg == nil {
-		return nil, eap.ErrTLSNotConfigured
-	}
-
-	engine, err := tlsengine.New(cfg)
-	if err != nil {
-		return nil, fmt.Errorf("%w: %v", eap.ErrTLSNotConfigured, err)
-	}
-	if state.Data == nil {
-		state.Data = make(map[string]interface{})
-	}
-	state.Data[stateKeyEngine] = engine
-	return engine, nil
-}
-
 // writeChallenge sends eapData inside a RADIUS Access-Challenge, echoing the
 // handshake State attribute and protecting the response with a
 // Message-Authenticator.
@@ -354,13 +188,6 @@ func (h *TLSHandler) writeChallenge(ctx *eap.EAPContext, stateID string, eapData
 // is clear and the TLS Message Length field is absent.
 func (h *TLSHandler) buildStartRequest(identifier uint8) []byte {
 	return h.buildEAPRequest(identifier, &tlsfragment.Packet{Flags: tlsfragment.FlagStart})
-}
-
-// buildFragmentACK constructs an EAP-Request/EAP-TLS fragment acknowledgement: a
-// payload with a single flags octet (all flags clear) and no TLS data
-// (RFC 5216 §2.1.5).
-func (h *TLSHandler) buildFragmentACK(identifier uint8) []byte {
-	return h.buildEAPRequest(identifier, &tlsfragment.Packet{})
 }
 
 // buildEAPRequest wraps an EAP-TLS payload in an EAP-Request header.
@@ -415,10 +242,6 @@ func resetReassembler(state *eap.EAPState) {
 }
 
 // --- small typed helpers over the untyped state.Data map ------------------
-
-func (h *TLSHandler) hasQueuedFragments(state *eap.EAPState) bool {
-	return len(getFragments(state)) > 0
-}
 
 func getFragments(state *eap.EAPState) []*tlsfragment.Packet {
 	if state.Data == nil {

--- a/internal/radiusd/plugins/eap/handlers/tls_handler_handshake_test.go
+++ b/internal/radiusd/plugins/eap/handlers/tls_handler_handshake_test.go
@@ -176,7 +176,8 @@ func (c *hsConn) SetWriteDeadline(time.Time) error { return nil }
 // fragments and acknowledging each one per RFC 5216 §2.1.5.
 type supplicant struct {
 	t          *testing.T
-	h          *TLSHandler
+	h          eap.EAPHandler
+	eapType    uint8
 	sm         eap.EAPStateManager
 	stateID    string
 	secret     string
@@ -189,6 +190,10 @@ type supplicant struct {
 
 // newSupplicant starts a TLS client handshake bound to the handler's state.
 func newSupplicant(t *testing.T, h *TLSHandler, sm eap.EAPStateManager, stateID, secret string, clientCfg *tls.Config) *supplicant {
+	return newSupplicantForType(t, h, eap.TypeTLS, sm, stateID, secret, clientCfg)
+}
+
+func newSupplicantForType(t *testing.T, h eap.EAPHandler, eapType uint8, sm eap.EAPStateManager, stateID, secret string, clientCfg *tls.Config) *supplicant {
 	t.Helper()
 	toClient := newHSStream()
 	fromClient := newHSStream()
@@ -203,7 +208,7 @@ func newSupplicant(t *testing.T, h *TLSHandler, sm eap.EAPStateManager, stateID,
 	}()
 
 	return &supplicant{
-		t: t, h: h, sm: sm, stateID: stateID, secret: secret,
+		t: t, h: h, eapType: eapType, sm: sm, stateID: stateID, secret: secret,
 		toClient: toClient, fromClient: fromClient, clientDone: done, ident: 20,
 	}
 }
@@ -301,7 +306,7 @@ func (s *supplicant) responseCtx(writer *mockResponseWriter, tlsData []byte) *ea
 		ResponseWriter: writer,
 		StateManager:   s.sm,
 		Secret:         s.secret,
-		EAPMessage:     &eap.EAPMessage{Code: eap.CodeResponse, Identifier: s.ident, Type: eap.TypeTLS, Data: data},
+		EAPMessage:     &eap.EAPMessage{Code: eap.CodeResponse, Identifier: s.ident, Type: s.eapType, Data: data},
 	}
 }
 
@@ -309,14 +314,14 @@ func (s *supplicant) parseChallenge(resp *radius.Packet) *tlsfragment.Packet {
 	eapData, err := rfc2869.EAPMessage_Lookup(resp)
 	require.NoError(s.t, err)
 	require.GreaterOrEqual(s.t, len(eapData), 5)
-	require.Equal(s.t, byte(eap.TypeTLS), eapData[4])
+	require.Equal(s.t, s.eapType, eapData[4])
 	frag, err := tlsfragment.Parse(eapData[5:])
 	require.NoError(s.t, err)
 	return frag
 }
 
 // startHandshake runs HandleIdentity and returns the issued state ID.
-func startHandshake(t *testing.T, h *TLSHandler, sm eap.EAPStateManager, username, secret string) string {
+func startHandshake(t *testing.T, h eap.EAPHandler, sm eap.EAPStateManager, username, secret string) string {
 	t.Helper()
 	packet := radius.New(radius.CodeAccessRequest, []byte(secret))
 	if username != "" {

--- a/internal/radiusd/plugins/eap/handlers/tls_tunnel.go
+++ b/internal/radiusd/plugins/eap/handlers/tls_tunnel.go
@@ -1,0 +1,205 @@
+package handlers
+
+import (
+	"fmt"
+
+	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap/tlsengine"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap/tlsfragment"
+	"layeh.com/radius"
+	"layeh.com/radius/rfc2865"
+)
+
+// tlsTunnel drives the TLS record exchange shared by EAP-TLS and PEAP outer
+// tunnels.
+//
+// RFC 5216 §2.1.5 and §3.1 define the Length/More-Fragments/Start framing used
+// by EAP-TLS. PEAPv0 has no formal RFC, but Microsoft [MS-PEAP] carries the
+// outer TLS handshake using the same EAP-TLS-derived flags with the low bits as
+// the PEAP version field. The eapType parameter keeps the shared state machine
+// byte-identical for EAP-TLS while emitting type 25 for PEAP.
+type tlsTunnel struct {
+	eapType             uint8
+	maxFragment         int
+	configProvider      TLSConfigProvider
+	onHandshakeComplete func(ctx *eap.EAPContext, state *eap.EAPState, engine *tlsengine.Engine) (bool, error)
+}
+
+// HandleResponse handles EAP-Response messages carrying TLS handshake bytes.
+func (t *tlsTunnel) HandleResponse(ctx *eap.EAPContext) (bool, error) {
+	stateID := rfc2865.State_GetString(ctx.Request.Packet)
+	if stateID == "" {
+		return false, eap.ErrStateNotFound
+	}
+
+	state, err := ctx.StateManager.GetState(stateID)
+	if err != nil {
+		return false, err
+	}
+
+	frag, err := tlsfragment.Parse(ctx.EAPMessage.Data)
+	if err != nil {
+		return false, err
+	}
+
+	if getBool(state, stateKeyPendingSuccess) {
+		if !frag.IsACK() {
+			closeEngine(state)
+			return false, eap.ErrTLSUnexpectedFragment
+		}
+		engine, err := t.engineFor(state)
+		if err != nil {
+			return false, err
+		}
+		return t.onHandshakeComplete(ctx, state, engine)
+	}
+
+	if t.hasQueuedFragments(state) {
+		return t.sendNextFragment(ctx, state, frag)
+	}
+
+	reassembler := loadReassembler(state)
+	complete, err := reassembler.Accept(frag)
+	if err != nil {
+		closeEngine(state)
+		return false, err
+	}
+
+	if !complete {
+		saveReassembler(state, reassembler)
+		if err := ctx.StateManager.SetState(stateID, state); err != nil {
+			closeEngine(state)
+			return false, err
+		}
+		return false, t.writeChallenge(ctx, stateID, t.buildFragmentACK(ctx.EAPMessage.Identifier+1))
+	}
+
+	tlsInput := reassembler.Buffer()
+	resetReassembler(state)
+	return t.advanceHandshake(ctx, state, tlsInput)
+}
+
+func (t *tlsTunnel) advanceHandshake(ctx *eap.EAPContext, state *eap.EAPState, tlsInput []byte) (bool, error) {
+	engine, err := t.engineFor(state)
+	if err != nil {
+		return false, err
+	}
+
+	out, done, hsErr := engine.Process(tlsInput)
+	if hsErr != nil {
+		closeEngine(state)
+		return false, fmt.Errorf("%w: %v", eap.ErrTLSHandshakeFailed, hsErr)
+	}
+
+	if len(out) == 0 {
+		if done {
+			return t.onHandshakeComplete(ctx, state, engine)
+		}
+		closeEngine(state)
+		return false, eap.ErrTLSUnexpectedFragment
+	}
+
+	return t.startFlight(ctx, state, out, done)
+}
+
+func (t *tlsTunnel) startFlight(ctx *eap.EAPContext, state *eap.EAPState, tlsData []byte, done bool) (bool, error) {
+	packets, err := tlsfragment.Fragment(tlsData, t.maxFragment)
+	if err != nil {
+		return false, err
+	}
+
+	first, rest := packets[0], packets[1:]
+	setBool(state, stateKeyHandshakeDone, done)
+
+	if len(rest) > 0 {
+		setFragments(state, rest)
+	} else if done {
+		setBool(state, stateKeyPendingSuccess, true)
+	}
+
+	if err := ctx.StateManager.SetState(state.StateID, state); err != nil {
+		closeEngine(state)
+		return false, err
+	}
+	return false, t.writeChallenge(ctx, state.StateID, t.buildEAPRequest(ctx.EAPMessage.Identifier+1, first))
+}
+
+func (t *tlsTunnel) sendNextFragment(ctx *eap.EAPContext, state *eap.EAPState, frag *tlsfragment.Packet) (bool, error) {
+	if !frag.IsACK() {
+		closeEngine(state)
+		return false, eap.ErrTLSUnexpectedFragment
+	}
+
+	queue := getFragments(state)
+	next := queue[0]
+	queue = queue[1:]
+
+	if len(queue) > 0 {
+		setFragments(state, queue)
+	} else {
+		clearKey(state, stateKeyOutFrags)
+		if getBool(state, stateKeyHandshakeDone) {
+			setBool(state, stateKeyPendingSuccess, true)
+		}
+	}
+
+	if err := ctx.StateManager.SetState(state.StateID, state); err != nil {
+		closeEngine(state)
+		return false, err
+	}
+	return false, t.writeChallenge(ctx, state.StateID, t.buildEAPRequest(ctx.EAPMessage.Identifier+1, next))
+}
+
+func (t *tlsTunnel) engineFor(state *eap.EAPState) (*tlsengine.Engine, error) {
+	if state.Data != nil {
+		if e, ok := state.Data[stateKeyEngine].(*tlsengine.Engine); ok && e != nil {
+			return e, nil
+		}
+	}
+
+	if t.configProvider == nil {
+		return nil, eap.ErrTLSNotConfigured
+	}
+	cfg, err := t.configProvider()
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", eap.ErrTLSNotConfigured, err)
+	}
+	if cfg == nil {
+		return nil, eap.ErrTLSNotConfigured
+	}
+
+	engine, err := tlsengine.New(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", eap.ErrTLSNotConfigured, err)
+	}
+	if state.Data == nil {
+		state.Data = make(map[string]interface{})
+	}
+	state.Data[stateKeyEngine] = engine
+	return engine, nil
+}
+
+func (t *tlsTunnel) hasQueuedFragments(state *eap.EAPState) bool {
+	return len(getFragments(state)) > 0
+}
+
+func (t *tlsTunnel) buildFragmentACK(identifier uint8) []byte {
+	return t.buildEAPRequest(identifier, &tlsfragment.Packet{})
+}
+
+func (t *tlsTunnel) buildEAPRequest(identifier uint8, frag *tlsfragment.Packet) []byte {
+	msg := &eap.EAPMessage{
+		Code:       eap.CodeRequest,
+		Identifier: identifier,
+		Type:       t.eapType,
+		Data:       frag.Encode(),
+	}
+	return msg.Encode()
+}
+
+func (t *tlsTunnel) writeChallenge(ctx *eap.EAPContext, stateID string, eapData []byte) error {
+	response := ctx.Request.Response(radius.CodeAccessChallenge)
+	_ = rfc2865.State_SetString(response, stateID) //nolint:errcheck
+	eap.SetEAPMessageAndAuth(response, eapData, ctx.Secret)
+	return ctx.ResponseWriter.Write(response)
+}

--- a/internal/radiusd/plugins/eap/tlsengine/engine.go
+++ b/internal/radiusd/plugins/eap/tlsengine/engine.go
@@ -9,12 +9,13 @@
 // transmitted in the next EAP-Request. This package bridges Go's blocking
 // crypto/tls handshake to that turn-based model using an in-memory transport.
 //
-// Certificate validation (CA chain) is delegated to crypto/tls: the engine is
-// configured with ClientAuth=RequireAndVerifyClientCert and a ClientCAs pool, so
-// a handshake only completes when the peer presents a certificate that chains to
-// a configured CA (RFC 5216 §2.2, §5.3). After a successful handshake the
-// validated peer identity is extracted from the client certificate per
-// RFC 5216 §5.2.
+// Certificate validation (CA chain) is delegated to crypto/tls for EAP-TLS: the
+// engine is configured with ClientAuth=RequireAndVerifyClientCert and a
+// ClientCAs pool, so a handshake only completes when the peer presents a
+// certificate that chains to a configured CA (RFC 5216 §2.2, §5.3). PEAP/TTLS
+// server-only tunnels set Config.ServerOnly and authenticate the peer inside the
+// protected tunnel instead. After a successful EAP-TLS handshake the validated
+// peer identity is extracted from the client certificate per RFC 5216 §5.2.
 package tlsengine
 
 import (
@@ -61,6 +62,10 @@ type Config struct {
 	// MinVersion optionally pins the minimum TLS version (e.g. tls.VersionTLS12).
 	// Zero lets crypto/tls choose its default.
 	MinVersion uint16
+	// ServerOnly disables client-certificate requests for tunneled EAP methods
+	// such as PEAP/TTLS whose peers authenticate inside the protected tunnel
+	// rather than with an outer TLS client certificate.
+	ServerOnly bool
 	// HandshakeTimeout bounds the total handshake duration. Zero selects
 	// DefaultHandshakeTimeout.
 	HandshakeTimeout time.Duration
@@ -91,7 +96,7 @@ func New(cfg *Config) (*Engine, error) {
 	if cfg == nil {
 		return nil, ErrNoConfig
 	}
-	if cfg.ClientCAs == nil {
+	if !cfg.ServerOnly && cfg.ClientCAs == nil {
 		return nil, fmt.Errorf("%w: ClientCAs is required for EAP-TLS peer authentication", ErrNoConfig)
 	}
 	if len(cfg.ServerCertificate.Certificate) == 0 || cfg.ServerCertificate.PrivateKey == nil {
@@ -100,9 +105,13 @@ func New(cfg *Config) (*Engine, error) {
 
 	tlsCfg := &tls.Config{
 		Certificates: []tls.Certificate{cfg.ServerCertificate},
-		ClientAuth:   tls.RequireAndVerifyClientCert,
-		ClientCAs:    cfg.ClientCAs,
 		MinVersion:   cfg.MinVersion,
+	}
+	if cfg.ServerOnly {
+		tlsCfg.ClientAuth = tls.NoClientCert
+	} else {
+		tlsCfg.ClientAuth = tls.RequireAndVerifyClientCert
+		tlsCfg.ClientCAs = cfg.ClientCAs
 	}
 
 	trans := newTransport()

--- a/internal/radiusd/plugins/eap/tlsengine/engine_test.go
+++ b/internal/radiusd/plugins/eap/tlsengine/engine_test.go
@@ -247,6 +247,39 @@ func TestEngine_New_RequiresClientCAs(t *testing.T) {
 	}
 }
 
+func TestEngine_ServerOnly_DoesNotRequireClientCAs(t *testing.T) {
+	ca := newTestCA(t, "Server Root CA")
+	serverCert := ca.issue(t, "radius.example.com", func(c *x509.Certificate) {
+		c.DNSNames = []string{"radius.example.com"}
+	})
+
+	eng, err := New(&Config{
+		ServerCertificate: serverCert,
+		ServerOnly:        true,
+		MinVersion:        tls.VersionTLS12,
+		HandshakeTimeout:  5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("server-only engine should not require ClientCAs: %v", err)
+	}
+	defer func() { _ = eng.Close() }()
+
+	clientErr, serverErr := driveHandshake(t, eng, &tls.Config{
+		RootCAs:    ca.pool,
+		ServerName: "radius.example.com",
+		MinVersion: tls.VersionTLS12,
+	})
+	if clientErr != nil {
+		t.Fatalf("client handshake error: %v", clientErr)
+	}
+	if serverErr != nil {
+		t.Fatalf("server handshake error: %v", serverErr)
+	}
+	if _, err := eng.Identity(); err != ErrNoPeerCertificate {
+		t.Fatalf("expected ErrNoPeerCertificate for server-only handshake, got %v", err)
+	}
+}
+
 func TestEngine_New_RequiresServerCertificate(t *testing.T) {
 	ca := newTestCA(t, "Root")
 	if _, err := New(&Config{ClientCAs: ca.pool}); err != ErrNoServerCertificate {

--- a/internal/radiusd/plugins/init.go
+++ b/internal/radiusd/plugins/init.go
@@ -79,12 +79,15 @@ func InitPlugins(appCtx app.ConfigManagerProvider, sessionRepo repository.Sessio
 	}
 
 	// PEAPv0 (EAP type 25) is a compatibility-first tunneled method for
-	// Windows / Active Directory estates. Milestone M8.1 registers the handler
-	// skeleton: it answers EAP-Response/Identity with a PEAPv0 Start but rejects
-	// every handshake response with eap.ErrPEAPNotImplemented, so it can never
-	// authenticate a client until the outer TLS tunnel (M8.2) and inner
-	// EAP-MSCHAPv2 exchange (M8.3) are delivered.
-	registry.RegisterEAPHandler(eaphandlers.NewPEAPHandler())
+	// Windows / Active Directory estates. M8.2 establishes the server-only outer
+	// TLS tunnel with EAP-TLS framing, then rejects safely until the inner
+	// EAP-MSCHAPv2 exchange (M8.3) is delivered.
+	if appCtx != nil && appCtx.ConfigMgr() != nil {
+		provider := eaphandlers.NewSettingsPEAPConfigProvider(appCtx.ConfigMgr())
+		registry.RegisterEAPHandler(eaphandlers.NewPEAPHandlerWithConfig(provider))
+	} else {
+		registry.RegisterEAPHandler(eaphandlers.NewPEAPHandler())
+	}
 
 	// Vendor parsers under vendor/parsers register themselves via init()
 }


### PR DESCRIPTION
## 概述

实现 PEAPv0 **外层 TLS 隧道**（TR-F004 / roadmap **M8.2**）。通过抽取并参数化 EAP-TLS 握手状态机，PEAP 复用同一套分片/重组与状态持久化逻辑建立服务器认证隧道。**隧道可完整建成，但 M8.2 永不放行**——内层 EAP-MSCHAPv2 留待 M8.3。

## 变更

**tlsengine**
- 新增 `Config.ServerOnly`：置位时 `New` 不再要求 `ClientCAs`，并使用 `ClientAuth=NoClientCert`（PEAP 用内层 EAP 而非客户端证书认证对端）。EAP-TLS 路径 `ServerOnly=false` → `RequireAndVerifyClientCert`+`ClientCAs`，行为字节级不变。

**handlers**
- 抽取外层隧道状态机到 `tls_tunnel.go`（`tlsTunnel`），由 `eapType`、`configProvider`、`onHandshakeComplete` 回调参数化。握手态仍全部落在 `EAPState` 并经 `StateManager` 持久化，驱动跨请求无状态。
- `TLSHandler.HandleResponse` 委派到 `newTunnel()`（`eapType=TypeTLS`，回调 `finalizeWithEngine` → 证书身份放行）。行为保持式重构。
- `PEAPHandler` 新增 `NewPEAPHandlerWithConfig` 与 `newTunnel()`（`eapType=TypePEAP`）。其 `onHandshakeComplete` 关闭引擎、`Success=false` 并返回 `ErrPEAPInnerNotImplemented`——**不可能返回 `(true, _)`**。
- 新增 `NewSettingsPEAPConfigProvider`：复用 EAP-TLS 服务器证书/私钥设置 + `ServerOnly:true`；证书未配置时返回 `nil`（安全拒绝）。
- `plugins/init.go` 在 ConfigMgr 可用时注入 PEAP 配置 provider。

**errors**
- `ErrPEAPNotImplemented` → `ErrPEAPInnerNotImplemented`，反映外层隧道已建成、仅内层方法待实现。

## 安全不变式

PEAP 在 M8.2 **永不授予访问**：`onHandshakeComplete` 唯一返回 `(false, ErrPEAPInnerNotImplemented)`，经 `mapEAPDispatchError` default 分支 → `AuthError` → Access-Reject + EAP-Failure，状态清理、无 panic/挂起/误放行。

## 测试

- server-only 引擎完成真实握手，`Identity()` 返回 `ErrNoPeerCertificate`。
- PEAP 完整握手（单帧 + `maxFragment=64` 强制分片）驱动真实 server-only TLS 握手至完成，断言以 `ErrPEAPInnerNotImplemented` 拒绝且 `state.Success=false`。
- 未配置证书时以 `ErrTLSNotConfigured` 拒绝。
- 既有 EAP-TLS 握手测试不变通过（supplicant 测试桩泛化为按 `eapType` 参数化）。

## 质量门（本地）

- `CGO_ENABLED=0 go build ./...` ✅
- `CGO_ENABLED=0 go vet ./internal/radiusd/...` ✅
- `CGO_ENABLED=0 go test ./internal/radiusd/... ./internal/app/...` ✅（0 失败）
- golangci-lint v2.12.2（`./internal/radiusd/plugins/...`、`./internal/app/...`）✅ 0 issues

## 协议规范

RFC 5216 §2.1.5/§3.1（分片与帧格式）；PEAPv0 [MS-PEAP]、`draft-kamath-pppext-peapv0`。
