### PR TITLE
feat: add agent PR template and review checklist (M4.7)

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -73,6 +73,8 @@
 - **协议合规**：协议行为改动引用 `docs/rfcs/` 对应 RFC（见 `skills/reference-rfc/SKILL.md`）。
 - **CI 验收测试**：协议 / 端到端改动带 CI 可自动执行的验收用例（`test/integration/`，见 `skills/add-acceptance-test/SKILL.md`）。
 - **走 PR + 审查门禁**：产出一律 Pull Request，禁止直接推 `main`；PR 打 `agent-roadmap` 标签并交 `skills/review-pr/SKILL.md` 审查，**仅在 `agent-approved` 且 CI 全绿时自动合并**，有阻断问题打 `needs-rework`、超轮次打 `needs-human` 交人。
+- **PR 模板**：agent 任务 PR 默认使用 [`.github/pull_request_template.md`](../.github/pull_request_template.md)，完整填写里程碑子任务、`TR-F`、验收与门禁结果。
+- **审查清单**：review gate 按 [`.github/review-checklists/agent-roadmap.md`](../.github/review-checklists/agent-roadmap.md) 逐项判定，避免凭主观印象放行。
 
 ### 上游 radius 库跟踪（手动）
 

--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -31,7 +31,8 @@ The gate has teeth only because it is **anchored to mechanical signals (CI) and 
    - Any job failing for a **real** reason (compile/test/lint/integration) -> this is a blocking issue; go to step 3 (rework) and cite the failing job.
    - Failing only from transient infra (e.g. registry/network timeout in "Initialize containers") -> `gh run rerun <run-id> --failed` once; re-check.
    - Still pending -> do not approve this round; leave the PR untouched. A pending-CI PR still counts as **unreviewed**, so per the in-flight gate below the round does **not** select a new task while it is open - move on to the next PR in the drain list, then wait for CI / stop the round rather than starting new work.
-2. **Independent adversarial read.** Review as a *separate pass* with fresh context - in a multi-agent environment dispatch a `code-review` sub-agent; otherwise consciously switch roles. Feed it only: `gh pr diff <n>`, the PR description, the linked milestone + `TR-F` ID, and the acceptance criteria. Apply a high signal bar - flag only issues that genuinely matter:
+2. **Load and follow the review checklist first.** Read `.github/review-checklists/agent-roadmap.md` and enforce it item-by-item before writing the verdict comment.
+3. **Independent adversarial read.** Review as a *separate pass* with fresh context - in a multi-agent environment dispatch a `code-review` sub-agent; otherwise consciously switch roles. Feed it only: `gh pr diff <n>`, the PR description, the linked milestone + `TR-F` ID, and the acceptance criteria. Apply a high signal bar - flag only issues that genuinely matter:
    - correctness / logic bugs, nil-deref, race, resource leaks;
    - security: leaked secrets, auth bypass, injection, plaintext where hashing is required;
    - scope: any change touching a non-goal `TR-N001`-`TR-N005`, or beyond the claimed `TR-F`;
@@ -39,10 +40,10 @@ The gate has teeth only because it is **anchored to mechanical signals (CI) and 
    - missing/insufficient tests for the changed behavior; for protocol / E2E changes, a missing `test/integration/` acceptance test;
    - pushed to `main` directly, generated artifacts or secrets committed.
    - Do **not** comment on style, formatting, or naming taste.
-3. **Record the verdict.**
+4. **Record the verdict.**
    - **Blocking issues found** -> `gh pr comment`/`gh pr review --comment` enumerating each issue with `file:line` and a concrete fix; `gh pr edit <n> --add-label needs-rework --remove-label agent-approved`. Do not merge.
    - **No blocking issues AND CI green** -> post a COMMENT review that summarizes what was checked **and records the exact reviewed head SHA** (`gh pr view <n> --json headRefOid -q .headRefOid`); `gh pr edit <n> --add-label agent-approved --remove-label needs-rework`. The recorded SHA is what binds the approval to the reviewed code.
-4. **Merge gate.** Merge only when **all** hold: the PR carries `agent-approved`, has **no** `needs-rework`/`needs-human`, `gh pr checks <n>` re-confirms all green, **and the current head SHA equals the SHA recorded in the approval comment**. A label is not bound to a commit, so always re-verify:
+5. **Merge gate.** Merge only when **all** hold: the PR carries `agent-approved`, has **no** `needs-rework`/`needs-human`, `gh pr checks <n>` re-confirms all green, **and the current head SHA equals the SHA recorded in the approval comment**. A label is not bound to a commit, so always re-verify:
    ```
    reviewed=<sha from approval comment>
    current=$(gh pr view <n> --json headRefOid -q .headRefOid)
@@ -57,7 +58,7 @@ Before `orchestrate-roadmap` selects any new task, drain the queue - oldest firs
 gh pr list --state open --label agent-roadmap --json number,labels,headRefName
 ```
 - `needs-rework` -> read the review thread, **address every blocking comment** by re-running the original execution SOP on that branch, push, then re-run "Reviewing one PR" from step 1. This is mandatory work, not optional.
-- `agent-approved` + green -> merge **via the step-4 gate** (re-verify head SHA == approved SHA first; if it moved, the approval is stale -> re-review).
+- `agent-approved` + green -> merge **via the step-5 gate** (re-verify head SHA == approved SHA first; if it moved, the approval is stale -> re-review).
 - `needs-human` -> skip; leave it for a human.
 - pending CI / no verdict yet -> run "Reviewing one PR".
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+# Summary
+
+## Roadmap Mapping (Required for agent tasks)
+
+- Milestone subtask: `M?.?`
+- Feature ID(s): `TR-F???`
+- Out-of-scope non-goals checked: `TR-N001` `TR-N002` `TR-N003` `TR-N004` `TR-N005`
+
+## What Changed
+
+- 
+
+## Acceptance Criteria Covered
+
+- [ ] The change only covers the mapped `TR-F` scope
+- [ ] Protocol behavior updates include RFC clause references in code/tests/PR description
+- [ ] Protocol or E2E behavior changes include CI-runnable acceptance tests under `test/integration/`
+
+## Verification
+
+- [ ] `go build ./...`
+- [ ] `go test ./...`
+- [ ] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`
+- [ ] `cd web && npm run build` (required only when frontend files changed)
+
+## Risks and Rollback
+
+- Risk level: `low | medium | high`
+- Main risk:
+- Rollback plan:
+
+## Reviewer Notes
+
+- Suggested review order (files/modules):
+- Open questions / assumptions:

--- a/.github/review-checklists/agent-roadmap.md
+++ b/.github/review-checklists/agent-roadmap.md
@@ -1,0 +1,33 @@
+# Agent Roadmap PR Review Checklist (TR-F022)
+
+Use this checklist when reviewing PRs labeled `agent-roadmap`.
+
+## 1) Context and Scope
+
+- [ ] PR explicitly maps to one roadmap subtask (`M?.?`) and `TR-F` ID(s)
+- [ ] No non-goal scope (`TR-N001` to `TR-N005`) is introduced
+- [ ] Claimed acceptance criteria match the actual diff
+
+## 2) Mechanical Gates
+
+- [ ] `gh pr checks <n>` is fully green (or a transient failure has been rerun once)
+- [ ] Required local gates are reported in PR (`go build`, `go test`, `golangci-lint`, optional `web build`)
+
+## 3) Code and Safety Review
+
+- [ ] No correctness regressions (logic, nil dereference, race, resource leak)
+- [ ] No security regressions (auth bypass, injection, secret/plaintext leakage)
+- [ ] Data/schema changes preserve PostgreSQL and SQLite compatibility
+- [ ] Protocol behavior changes include RFC references and do not contradict cited clauses
+
+## 4) Test Sufficiency
+
+- [ ] Changed behavior is covered by tests (unit/integration)
+- [ ] Protocol/E2E changes include `test/integration/` acceptance coverage
+
+## 5) Review Verdict
+
+- [ ] Blocking findings are posted with `file:line` and concrete fix guidance
+- [ ] Verdict label is exactly one of: `agent-approved`, `needs-rework`, `needs-human`
+- [ ] Approval comment records the reviewed head SHA
+- [ ] Merge happens only when `agent-approved` + green checks + SHA still matches


### PR DESCRIPTION
## Summary

- establish a default PR template for agent roadmap tasks under `.github/pull_request_template.md`
- add a dedicated reviewer checklist at `.github/review-checklists/agent-roadmap.md`
- wire the checklist into `review-pr` skill and document both artifacts in `.agents/README.md`

## Roadmap Mapping

- Milestone subtask: `M4.7`
- Feature ID: `TR-F022`
- Non-goals checked: `TR-N001` `TR-N002` `TR-N003` `TR-N004` `TR-N005`

## Acceptance Coverage

- [x] Agent tasks now have a repo-level PR template
- [x] Review gate now has a concrete checklist artifact and execution hook

## Verification

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`
- [ ] `cd web && npm run build` (not required, no frontend code changed)
