### PR TITLE
feat(eap): establish EAP-TTLS outer TLS tunnel + fragmentation (M9.2)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -205,7 +205,7 @@
 
 子任务：
 - [x] M9.1 注册 EAP-TTLS handler 骨架与启用列表配置 ✅ 实现 `TTLSHandler`（EAP type 21 / name `eap-ttls`），对 EAP-Response/Identity 回送 EAP-TTLSv0 Start（RFC 5281 §9.2，Flags 复用 EAP-TLS 框架 RFC 5216 §3.1，version 位为 0），并在协调器 `handleIdentityResponse` 增加 `eap-ttls` 分支、`init.go` 无条件注册该 handler；`HandleResponse` 为安全桩，对任何挑战响应一律返回 `ErrTTLSNotImplemented`、永不放行（外层隧道见 M9.2）。`EapMethod` 枚举在 `config_schemas.json` + `config_manager.go` + 前端 `i18n/{en-US,zh-CN}.ts` 三处同步加入 `eap-ttls` 并补充双语说明。单测覆盖 Name/EAPType(21)/CanHandle/HandleIdentity(Start 帧+状态持久化)/buildStartRequest/HandleResponse 永不认证，并在 `coordinator_test.go` 增加 `eap-ttls` 选路用例。门禁：`go build ./...`、`go test ./...`、golangci-lint v2.12.2、`cd web && npm run build` 均通过。
-- [ ] M9.2 外层 TLS 隧道建立与分片重组（复用 EAP-TLS 状态机）
+- [x] M9.2 外层 TLS 隧道建立与分片重组（复用 EAP-TLS 状态机）✅ `TTLSHandler` 增加 `NewTTLSHandlerWithConfig` 与 `configProvider`/`maxFragment`，`HandleResponse` 复用共享 `tlsTunnel` 状态机（`eapType=TypeTTLS`）驱动 server-only 外层 TLS 握手与 RFC 5216 §2.1.5/§3.1 分片重组；握手完成回调 `onHandshakeComplete` 在内层 AVP 认证（M9.3+）落地前返回 `eap.ErrTTLSInnerNotImplemented`，隧道可建立可分片但**永不放行**。新增 `NewSettingsTTLSConfigProvider`（server-only，复用 `EapTlsCertFile/KeyFile/MinVersion`）；`init.go` 按 `ConfigMgr()` 是否可用分支注册（缺省回落到未配置 handler，按 `ErrTLSNotConfigured` 安全拒绝）。测试：未配置→`ErrTLSNotConfigured`；真实 server-only TLS 握手经隧道跑通后→`ErrTTLSInnerNotImplemented`（含强制 `maxFragment=48` 的分片重组用例）。门禁 `go build/test ./...`、golangci-lint v2.12.2 全过。
 - [ ] M9.3 隧道内 AVP 封装与 PAP 内层认证（最小可用闭环）
 - [ ] M9.4 增加 MS-CHAP-V2 内层认证与密钥导出
 - [ ] M9.5 明确失败原因 + 指标 + 单元测试；配置项与默认值

--- a/internal/radiusd/plugins/eap/errors.go
+++ b/internal/radiusd/plugins/eap/errors.go
@@ -43,10 +43,10 @@ var (
 	// (unexpected EAP code/type/opcode for the current inner sub-state). It
 	// guarantees a malformed inner exchange rejects rather than grants.
 	ErrPEAPInnerProtocol = errors.New("PEAP inner EAP-MSCHAPv2 protocol violation")
-	// ErrTTLSNotImplemented is returned by the EAP-TTLS handler skeleton until
-	// the outer TLS tunnel and inner AVP authentication are implemented
-	// (milestones M9.2 / M9.3). It guarantees the skeleton, which answers the
-	// EAP-Response/Identity with an EAP-TTLS Start (RFC 5281 §9.2), can never
-	// grant access on a challenge response.
-	ErrTTLSNotImplemented = errors.New("EAP-TTLS tunnel is not implemented yet")
+	// ErrTTLSInnerNotImplemented is returned after EAP-TTLS's outer TLS tunnel
+	// has been established but before the inner AVP authentication (PAP /
+	// MS-CHAP-V2) is implemented (milestones M9.3 / M9.4). It guarantees the
+	// M9.2 outer tunnel can establish and fragment correctly yet never grant
+	// access (RFC 5281 §10/§11 inner authentication is pending).
+	ErrTTLSInnerNotImplemented = errors.New("EAP-TTLS inner authentication is not implemented yet")
 )

--- a/internal/radiusd/plugins/eap/handlers/tls_config.go
+++ b/internal/radiusd/plugins/eap/handlers/tls_config.go
@@ -125,6 +125,48 @@ func NewSettingsPEAPConfigProvider(reader TLSSettingsReader) TLSConfigProvider {
 	}
 }
 
+// NewSettingsTTLSConfigProvider returns a TLSConfigProvider for EAP-TTLS's outer
+// server-authenticated tunnel.
+//
+// EAP-TTLS (RFC 5281 §7) reuses the EAP-TLS fragmentation/framing defined by
+// RFC 5216 §2.1.5 and §3.1 but authenticates the peer with legacy inner
+// authentication carried as AVPs inside the tunnel (PAP / CHAP / MS-CHAP /
+// MS-CHAP-V2), so no client CA is required for the outer TLS handshake. Like
+// PEAP it intentionally reuses the existing EAP-TLS server certificate settings
+// (radius.EapTlsCertFile / radius.EapTlsKeyFile) and honors the configured
+// minimum TLS version (radius.EapTlsMinVersion).
+//
+// Security note: the outer tunnel carries cleartext-equivalent inner
+// credentials (PAP sends the password inside the tunnel), so the server-only
+// TLS tunnel must stay strong — this provider keeps ServerOnly authentication
+// with the operator-selected minimum TLS version and never weakens it. Until
+// the server certificate/key are configured it returns a nil config so the
+// handler rejects safely with eap.ErrTLSNotConfigured.
+func NewSettingsTTLSConfigProvider(reader TLSSettingsReader) TLSConfigProvider {
+	return func() (*tlsengine.Config, error) {
+		if reader == nil {
+			return nil, nil
+		}
+
+		certFile := strings.TrimSpace(reader.GetString("radius", SettingEapTlsCertFile))
+		keyFile := strings.TrimSpace(reader.GetString("radius", SettingEapTlsKeyFile))
+		if certFile == "" || keyFile == "" {
+			return nil, nil
+		}
+
+		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			return nil, fmt.Errorf("load EAP-TTLS server certificate: %w", err)
+		}
+
+		return &tlsengine.Config{
+			ServerCertificate: cert,
+			ServerOnly:        true,
+			MinVersion:        parseTLSMinVersion(reader.GetString("radius", SettingEapTlsMinVersion)),
+		}, nil
+	}
+}
+
 // parseTLSMinVersion maps a configured minimum TLS version string to the
 // crypto/tls constant. It defaults to TLS 1.2, the interoperability floor for
 // modern EAP-TLS deployments; an unrecognized value falls back to the same

--- a/internal/radiusd/plugins/eap/handlers/ttls_handler.go
+++ b/internal/radiusd/plugins/eap/handlers/ttls_handler.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap/tlsengine"
 	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap/tlsfragment"
 	"github.com/talkincode/toughradius/v9/pkg/common"
 	"layeh.com/radius"
@@ -34,22 +35,48 @@ const (
 // EAP-Message attributes (RFC 3579).
 //
 // Milestone scope:
-//   - M9.1 (current): registers the method (EAP type 21, name "eap-ttls") and
-//     answers EAP-Response/Identity with an EAP-TTLSv0 Start. HandleResponse is
-//     a safe stub that always rejects with eap.ErrTTLSNotImplemented until the
-//     outer tunnel lands, so the skeleton can never grant access.
-//   - M9.2: establishes the outer TLS tunnel and fragmentation reassembly,
-//     reusing the EAP-TLS state machine.
+//   - M9.1: registered the method (EAP type 21, name "eap-ttls") and answered
+//     EAP-Response/Identity with an EAP-TTLSv0 Start.
+//   - M9.2 (current): establishes the outer TLS tunnel and fragmentation
+//     reassembly, reusing the shared EAP-TLS state machine (tlsTunnel). Until
+//     the inner phase lands, a completed handshake rejects safely with
+//     eap.ErrTTLSInnerNotImplemented, so the tunnel can never grant access.
 //   - M9.3: tunneled AVP encapsulation and inner PAP authentication.
 //   - M9.4: inner MS-CHAP-V2 authentication and key derivation.
-type TTLSHandler struct{}
+type TTLSHandler struct {
+	configProvider TLSConfigProvider
+	maxFragment    int
+}
 
-// NewTTLSHandler creates an EAP-TTLSv0 handler skeleton. It accepts the EAP-TTLS
-// Start exchange but rejects challenge responses safely with
-// eap.ErrTTLSNotImplemented until the outer TLS tunnel is implemented (M9.2), so
-// it can never authenticate a client.
+// NewTTLSHandler creates an EAP-TTLSv0 handler without TLS material configured.
+// It accepts the EAP-TTLS Start exchange but rejects handshake attempts safely
+// with eap.ErrTLSNotConfigured until a server-certificate config provider is
+// supplied, so it can never authenticate a client.
 func NewTTLSHandler() *TTLSHandler {
-	return &TTLSHandler{}
+	return &TTLSHandler{maxFragment: defaultMaxTLSFragment}
+}
+
+// NewTTLSHandlerWithConfig creates an EAP-TTLSv0 handler that drives the outer
+// TLS tunnel using the TLS material returned by provider.
+func NewTTLSHandlerWithConfig(provider TLSConfigProvider) *TTLSHandler {
+	return &TTLSHandler{configProvider: provider, maxFragment: defaultMaxTLSFragment}
+}
+
+// newTunnel builds the shared EAP-TLS/PEAP/TTLS tunnel state machine configured
+// for EAP-TTLS (EAP type 21). Once the outer handshake completes, the M9.2
+// milestone rejects with eap.ErrTTLSInnerNotImplemented in place of running the
+// inner AVP exchange (M9.3+), so the tunnel can establish and fragment correctly
+// yet never grant access.
+func (h *TTLSHandler) newTunnel() *tlsTunnel {
+	return &tlsTunnel{
+		eapType:        eap.TypeTTLS,
+		maxFragment:    h.maxFragment,
+		configProvider: h.configProvider,
+		onHandshakeComplete: func(_ *eap.EAPContext, state *eap.EAPState, _ *tlsengine.Engine) (bool, error) {
+			closeEngine(state)
+			return false, eap.ErrTTLSInnerNotImplemented
+		},
+	}
 }
 
 // Name returns the handler name ("eap-ttls").
@@ -74,7 +101,7 @@ func (h *TTLSHandler) CanHandle(ctx *eap.EAPContext) bool {
 // request (an EAP-Request with EAP-Type=TTLS, the Start (S) bit set, version
 // bits 0, and no TLS data; RFC 5281 §9.2, framing per RFC 5216 §3.1). It
 // persists handshake state keyed by the RADIUS State attribute so subsequent
-// rounds (milestone M9.2) can correlate the tunnel.
+// tunnel rounds can correlate the exchange.
 func (h *TTLSHandler) HandleIdentity(ctx *eap.EAPContext) (bool, error) {
 	eapData := h.buildStartRequest(ctx.EAPMessage.Identifier)
 
@@ -95,12 +122,14 @@ func (h *TTLSHandler) HandleIdentity(ctx *eap.EAPContext) (bool, error) {
 	return true, h.writeChallenge(ctx, stateID, eapData)
 }
 
-// HandleResponse is the M9.1 safe stub for EAP-TTLS challenge responses. The
-// outer TLS tunnel (M9.2) and inner AVP authentication (M9.3+) are not yet
-// implemented, so it always rejects with eap.ErrTTLSNotImplemented and never
-// grants access.
+// HandleResponse drives EAP-TTLS's outer TLS tunnel and fragmentation using the
+// shared EAP-TLS state machine (RFC 5281 §7-§9, framing per RFC 5216
+// §2.1.5/§3.1). The M9.2 milestone establishes the server-only tunnel but does
+// not yet run the inner AVP authentication (M9.3+), so a completed handshake
+// rejects with eap.ErrTTLSInnerNotImplemented and the handler never grants
+// access.
 func (h *TTLSHandler) HandleResponse(ctx *eap.EAPContext) (bool, error) {
-	return false, eap.ErrTTLSNotImplemented
+	return h.newTunnel().HandleResponse(ctx)
 }
 
 // buildStartRequest constructs an EAP-TTLSv0 Start request: an EAP-Request with

--- a/internal/radiusd/plugins/eap/handlers/ttls_handler_test.go
+++ b/internal/radiusd/plugins/eap/handlers/ttls_handler_test.go
@@ -2,12 +2,16 @@ package handlers
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap"
 	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap/statemanager"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap/tlsengine"
 	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap/tlsfragment"
 	"layeh.com/radius"
 	"layeh.com/radius/rfc2865"
@@ -128,10 +132,11 @@ func TestTTLSHandler_buildStartRequest(t *testing.T) {
 	assert.Equal(t, byte(tlsfragment.FlagStart), result[5], "Flags should have only the Start bit set (version 0)")
 }
 
-// TestTTLSHandler_HandleResponse_NeverAuthenticates ensures the M9.1 skeleton
-// rejects every challenge response with eap.ErrTTLSNotImplemented and never
-// grants access before the outer TLS tunnel (M9.2) is implemented.
-func TestTTLSHandler_HandleResponse_NeverAuthenticates(t *testing.T) {
+// TestTTLSHandler_HandleResponse_NeverAuthenticatesWithoutConfig ensures the
+// EAP-TTLS handler rejects safely before server certificate/key material is
+// configured: without a TLS config provider the outer tunnel cannot be driven,
+// so it can never grant access.
+func TestTTLSHandler_HandleResponse_NeverAuthenticatesWithoutConfig(t *testing.T) {
 	h := NewTTLSHandler()
 
 	packet := radius.New(radius.CodeAccessRequest, []byte("secret"))
@@ -148,7 +153,80 @@ func TestTTLSHandler_HandleResponse_NeverAuthenticates(t *testing.T) {
 	}
 
 	success, err := h.HandleResponse(ctx)
-	assert.False(t, success, "EAP-TTLS skeleton must never authenticate")
+	assert.False(t, success, "EAP-TTLS must never authenticate without an outer TLS server certificate")
 	require.Error(t, err)
-	assert.ErrorIs(t, err, eap.ErrTTLSNotImplemented)
+	assert.ErrorIs(t, err, eap.ErrTLSNotConfigured)
+}
+
+func ttlsServerEngineConfig(t *testing.T, serverCA *hsTestCA) *tlsengine.Config {
+	t.Helper()
+	serverCert := serverCA.issue(t, "radius.example.com", func(c *x509.Certificate) {
+		c.DNSNames = []string{"radius.example.com"}
+	})
+	return &tlsengine.Config{
+		ServerCertificate: serverCert,
+		ServerOnly:        true,
+		MinVersion:        tls.VersionTLS12,
+		HandshakeTimeout:  5 * time.Second,
+	}
+}
+
+// ttlsTunnelClientCfg builds a server-only TLS client config (no client
+// certificate): EAP-TTLS authenticates the peer with inner AVPs, so the outer
+// handshake only verifies the server (RFC 5281 §7).
+func ttlsTunnelClientCfg(serverCA *hsTestCA) *tls.Config {
+	return &tls.Config{
+		RootCAs:    serverCA.pool,
+		ServerName: "radius.example.com",
+		MinVersion: tls.VersionTLS12,
+	}
+}
+
+// TestTTLSHandler_FullHandshake_EstablishesTunnelThenRejects drives a real
+// server-only TLS handshake through the EAP-TTLS outer tunnel. Reaching the
+// handshake-complete callback proves the tunnel and fragmentation framing
+// (RFC 5281 §7-§9, RFC 5216 §2.1.5/§3.1) work end to end; the M9.2 milestone
+// then rejects with eap.ErrTTLSInnerNotImplemented because the inner AVP
+// authentication (M9.3+) is not yet implemented, so the tunnel never grants.
+func TestTTLSHandler_FullHandshake_EstablishesTunnelThenRejects(t *testing.T) {
+	ca := newHSTestCA(t, "TTLS Outer Root CA")
+	cfg := ttlsServerEngineConfig(t, ca)
+	h := NewTTLSHandlerWithConfig(func() (*tlsengine.Config, error) { return cfg, nil })
+
+	sm := statemanager.NewMemoryStateManager()
+	defer sm.Close()
+
+	stateID := startHandshake(t, h, sm, "ttlsuser", "secret")
+	sup := newSupplicantForType(t, h, eap.TypeTTLS, sm, stateID, "secret", ttlsTunnelClientCfg(ca))
+
+	success, err := sup.run()
+	assert.False(t, success, "EAP-TTLS M9.2 outer tunnel must not grant access on its own")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, eap.ErrTTLSInnerNotImplemented)
+
+	state, err := sm.GetState(stateID)
+	require.NoError(t, err)
+	assert.False(t, state.Success, "state must not be marked successful")
+}
+
+// TestTTLSHandler_FullHandshake_Fragmented forces a small fragment size so the
+// outer handshake spans multiple EAP-TLS fragments, exercising reassembly and
+// the ACK exchange (RFC 5216 §2.1.5). It must still reach the
+// inner-not-implemented rejection without granting.
+func TestTTLSHandler_FullHandshake_Fragmented(t *testing.T) {
+	ca := newHSTestCA(t, "TTLS Outer Fragment Root CA")
+	cfg := ttlsServerEngineConfig(t, ca)
+	h := NewTTLSHandlerWithConfig(func() (*tlsengine.Config, error) { return cfg, nil })
+	h.maxFragment = 48 // force the handshake records to fragment
+
+	sm := statemanager.NewMemoryStateManager()
+	defer sm.Close()
+
+	stateID := startHandshake(t, h, sm, "ttlsuser", "secret")
+	sup := newSupplicantForType(t, h, eap.TypeTTLS, sm, stateID, "secret", ttlsTunnelClientCfg(ca))
+
+	success, err := sup.run()
+	assert.False(t, success)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, eap.ErrTTLSInnerNotImplemented)
 }

--- a/internal/radiusd/plugins/init.go
+++ b/internal/radiusd/plugins/init.go
@@ -91,11 +91,18 @@ func InitPlugins(appCtx app.ConfigManagerProvider, sessionRepo repository.Sessio
 
 	// EAP-TTLS (EAP type 21) is a back-end-adaptation tunneled method (RFC 5281)
 	// that protects legacy inner authentication (PAP / MS-CHAP-V2) with a
-	// server-only TLS tunnel. The M9.1 skeleton answers the EAP-Response/Identity
-	// with an EAP-TTLSv0 Start, then rejects safely with
-	// eap.ErrTTLSNotImplemented until the outer tunnel (M9.2) and inner AVP
-	// authentication (M9.3+) are delivered, so it can never grant access yet.
-	registry.RegisterEAPHandler(eaphandlers.NewTTLSHandler())
+	// server-only TLS tunnel. M9.2 establishes the outer TLS tunnel with EAP-TLS
+	// framing, then rejects safely with eap.ErrTTLSInnerNotImplemented until the
+	// inner AVP authentication (M9.3+) is delivered, so it can never grant access
+	// yet. When no config manager is available (e.g. unit tests with a nil
+	// appCtx), fall back to the unconfigured handler which rejects identically
+	// with eap.ErrTLSNotConfigured.
+	if appCtx != nil && appCtx.ConfigMgr() != nil {
+		provider := eaphandlers.NewSettingsTTLSConfigProvider(appCtx.ConfigMgr())
+		registry.RegisterEAPHandler(eaphandlers.NewTTLSHandlerWithConfig(provider))
+	} else {
+		registry.RegisterEAPHandler(eaphandlers.NewTTLSHandler())
+	}
 
 	// Vendor parsers under vendor/parsers register themselves via init()
 }


### PR DESCRIPTION
## 关联

- Feature: `TR-F004`（EAP 认证方法扩展）
- Roadmap: **M9.2 外层 TLS 隧道建立与分片重组（复用 EAP-TLS 状态机）**（M9 — EAP-TTLS 隧道认证支持，P1）
- 协议规范：RFC 5281 §7–§9（EAP-TTLS 隧道/握手），RFC 5216 §2.1.5/§3.1（EAP-TLS 分片/框架复用），RFC 3579（RADIUS 承载 EAP）

## 背景

承接 M9.1 骨架。EAP-TTLS 用**仅服务器证书**建立 TLS 隧道（peer 用隧道内 AVP 认证，外层不需要客户端证书）。本 PR 让外层隧道真正跑起来——握手与分片重组——但**绝不放行**，内层 AVP 认证（PAP / MS-CHAP-V2）属于 M9.3+。

## 变更

- **`TTLSHandler` 驱动外层隧道**：新增 `NewTTLSHandlerWithConfig` 与 `configProvider`/`maxFragment` 字段；`HandleResponse` 改为委托共享的 `tlsTunnel` 状态机（`eapType=TypeTTLS=21`），复用 EAP-TLS/PEAP 已有的 Length/More/Start 分片与重组（RFC 5216 §2.1.5/§3.1），不重写协调器、不重写隧道。
- **握手完成边界**：`onHandshakeComplete` 返回新的 `eap.ErrTTLSInnerNotImplemented`（替换 M9.1 的 `ErrTTLSNotImplemented` 整体桩）。外层握手一旦完成即安全拒绝，因为内层 AVP 交换是 M9.3+。**永不放行**。
- **配置 provider**：新增 `NewSettingsTTLSConfigProvider` —— server-only 外层隧道配置，复用 EAP-TLS 的服务器证书设置（`EapTlsCertFile`/`EapTlsKeyFile`）与最小 TLS 版本；证书/私钥未配置时返回 nil，按 `eap.ErrTLSNotConfigured` 安全拒绝。
- **注册**：`init.go` 在 `ConfigMgr()` 可用时注册 `NewTTLSHandlerWithConfig`，否则回落到未配置 handler（与 PEAP M8.2 一致）。

## 测试

- `TestTTLSHandler_HandleResponse_NeverAuthenticatesWithoutConfig`：未配置→`ErrTLSNotConfigured`。
- `TestTTLSHandler_FullHandshake_EstablishesTunnelThenRejects`：用真实 crypto/tls 客户端经隧道跑通**完整 server-only TLS 握手**，到达握手完成回调→`ErrTTLSInnerNotImplemented`（证明隧道建立但不放行，`state.Success=false`）。
- `TestTTLSHandler_FullHandshake_Fragmented`：强制 `maxFragment=48`，验证多分片重组 + ACK 交换仍到达同一拒绝。
- 既有骨架测试（Name/EAPType(21)/CanHandle/HandleIdentity/buildStartRequest）保持通过。

## 门禁

- `CGO_ENABLED=0 go build ./...` ✅
- `go test ./...` ✅（含新增握手/分片用例）
- golangci-lint v2.12.2 `run ./internal/radiusd/plugins/... ./internal/app/...` → 0 issues ✅

## 边界

- **不实现**内层 AVP 封装/PAP（M9.3）、内层 MS-CHAP-V2（M9.4）、失败原因+指标（M9.5）、端到端验收（M9.6）。
- 外层隧道为 server-only：peer 不出示客户端证书，认证由后续内层 AVP 完成。