### PR TITLE
feat(eap): register EAP-TTLS handler skeleton + enablement config (M9.1)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -204,7 +204,7 @@
 - **协议规范**：`docs/rfcs/rfc5281-eap-ttls.txt`（EAP-TTLS）、`rfc3748-eap.txt`、`rfc2759-mschapv2.txt`（内层 MS-CHAP-V2）、`rfc3579-radius-eap-support.txt`；TLS 1.3 隧道按 `rfc9427`（本地缺失，按 `reference-rfc` 登记）。
 
 子任务：
-- [ ] M9.1 注册 EAP-TTLS handler 骨架与启用列表配置
+- [x] M9.1 注册 EAP-TTLS handler 骨架与启用列表配置 ✅ 实现 `TTLSHandler`（EAP type 21 / name `eap-ttls`），对 EAP-Response/Identity 回送 EAP-TTLSv0 Start（RFC 5281 §9.2，Flags 复用 EAP-TLS 框架 RFC 5216 §3.1，version 位为 0），并在协调器 `handleIdentityResponse` 增加 `eap-ttls` 分支、`init.go` 无条件注册该 handler；`HandleResponse` 为安全桩，对任何挑战响应一律返回 `ErrTTLSNotImplemented`、永不放行（外层隧道见 M9.2）。`EapMethod` 枚举在 `config_schemas.json` + `config_manager.go` + 前端 `i18n/{en-US,zh-CN}.ts` 三处同步加入 `eap-ttls` 并补充双语说明。单测覆盖 Name/EAPType(21)/CanHandle/HandleIdentity(Start 帧+状态持久化)/buildStartRequest/HandleResponse 永不认证，并在 `coordinator_test.go` 增加 `eap-ttls` 选路用例。门禁：`go build ./...`、`go test ./...`、golangci-lint v2.12.2、`cd web && npm run build` 均通过。
 - [ ] M9.2 外层 TLS 隧道建立与分片重组（复用 EAP-TLS 状态机）
 - [ ] M9.3 隧道内 AVP 封装与 PAP 内层认证（最小可用闭环）
 - [ ] M9.4 增加 MS-CHAP-V2 内层认证与密钥导出

--- a/internal/app/config_manager.go
+++ b/internal/app/config_manager.go
@@ -151,8 +151,8 @@ func (cm *ConfigManager) registerHardcodedSchemas() {
 		Key:         "radius.EapMethod",
 		Type:        TypeString,
 		Default:     "eap-md5",
-		Enum:        []string{"eap-md5", "eap-mschapv2", "eap-tls", "eap-peap"},
-		Description: "EAP authentication method. eap-peap reuses the EAP-TLS server certificate/key to build the outer TLS tunnel and runs EAP-MSCHAPv2 inside it for Windows/AD compatibility; the inner MS-CHAPv2 carries an NTLMv1-like attack surface, so keep the outer TLS strong and prefer eap-tls where clients support certificates.",
+		Enum:        []string{"eap-md5", "eap-mschapv2", "eap-tls", "eap-peap", "eap-ttls"},
+		Description: "EAP authentication method. eap-peap reuses the EAP-TLS server certificate/key to build the outer TLS tunnel and runs EAP-MSCHAPv2 inside it for Windows/AD compatibility; the inner MS-CHAPv2 carries an NTLMv1-like attack surface, so keep the outer TLS strong and prefer eap-tls where clients support certificates. eap-ttls (RFC 5281) likewise builds a server-only TLS tunnel and carries legacy inner authentication (PAP / MS-CHAP-V2) for LDAP / legacy / mixed back ends; it is being delivered incrementally (M9) and currently negotiates the tunnel Start only.",
 	})
 
 	cm.register(&ConfigSchema{

--- a/internal/app/config_manager_test.go
+++ b/internal/app/config_manager_test.go
@@ -160,6 +160,7 @@ func TestConfigManagerJSON(t *testing.T) {
 	assert.Contains(t, radiusEapSchema.Enum, "eap-md5", "Enum values should include eap-md5")
 	assert.Contains(t, radiusEapSchema.Enum, "eap-mschapv2", "Enum values should include eap-mschapv2")
 	assert.Contains(t, radiusEapSchema.Enum, "eap-peap", "Enum values should include eap-peap")
+	assert.Contains(t, radiusEapSchema.Enum, "eap-ttls", "Enum values should include eap-ttls")
 	assert.Equal(t, "EAP Method", radiusEapSchema.Title)
 	assert.Equal(t, "config.radius.eap_method.title", radiusEapSchema.TitleI18n)
 	assert.Equal(t, "config.radius.eap_method.description", radiusEapSchema.DescI18n)

--- a/internal/app/config_schemas.json
+++ b/internal/app/config_schemas.json
@@ -4,10 +4,10 @@
       "key": "radius.EapMethod",
       "type": "string",
       "default": "eap-md5",
-      "enum": ["eap-md5", "eap-mschapv2", "eap-tls", "eap-peap"],
+      "enum": ["eap-md5", "eap-mschapv2", "eap-tls", "eap-peap", "eap-ttls"],
       "title": "EAP Method",
       "title_i18n": "config.radius.eap_method.title",
-      "description": "EAP authentication method. eap-peap reuses the EAP-TLS server certificate/key (EapTlsCertFile/EapTlsKeyFile) to build the outer TLS tunnel and runs EAP-MSCHAPv2 inside it for Windows/AD compatibility; the inner MS-CHAPv2 carries an NTLMv1-like attack surface (per Microsoft), so keep the outer TLS strong and prefer eap-tls where clients support certificates.",
+      "description": "EAP authentication method. eap-peap reuses the EAP-TLS server certificate/key (EapTlsCertFile/EapTlsKeyFile) to build the outer TLS tunnel and runs EAP-MSCHAPv2 inside it for Windows/AD compatibility; the inner MS-CHAPv2 carries an NTLMv1-like attack surface (per Microsoft), so keep the outer TLS strong and prefer eap-tls where clients support certificates. eap-ttls (RFC 5281) likewise builds a server-only TLS tunnel and carries legacy inner authentication (PAP / MS-CHAP-V2) for LDAP / legacy / mixed back ends; it is being delivered incrementally (M9) and currently negotiates the tunnel Start only.",
       "description_i18n": "config.radius.eap_method.description"
     },
     {

--- a/internal/radiusd/plugins/eap/coordinator.go
+++ b/internal/radiusd/plugins/eap/coordinator.go
@@ -102,6 +102,8 @@ func (c *Coordinator) handleIdentityResponse(ctx *EAPContext, configuredMethod s
 		handler, _ = c.handlerRegistry.GetHandler(TypeOTP)
 	case "eap-tls":
 		handler, _ = c.handlerRegistry.GetHandler(TypeTLS)
+	case "eap-ttls":
+		handler, _ = c.handlerRegistry.GetHandler(TypeTTLS)
 	case "eap-peap":
 		handler, _ = c.handlerRegistry.GetHandler(TypePEAP)
 	default:

--- a/internal/radiusd/plugins/eap/coordinator_test.go
+++ b/internal/radiusd/plugins/eap/coordinator_test.go
@@ -357,6 +357,31 @@ func TestHandleEAPRequest_IdentityResponse_PEAP(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestHandleEAPRequest_IdentityResponse_TTLS(t *testing.T) {
+	registry := newMockHandlerRegistry()
+	registry.Register(&mockEAPHandler{
+		name:             "eap-ttls",
+		eapType:          TypeTTLS,
+		canHandle:        true,
+		handleIdentityOk: true,
+	})
+
+	coordinator := NewCoordinator(newMockStateManager(), &mockPasswordProvider{}, registry, false)
+	writer := &mockResponseWriter{}
+
+	packet := createEAPIdentityResponse(1, "ttlsuser")
+	req := &radius.Request{Packet: packet}
+	response := req.Response(radius.CodeAccessAccept)
+
+	handled, success, err := coordinator.HandleEAPRequest(
+		writer, req, &domain.RadiusUser{}, &domain.NetNas{}, response, "secret", false, "eap-ttls",
+	)
+
+	assert.True(t, handled)
+	assert.False(t, success)
+	assert.NoError(t, err)
+}
+
 func TestHandleEAPRequest_IdentityResponse_DefaultToMD5(t *testing.T) {
 	registry := newMockHandlerRegistry()
 	registry.Register(&mockEAPHandler{

--- a/internal/radiusd/plugins/eap/errors.go
+++ b/internal/radiusd/plugins/eap/errors.go
@@ -43,4 +43,10 @@ var (
 	// (unexpected EAP code/type/opcode for the current inner sub-state). It
 	// guarantees a malformed inner exchange rejects rather than grants.
 	ErrPEAPInnerProtocol = errors.New("PEAP inner EAP-MSCHAPv2 protocol violation")
+	// ErrTTLSNotImplemented is returned by the EAP-TTLS handler skeleton until
+	// the outer TLS tunnel and inner AVP authentication are implemented
+	// (milestones M9.2 / M9.3). It guarantees the skeleton, which answers the
+	// EAP-Response/Identity with an EAP-TTLS Start (RFC 5281 §9.2), can never
+	// grant access on a challenge response.
+	ErrTTLSNotImplemented = errors.New("EAP-TTLS tunnel is not implemented yet")
 )

--- a/internal/radiusd/plugins/eap/handlers/ttls_handler.go
+++ b/internal/radiusd/plugins/eap/handlers/ttls_handler.go
@@ -1,0 +1,129 @@
+package handlers
+
+import (
+	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap/tlsfragment"
+	"github.com/talkincode/toughradius/v9/pkg/common"
+	"layeh.com/radius"
+	"layeh.com/radius/rfc2865"
+)
+
+const (
+	// EAPMethodTTLS is the configuration / handler name for EAP-TTLSv0.
+	EAPMethodTTLS = "eap-ttls"
+
+	// ttlsVersion0 is the EAP-TTLS version advertised in the low three bits of
+	// the Flags octet. RFC 5281 §9.1 defines the Flags octet as
+	// "L M S R R V V V", where the three-bit Version field (V) is 000 for
+	// EAP-TTLSv0. Encoding version 0 makes the EAP-TTLS Start byte-identical to
+	// an EAP-TLS Start (RFC 5216 §3.1), so the shared tlsfragment framing
+	// applies unchanged.
+	ttlsVersion0 = 0x00
+)
+
+// TTLSHandler is the EAP-TTLSv0 (Tunneled TLS, RFC 5281) authentication handler.
+//
+// EAP-TTLS establishes a TLS tunnel using only a server certificate (no client
+// certificate is required) and then carries legacy inner authentication —
+// PAP / CHAP / MS-CHAP / MS-CHAP-V2 or an inner EAP method — inside that tunnel
+// as Diameter AVPs (RFC 5281 §10/§11). Its practical value is back-end
+// adaptation: an existing username/password user store (LDAP, legacy databases,
+// mixed clients) can be protected by the server-side TLS tunnel without
+// migrating every client to a certificate identity. The outer tunnel reuses the
+// EAP-TLS Flags/fragmentation framing (RFC 5216 §3.1) carried over RADIUS
+// EAP-Message attributes (RFC 3579).
+//
+// Milestone scope:
+//   - M9.1 (current): registers the method (EAP type 21, name "eap-ttls") and
+//     answers EAP-Response/Identity with an EAP-TTLSv0 Start. HandleResponse is
+//     a safe stub that always rejects with eap.ErrTTLSNotImplemented until the
+//     outer tunnel lands, so the skeleton can never grant access.
+//   - M9.2: establishes the outer TLS tunnel and fragmentation reassembly,
+//     reusing the EAP-TLS state machine.
+//   - M9.3: tunneled AVP encapsulation and inner PAP authentication.
+//   - M9.4: inner MS-CHAP-V2 authentication and key derivation.
+type TTLSHandler struct{}
+
+// NewTTLSHandler creates an EAP-TTLSv0 handler skeleton. It accepts the EAP-TTLS
+// Start exchange but rejects challenge responses safely with
+// eap.ErrTTLSNotImplemented until the outer TLS tunnel is implemented (M9.2), so
+// it can never authenticate a client.
+func NewTTLSHandler() *TTLSHandler {
+	return &TTLSHandler{}
+}
+
+// Name returns the handler name ("eap-ttls").
+func (h *TTLSHandler) Name() string {
+	return EAPMethodTTLS
+}
+
+// EAPType returns the EAP method type code handled (21, EAP-TTLS).
+func (h *TTLSHandler) EAPType() uint8 {
+	return eap.TypeTTLS
+}
+
+// CanHandle reports whether this handler can process the EAP message.
+func (h *TTLSHandler) CanHandle(ctx *eap.EAPContext) bool {
+	if ctx == nil || ctx.EAPMessage == nil {
+		return false
+	}
+	return ctx.EAPMessage.Type == eap.TypeTTLS
+}
+
+// HandleIdentity handles EAP-Response/Identity by sending an EAP-TTLSv0 Start
+// request (an EAP-Request with EAP-Type=TTLS, the Start (S) bit set, version
+// bits 0, and no TLS data; RFC 5281 §9.2, framing per RFC 5216 §3.1). It
+// persists handshake state keyed by the RADIUS State attribute so subsequent
+// rounds (milestone M9.2) can correlate the tunnel.
+func (h *TTLSHandler) HandleIdentity(ctx *eap.EAPContext) (bool, error) {
+	eapData := h.buildStartRequest(ctx.EAPMessage.Identifier)
+
+	stateID := common.UUID()
+	username := rfc2865.UserName_GetString(ctx.Request.Packet)
+
+	state := &eap.EAPState{
+		Username: username,
+		StateID:  stateID,
+		Method:   EAPMethodTTLS,
+		Success:  false,
+	}
+
+	if err := ctx.StateManager.SetState(stateID, state); err != nil {
+		return false, err
+	}
+
+	return true, h.writeChallenge(ctx, stateID, eapData)
+}
+
+// HandleResponse is the M9.1 safe stub for EAP-TTLS challenge responses. The
+// outer TLS tunnel (M9.2) and inner AVP authentication (M9.3+) are not yet
+// implemented, so it always rejects with eap.ErrTTLSNotImplemented and never
+// grants access.
+func (h *TTLSHandler) HandleResponse(ctx *eap.EAPContext) (bool, error) {
+	return false, eap.ErrTTLSNotImplemented
+}
+
+// buildStartRequest constructs an EAP-TTLSv0 Start request: an EAP-Request with
+// EAP-Type=TTLS and a single Flags octet carrying the Start (S) bit and version
+// 0. No TLS data is included, so the L bit is clear and the TLS Message Length
+// field is absent (RFC 5281 §9.1/§9.2).
+func (h *TTLSHandler) buildStartRequest(identifier uint8) []byte {
+	frag := &tlsfragment.Packet{Flags: tlsfragment.FlagStart | ttlsVersion0}
+	msg := &eap.EAPMessage{
+		Code:       eap.CodeRequest,
+		Identifier: identifier,
+		Type:       eap.TypeTTLS,
+		Data:       frag.Encode(),
+	}
+	return msg.Encode()
+}
+
+// writeChallenge sends eapData inside a RADIUS Access-Challenge, echoing the
+// handshake State attribute and protecting the response with a
+// Message-Authenticator (RFC 3579 §3.2).
+func (h *TTLSHandler) writeChallenge(ctx *eap.EAPContext, stateID string, eapData []byte) error {
+	response := ctx.Request.Response(radius.CodeAccessChallenge)
+	_ = rfc2865.State_SetString(response, stateID) //nolint:errcheck
+	eap.SetEAPMessageAndAuth(response, eapData, ctx.Secret)
+	return ctx.ResponseWriter.Write(response)
+}

--- a/internal/radiusd/plugins/eap/handlers/ttls_handler_test.go
+++ b/internal/radiusd/plugins/eap/handlers/ttls_handler_test.go
@@ -1,0 +1,154 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap/statemanager"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap/tlsfragment"
+	"layeh.com/radius"
+	"layeh.com/radius/rfc2865"
+	"layeh.com/radius/rfc2869"
+)
+
+func TestNewTTLSHandler(t *testing.T) {
+	assert.NotNil(t, NewTTLSHandler())
+}
+
+func TestTTLSHandler_Name(t *testing.T) {
+	assert.Equal(t, "eap-ttls", NewTTLSHandler().Name())
+}
+
+func TestTTLSHandler_EAPType(t *testing.T) {
+	assert.Equal(t, uint8(eap.TypeTTLS), NewTTLSHandler().EAPType())
+	assert.Equal(t, uint8(21), NewTTLSHandler().EAPType(), "EAP-TTLS is IANA EAP method type 21")
+}
+
+func TestTTLSHandler_CanHandle(t *testing.T) {
+	h := NewTTLSHandler()
+
+	tests := []struct {
+		name     string
+		ctx      *eap.EAPContext
+		expected bool
+	}{
+		{
+			name:     "can handle TTLS type",
+			ctx:      &eap.EAPContext{EAPMessage: &eap.EAPMessage{Type: eap.TypeTTLS}},
+			expected: true,
+		},
+		{
+			name:     "cannot handle PEAP type",
+			ctx:      &eap.EAPContext{EAPMessage: &eap.EAPMessage{Type: eap.TypePEAP}},
+			expected: false,
+		},
+		{
+			name:     "cannot handle EAP-TLS type",
+			ctx:      &eap.EAPContext{EAPMessage: &eap.EAPMessage{Type: eap.TypeTLS}},
+			expected: false,
+		},
+		{
+			name:     "cannot handle nil message",
+			ctx:      &eap.EAPContext{EAPMessage: nil},
+			expected: false,
+		},
+		{
+			name:     "cannot handle nil context",
+			ctx:      nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, h.CanHandle(tt.ctx))
+		})
+	}
+}
+
+// TestTTLSHandler_HandleIdentity verifies an EAP-TTLSv0 Start (S bit set,
+// version 0, no data) is sent in an Access-Challenge with handshake state stored
+// (RFC 5281 §9.2, framing per RFC 5216 §3.1).
+func TestTTLSHandler_HandleIdentity(t *testing.T) {
+	h := NewTTLSHandler()
+	stateManager := statemanager.NewMemoryStateManager()
+	writer := &mockResponseWriter{}
+
+	packet := radius.New(radius.CodeAccessRequest, []byte("secret"))
+	require.NoError(t, rfc2865.UserName_SetString(packet, "ttlsuser"))
+
+	ctx := &eap.EAPContext{
+		Context:        context.Background(),
+		Request:        &radius.Request{Packet: packet},
+		ResponseWriter: writer,
+		EAPMessage:     &eap.EAPMessage{Code: eap.CodeResponse, Identifier: 7, Type: eap.TypeIdentity},
+		StateManager:   stateManager,
+		Secret:         "secret",
+	}
+
+	handled, err := h.HandleIdentity(ctx)
+	require.NoError(t, err)
+	assert.True(t, handled)
+	require.NotNil(t, writer.response)
+	assert.Equal(t, radius.CodeAccessChallenge, writer.response.Code)
+
+	// A State attribute must be present so the client can echo it.
+	stateID := rfc2865.State_GetString(writer.response)
+	require.NotEmpty(t, stateID)
+	storedState, err := stateManager.GetState(stateID)
+	require.NoError(t, err)
+	assert.Equal(t, EAPMethodTTLS, storedState.Method)
+	assert.Equal(t, "ttlsuser", storedState.Username)
+	assert.False(t, storedState.Success)
+
+	// Verify the EAP-TTLSv0 Start payload.
+	eapData, err := rfc2869.EAPMessage_Lookup(writer.response)
+	require.NoError(t, err)
+	require.Len(t, eapData, 6)
+	assert.Equal(t, byte(eap.CodeRequest), eapData[0])
+	assert.Equal(t, byte(7), eapData[1])
+	assert.Equal(t, byte(eap.TypeTTLS), eapData[4])
+	assert.Equal(t, byte(tlsfragment.FlagStart), eapData[5], "Start (S) bit must be set, version 0")
+	assert.Zero(t, eapData[5]&tlsfragment.FlagLengthIncluded, "L bit must be clear for a Start with no data")
+	assert.Zero(t, eapData[5]&0x07, "EAP-TTLSv0 version bits (RFC 5281 §9.1) must be 0")
+}
+
+func TestTTLSHandler_buildStartRequest(t *testing.T) {
+	result := NewTTLSHandler().buildStartRequest(3)
+
+	require.Len(t, result, 6)
+	assert.Equal(t, byte(eap.CodeRequest), result[0], "Code should be Request")
+	assert.Equal(t, byte(3), result[1], "Identifier should match")
+	actualLen := (int(result[2]) << 8) | int(result[3])
+	assert.Equal(t, 6, actualLen, "Length should be 6")
+	assert.Equal(t, byte(eap.TypeTTLS), result[4], "Type should be TTLS")
+	assert.Equal(t, byte(tlsfragment.FlagStart), result[5], "Flags should have only the Start bit set (version 0)")
+}
+
+// TestTTLSHandler_HandleResponse_NeverAuthenticates ensures the M9.1 skeleton
+// rejects every challenge response with eap.ErrTTLSNotImplemented and never
+// grants access before the outer TLS tunnel (M9.2) is implemented.
+func TestTTLSHandler_HandleResponse_NeverAuthenticates(t *testing.T) {
+	h := NewTTLSHandler()
+
+	packet := radius.New(radius.CodeAccessRequest, []byte("secret"))
+	require.NoError(t, rfc2865.State_SetString(packet, "ttls-state-1"))
+	sm := statemanager.NewMemoryStateManager()
+	require.NoError(t, sm.SetState("ttls-state-1", &eap.EAPState{StateID: "ttls-state-1", Method: EAPMethodTTLS}))
+
+	ctx := &eap.EAPContext{
+		Context:      context.Background(),
+		Request:      &radius.Request{Packet: packet},
+		EAPMessage:   &eap.EAPMessage{Code: eap.CodeResponse, Identifier: 8, Type: eap.TypeTTLS, Data: []byte{0x00, 0x16, 0x03, 0x01}},
+		StateManager: sm,
+		Secret:       "secret",
+	}
+
+	success, err := h.HandleResponse(ctx)
+	assert.False(t, success, "EAP-TTLS skeleton must never authenticate")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, eap.ErrTTLSNotImplemented)
+}

--- a/internal/radiusd/plugins/eap/interfaces.go
+++ b/internal/radiusd/plugins/eap/interfaces.go
@@ -24,6 +24,7 @@ const (
 	TypeOTP          = 5  // One-Time Password
 	TypeGTC          = 6  // Generic Token Card
 	TypeTLS          = 13 // EAP-TLS
+	TypeTTLS         = 21 // EAP-TTLS (Tunneled TLS), IANA EAP method type 21
 	TypePEAP         = 25 // Protected EAP (PEAP), IANA EAP method type 25
 	TypeMSCHAPv2     = 26 // EAP-MSCHAPv2
 )

--- a/internal/radiusd/plugins/init.go
+++ b/internal/radiusd/plugins/init.go
@@ -89,5 +89,13 @@ func InitPlugins(appCtx app.ConfigManagerProvider, sessionRepo repository.Sessio
 		registry.RegisterEAPHandler(eaphandlers.NewPEAPHandler())
 	}
 
+	// EAP-TTLS (EAP type 21) is a back-end-adaptation tunneled method (RFC 5281)
+	// that protects legacy inner authentication (PAP / MS-CHAP-V2) with a
+	// server-only TLS tunnel. The M9.1 skeleton answers the EAP-Response/Identity
+	// with an EAP-TTLSv0 Start, then rejects safely with
+	// eap.ErrTTLSNotImplemented until the outer tunnel (M9.2) and inner AVP
+	// authentication (M9.3+) are delivered, so it can never grant access yet.
+	registry.RegisterEAPHandler(eaphandlers.NewTTLSHandler())
+
 	// Vendor parsers under vendor/parsers register themselves via init()
 }

--- a/web/src/i18n/en-US.ts
+++ b/web/src/i18n/en-US.ts
@@ -611,7 +611,7 @@ const customEnglishMessages: TranslationMessages = {
     radius: {
       eap_method: {
         title: 'EAP Method',
-        description: 'Select the EAP authentication algorithm exposed to NAS clients (e.g., eap-md5, eap-mschapv2). eap-peap reuses the EAP-TLS server certificate/key to build the outer TLS tunnel and runs EAP-MSCHAPv2 inside it for Windows/AD compatibility; the inner MS-CHAPv2 has an NTLMv1-like attack surface, so keep the outer TLS strong and prefer eap-tls where clients support certificates.',
+        description: 'Select the EAP authentication algorithm exposed to NAS clients (e.g., eap-md5, eap-mschapv2). eap-peap reuses the EAP-TLS server certificate/key to build the outer TLS tunnel and runs EAP-MSCHAPv2 inside it for Windows/AD compatibility; the inner MS-CHAPv2 has an NTLMv1-like attack surface, so keep the outer TLS strong and prefer eap-tls where clients support certificates. eap-ttls (RFC 5281) likewise builds a server-only TLS tunnel and carries legacy inner authentication (PAP / MS-CHAP-V2) for LDAP / legacy / mixed back ends; it is being delivered incrementally (M9) and currently negotiates the tunnel Start only.',
       },
       eap_enabled_handlers: {
         title: 'Enabled EAP Handlers',

--- a/web/src/i18n/zh-CN.ts
+++ b/web/src/i18n/zh-CN.ts
@@ -611,7 +611,7 @@ const customChineseMessages: TranslationMessages = {
     radius: {
       eap_method: {
         title: 'EAP 认证方式',
-        description: '选择 RADIUS 服务器向 NAS 提供的 EAP 认证算法（如 eap-md5、eap-mschapv2）。eap-peap 复用 EAP-TLS 的服务器证书/私钥建立外层 TLS 隧道，隧道内运行 EAP-MSCHAPv2 以兼容 Windows/AD；内层 MS-CHAPv2 存在类似 NTLMv1 的攻击面，请保持外层 TLS 强度，客户端支持证书时优先使用 eap-tls。',
+        description: '选择 RADIUS 服务器向 NAS 提供的 EAP 认证算法（如 eap-md5、eap-mschapv2）。eap-peap 复用 EAP-TLS 的服务器证书/私钥建立外层 TLS 隧道，隧道内运行 EAP-MSCHAPv2 以兼容 Windows/AD；内层 MS-CHAPv2 存在类似 NTLMv1 的攻击面，请保持外层 TLS 强度，客户端支持证书时优先使用 eap-tls。eap-ttls（RFC 5281）同样建立仅服务器认证的 TLS 隧道，隧道内承载传统内层认证（PAP / MS-CHAP-V2），用于 LDAP / 老账号库 / 混合客户端后端；该方法按 M9 分阶段交付，目前仅协商隧道 Start。',
       },
       eap_enabled_handlers: {
         title: '启用的 EAP 处理器',


### PR DESCRIPTION
## 关联

- Feature: `TR-F004`（EAP 认证方法扩展）
- Roadmap: **M9.1 注册 EAP-TTLS handler 骨架与启用列表配置**（M9 — EAP-TTLS 隧道认证支持，P1）
- 协议规范：RFC 5281 §9.1/§9.2（EAP-TTLS Flags/Start），RFC 5216 §3.1（EAP-TLS 框架复用），RFC 3579（RADIUS 承载 EAP）

## 背景

EAP-TTLS 的现实价值是**后端适配**：用服务器证书建立 TLS 隧道，隧道内承载 PAP / CHAP / MS-CHAP / MS-CHAP-V2 等传统内层认证，让 LDAP、老账号库、混合客户端无需立即改造证书体系即可接入。M9 分阶段交付，本 PR 是 M9.1 的**最小骨架**：让该方法可被选择/协商，但**绝不放行**，外层隧道留待 M9.2。

## 变更

- **`TTLSHandler`（新增 `internal/radiusd/plugins/eap/handlers/ttls_handler.go`）**：EAP type **21** / name `eap-ttls`。
  - `HandleIdentity` 对 EAP-Response/Identity 回送 **EAP-TTLSv0 Start**（S 位置位、version 位为 0、无 TLS 数据），并以 RADIUS State 持久化握手状态。version 0 使 TTLS Start 与 EAP-TLS Start 字节一致，复用既有 `tlsfragment` 框架（RFC 5281 §9.1 / RFC 5216 §3.1）。
  - `HandleResponse` 为**安全桩**：对任何挑战响应一律返回 `eap.ErrTTLSNotImplemented`，`success=false`，**永不放行**。
- **协调器选路**：`coordinator.go` 的 `handleIdentityResponse` 增加 `case "eap-ttls"`（不重写协调器）。
- **注册**：`init.go` 无条件注册 `NewTTLSHandler()`（骨架不需要 TLS 配置，隧道见 M9.2）。
- **启用列表配置**：`EapMethod` 枚举在 `config_schemas.json`、`config_manager.go` 后端两处与前端 `web/src/i18n/{en-US,zh-CN}.ts` 同步加入 `eap-ttls`，并补充中英双语说明（后端适配定位 + 分阶段交付现状）。
- **错误语义**：新增 `eap.ErrTTLSNotImplemented` 哨兵，保证骨架永不授权。

## 测试

- `ttls_handler_test.go`：`Name`、`EAPType`（断言 `eap.TypeTTLS` 且字面量 21）、`CanHandle`（表驱动）、`HandleIdentity`（Access-Challenge + State 持久化 + Start 帧：len 6、`[4]`=21、`[5]`=FlagStart、version 位 `&0x07`==0、L 位清零）、`buildStartRequest`、`HandleResponse_NeverAuthenticates`（`ErrorIs(ErrTTLSNotImplemented)`）。
- `coordinator_test.go`：新增 `TestHandleEAPRequest_IdentityResponse_TTLS` 选路用例。
- `config_manager_test.go`：枚举断言增加 `eap-ttls`。

## 门禁

- `CGO_ENABLED=0 go build ./...` ✅
- `go test ./...` ✅
- golangci-lint v2.12.2 `run ./internal/radiusd/plugins/... ./internal/app/...` → 0 issues ✅
- `cd web && npm run build` ✅（改动了 i18n）

## 边界

- 不重写 EAP 协调器；骨架阶段**不实现**外层 TLS 隧道（M9.2）、内层 AVP/PAP（M9.3）、内层 MS-CHAP-V2（M9.4）。端到端 TTLS 验收用例属于 M9.6。