### PR TITLE
docs(adminapi): stdlib-style godoc for framework layer + NAS resource (M4.12)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -34,7 +34,7 @@
 | M6 | 可观测性与运维增强 | TR-F015 | P3 | 计划中 |
 | M7 | 上游 RADIUS 库跟踪与协议合规 | TR-F021 / TR-F022 | P2 | 进行中 |
 | M8 | PEAPv0 / EAP-MSCHAPv2 认证支持 | TR-F004 | P1 | 已完成 |
-| M9 | EAP-TTLS 隧道认证支持 | TR-F004 | P1 | 计划中 |
+| M9 | EAP-TTLS 隧道认证支持 | TR-F004 | P1 | 已完成 |
 | M10 | EAP-TLS 1.3 / RFC 9190 升级 | TR-F004 | P2 | 计划中 |
 | M11 | TEAP 隧道认证（中长期） | TR-F004 | P3 | 计划中 |
 | M12 | EAP-PWD 口令认证（按需） | TR-F004 | P3 | 计划中 |
@@ -135,7 +135,7 @@
 - [x] M4.11 制定 Go API 文档/注释规范并建立 `document-go-apis` 技能（标准库 godoc 风格，关联 `TR-F024`）
 - [x] M4.7 为 agent 任务建立 PR 模板与 review checklist
 - [ ] M4.8 收敛 agent 产出质量度量（CI 通过率、回滚率）
-- [ ] M4.12 按模块增量补齐导出标识符 godoc 注释与包注释（顺序建议：`internal/adminapi` → `internal/radiusd` → `pkg`），并探索 lint 度量（`TR-F024`）
+- [ ] M4.12 按模块增量补齐导出标识符 godoc 注释与包注释（顺序建议：`internal/adminapi` → `internal/radiusd` → `pkg`），并探索 lint 度量（`TR-F024`）<br/>进行中（增量交付）：批次 1 已补齐 `internal/adminapi` 框架层——新增包注释（`adminapi.go` 顶部，标准库风格，说明 /api/v1 管理 API 定位、handler 无状态从 echo context 取依赖、统一 `Response`/`ErrorResponse` 信封与 `RequireLevel` 鉴权模型）、`Init`/`GetAppContext`/`GetDB`/`GetConfig` 契约注释（读取来源、中间件契约、缺失即 panic 的程序性错误语义、按 key 回落），及 `Meta`/`Response`/`ErrorResponse` 信封类型契约；并以 `nas.go`（`ListNAS`/`GetNAS`/`CreateNAS`/`UpdateNAS`/`DeleteNAS`）为资源处理器范本：首段散文化契约（HTTP 方法/路径、鉴权级别、参数与默认值/钳制、错误码与响应体形状、SQL 注入护栏），保留既有 Swagger `@` 注解并以空注释行与散文分段（`go doc` 首段即干净摘要）。门禁：`gofmt`、`go build ./...`、`go vet`、`go test ./internal/adminapi/...`、golangci-lint v2.12.2 对该包 0 问题。余 `internal/adminapi` 其余资源处理器（users/profiles/sessions/accounting/dashboard/operators/nodes/settings/system_backup/system_logs/session_actions/auth/users_import）及 `internal/radiusd`、`pkg` 待后续批次续接；lint 度量（按包 ratchet 开启 ST1000/ST1020/ST1021 或 revive `exported`）待该包补齐后再探索。
 
 ## M5 — 厂商 VSA 覆盖扩展
 

--- a/internal/adminapi/adminapi.go
+++ b/internal/adminapi/adminapi.go
@@ -1,10 +1,36 @@
+// Package adminapi implements the ToughRADIUS management REST API served under
+// /api/v1. Its handlers back the React Admin frontend and expose CRUD and
+// action endpoints for operators, NAS devices, network nodes, RADIUS profiles
+// and users, online sessions, accounting records, the dashboard, system
+// settings, logs, and backups.
+//
+// Handlers are plain [github.com/labstack/echo/v4] HandlerFuncs registered with
+// the shared web server (see internal/webserver). They read their dependencies
+// — the application context, the GORM database handle, and the configuration
+// manager — from the echo context using [GetAppContext], [GetDB], and
+// [GetConfig], rather than holding injected state, so a handler is a stateless
+// function of its request.
+//
+// Successful responses use the unified [Response] envelope (a data object with
+// optional pagination [Meta]); failures use [ErrorResponse] with a stable,
+// machine-readable error code. Authorization is enforced per route with the
+// [RequireLevel] middleware against the operator levels [LevelSuper],
+// [LevelAdmin], and [LevelOperator].
 package adminapi
 
 import (
 	"github.com/talkincode/toughradius/v9/internal/app"
 )
 
-// Init registers all admin API routes
+// Init registers every admin API route group on the shared web server. It wires
+// the handlers in this package to their paths under /api/v1 and must be called
+// once during startup, after the application context is ready and before the
+// web server begins serving. It is not safe for concurrent use and is not meant
+// to be called more than once.
+//
+// The appCtx parameter is accepted for symmetry with other subsystems' Init
+// functions; handlers resolve the live application context per request from the
+// echo context (see [GetAppContext]) rather than capturing it here.
 func Init(appCtx app.AppContext) {
 	registerAuthRoutes()
 	registerUserRoutes()

--- a/internal/adminapi/context.go
+++ b/internal/adminapi/context.go
@@ -6,12 +6,22 @@ import (
 	"gorm.io/gorm"
 )
 
-// GetAppContext gets the application context from echo context
+// GetAppContext returns the application context that request middleware stored
+// on the echo context under the "appCtx" key. It is the entry point handlers use
+// to reach shared services (database, configuration, scheduler).
+//
+// It panics if no application context is present, which indicates the route was
+// registered without the middleware that injects it — a programming error rather
+// than a runtime condition, so it is surfaced immediately instead of returning a
+// nil context that would fault later.
 func GetAppContext(c echo.Context) app.AppContext {
 	return c.Get("appCtx").(app.AppContext) //nolint:errcheck // type assertion is safe for middleware-set context
 }
 
-// GetDB gets the database connection from echo context
+// GetDB returns the GORM database handle for the current request. It prefers a
+// per-request handle stored under the "db" key (used by tests and request-scoped
+// transactions) and otherwise falls back to the shared connection from the
+// application context, so handlers get a usable [*gorm.DB] either way.
 func GetDB(c echo.Context) *gorm.DB {
 	if db, ok := c.Get("db").(*gorm.DB); ok && db != nil {
 		return db
@@ -19,7 +29,9 @@ func GetDB(c echo.Context) *gorm.DB {
 	return GetAppContext(c).DB()
 }
 
-// GetConfig gets the configuration from echo context
+// GetConfig returns the configuration manager for the current request, resolved
+// from the application context. It is the handler-facing accessor for reading and
+// updating dynamic system settings.
 func GetConfig(c echo.Context) *app.ConfigManager {
 	return GetAppContext(c).ConfigMgr()
 }

--- a/internal/adminapi/nas.go
+++ b/internal/adminapi/nas.go
@@ -61,7 +61,14 @@ var allowedNasSortFields = map[string]bool{
 	"updated_at":  true,
 }
 
-// ListNAS retrieves the NAS device list
+// ListNAS handles GET /api/v1/network/nas, returning a paginated list of NAS
+// devices. It accepts the page and perPage query parameters (perPage is clamped
+// to 1..100, default 10) and optional name, status, and ipaddr filters; name
+// matches case-insensitively and ipaddr matches by prefix. The sort and order
+// parameters are validated against allowedNasSortFields to keep the ORDER BY
+// clause injection-safe. The response body is {"data": []domain.NetNas,
+// "total": int64}. Any authenticated operator may call it.
+//
 // @Summary get the NAS device list
 // @Tags NAS
 // @Param page query int false "Page number"
@@ -121,7 +128,11 @@ func ListNAS(c echo.Context) error {
 	})
 }
 
-// GetNAS fetches a single NAS device
+// GetNAS handles GET /api/v1/network/nas/:id, returning the single NAS device
+// with the given numeric id. It responds 400 with code INVALID_ID when the path
+// parameter is not an integer and 404 with code NOT_FOUND when no such device
+// exists. Any authenticated operator may call it.
+//
 // @Summary get NAS device detail
 // @Tags NAS
 // @Param id path int true "NAS ID"
@@ -141,7 +152,13 @@ func GetNAS(c echo.Context) error {
 	return ok(c, device)
 }
 
-// CreateNAS creates a NAS device
+// CreateNAS handles POST /api/v1/network/nas, creating a NAS device from the
+// JSON body bound to nasPayload and validated against its struct tags. The IP
+// address must be unique; a duplicate is rejected 409 with code IPADDR_EXISTS.
+// Unset optional fields default to status "enabled" and CoA port 3799. On
+// success it returns the persisted [domain.NetNas]. This endpoint requires an
+// admin or super operator (see requireAdmin).
+//
 // @Summary create a NAS device
 // @Tags NAS
 // @Param nas body nasPayload true "NAS device information"
@@ -196,7 +213,14 @@ func CreateNAS(c echo.Context) error {
 	return ok(c, device)
 }
 
-// UpdateNAS updates a NAS device
+// UpdateNAS handles PUT /api/v1/network/nas/:id, applying a partial update to an
+// existing NAS device from the JSON body bound to nasUpdatePayload. Only
+// non-empty fields are written, so omitted fields keep their stored values. A
+// changed IP address must remain unique across other devices; a collision is
+// rejected 409 with code IPADDR_EXISTS. It responds 404 with code NOT_FOUND when
+// the device does not exist and returns the updated [domain.NetNas] on success.
+// This endpoint requires an admin or super operator (see requireAdmin).
+//
 // @Summary update a NAS device
 // @Tags NAS
 // @Param id path int true "NAS ID"
@@ -276,7 +300,13 @@ func UpdateNAS(c echo.Context) error {
 	return ok(c, device)
 }
 
-// DeleteNAS deletes a NAS device
+// DeleteNAS handles DELETE /api/v1/network/nas/:id, removing the NAS device with
+// the given id. To protect accounting integrity it refuses deletion while the
+// device still has online sessions, responding 409 with code HAS_ONLINE_SESSIONS
+// and the active count in Details. It responds 400 with code INVALID_ID for a
+// non-integer id. This endpoint requires an admin or super operator (see
+// requireAdmin).
+//
 // @Summary delete a NAS device
 // @Tags NAS
 // @Param id path int true "NAS ID"

--- a/internal/adminapi/responses.go
+++ b/internal/adminapi/responses.go
@@ -8,20 +8,29 @@ import (
 	"go.uber.org/zap"
 )
 
-// Meta describes pagination information
+// Meta carries pagination information for a list response: the total number of
+// matching rows across all pages, the 1-based page index, and the page size that
+// were applied to the query.
 type Meta struct {
 	Total    int64 `json:"total"`
 	Page     int   `json:"page"`
 	PageSize int   `json:"pageSize"`
 }
 
-// Response represents the unified response structure
+// Response is the unified success envelope returned by admin API handlers. Data
+// holds the payload (an object or a slice) and is omitted when nil; Meta is
+// present only for paginated list responses. Handlers populate it through the
+// internal ok and paged helpers rather than constructing it directly.
 type Response struct {
 	Data interface{} `json:"data,omitempty"`
 	Meta *Meta       `json:"meta,omitempty"`
 }
 
-// ErrorResponse represents the error response structure
+// ErrorResponse is the unified failure envelope returned by admin API handlers.
+// Error is a stable, machine-readable code (for example "NOT_FOUND" or
+// "VALIDATION_ERROR") that clients may branch on; Message is a human-readable
+// explanation; Details carries optional structured context and is omitted for
+// server-side (5xx) failures so internal information is never leaked to clients.
 type ErrorResponse struct {
 	Error   string      `json:"error"`
 	Message string      `json:"message"`


### PR DESCRIPTION
## M4.12 — standard-library-style godoc backfill (batch 1: `internal/adminapi`)

Feature: `TR-F024` · Milestone subtask **M4.12** · Roadmap `docs/roadmap.md`

Begins the incremental godoc backfill the roadmap calls for (suggested order
`internal/adminapi` → `internal/radiusd` → `pkg`), following the
`.agents/skills/document-go-apis` standard. The goal: a reader using
`go doc ./internal/adminapi` or pkg.go.dev understands the API **without reading
the implementation**.

This is **batch 1** — the package's shared HTTP framework plus the NAS resource
as the documentation template for the remaining resource files.

### What this documents
- **Package comment** (atop `adminapi.go`, mirroring the repo's existing
  top-of-file `// Package …` convention — no `doc.go` files exist here): the
  `/api/v1` management API, the stateless-handler model (dependencies read from
  the echo context via `GetAppContext`/`GetDB`/`GetConfig`, not injected state),
  the unified `Response`/`ErrorResponse` envelope, and the `RequireLevel` auth
  model.
- **Framework API**: `Init` (call-once startup contract), `GetAppContext` /
  `GetDB` / `GetConfig` (resolution source, middleware contract, panic-on-missing
  semantics, per-request `db` fallback), and the `Meta` / `Response` /
  `ErrorResponse` envelope types (JSON shape, `omitempty` semantics, stable error
  codes, no detail leakage on 5xx).
- **NAS resource exemplar** (`ListNAS`/`GetNAS`/`CreateNAS`/`UpdateNAS`/
  `DeleteNAS`): each first-line summary now states the HTTP method + path,
  required operator level, query/body parameters with their defaults and clamps,
  error codes, the SQL-injection sort-column guard, and the response body shape.
  The existing Swagger `@`-annotations are preserved, separated from the prose by
  a blank comment line so `go doc` renders a clean first paragraph.

### Why batch it
`internal/adminapi` is ~40 source files with dozens of exported handlers.
Documenting the whole package in one PR would be a giant, low-signal diff (which
the doc skill explicitly warns against). This batch establishes the package
overview and a concrete handler-doc template; the remaining resource files
(users, profiles, sessions, accounting, dashboard, operators, nodes, settings,
system_backup, system_logs, session_actions, auth, users_import) and then
`internal/radiusd` / `pkg` follow in subsequent M4.12 batches. The lint ratchet
(scoped `ST1000`/`ST1020`/`ST1021` or `revive` `exported`) is deferred until the
package is fully documented, per the skill's "do not flip globally in one shot".

### Roadmap groom (folded in)
- Mark **M9 (EAP-TTLS)** `已完成` in the milestone overview (all M9.1–M9.6
  delivered; the prior round merged M9.6 but left the overview cell stale).
- Annotate **M4.12** with batch-1 progress and the remaining scope.

### No behavior change
Comments only (plus one roadmap doc edit). The Swagger annotations are unchanged,
and there is no swag/OpenAPI generation step in the build or CI, so nothing is
regenerated.

### Quality gates
- `gofmt -l` clean on all edited files
- `CGO_ENABLED=0 go build ./...` — pass
- `go vet ./internal/adminapi/...` — pass
- `go test ./...` — pass (incl. `./internal/adminapi/...`)
- `golangci-lint v2.12.2 run ./internal/adminapi/...` — **0 issues**

### Spec
`TR-F024` (standard-library godoc style) · `.agents/skills/document-go-apis`.
