### PR TITLE
docs(handbook): scaffold bilingual mdbook site + CI link-check (M13)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,3 +271,33 @@ jobs:
           # that runs during "Post job cleanup" on every run.
           skip-save-cache: true
         continue-on-error: ${{ github.event_name == 'pull_request' }}
+
+  docs:
+    name: Docs (mdbook)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      # Pin the mdBook version to match what contributors run locally so a build
+      # that passes locally also passes here (and vice versa).
+      - name: Install mdBook
+        uses: peaceiris/actions-mdbook@v2
+        with:
+          mdbook-version: '0.5.3'
+
+      - name: Build handbook
+        run: mdbook build docs-site
+
+      - name: Install lychee
+        uses: taiki-e/install-action@v2
+        with:
+          tool: lychee
+
+      # Offline link check over the generated HTML: a build failure or a broken
+      # internal link fails the pipeline. --offline skips http(s) links so the
+      # gate never flakes on network conditions; --root-dir lets the generated
+      # 404 page's root-relative links resolve.
+      - name: Check links (offline)
+        run: lychee --offline --no-progress --root-dir "$PWD/docs-site/book" 'docs-site/book/**/*.html'

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ pkg/tls/ca.crt
 pkg/tls/ca.key
 pkg/tls/my.crt
 pkg/tls/my.key
+# mdBook handbook build output (docs-site)
+docs-site/book/

--- a/docs-site/book.toml
+++ b/docs-site/book.toml
@@ -1,0 +1,11 @@
+[book]
+title = "ToughRADIUS Handbook"
+description = "Bilingual (English / 中文) handbook for the ToughRADIUS RADIUS server."
+authors = ["ToughRADIUS contributors"]
+language = "en"
+src = "src"
+
+[output.html]
+default-theme = "rust"
+preferred-dark-theme = "ayu"
+git-repository-url = "https://github.com/talkincode/toughradius"

--- a/docs-site/src/SUMMARY.md
+++ b/docs-site/src/SUMMARY.md
@@ -1,0 +1,15 @@
+# Summary
+
+[Introduction / 引言](./introduction.md)
+
+# English
+
+- [Overview](./en/overview.md)
+- [Documentation Map](./en/documentation-map.md)
+- [mdbook & GitBook Coexistence](./en/gitbook-coexistence.md)
+
+# 中文
+
+- [概述](./zh/overview.md)
+- [文档地图](./zh/documentation-map.md)
+- [mdbook 与 GitBook 并存](./zh/gitbook-coexistence.md)

--- a/docs-site/src/en/documentation-map.md
+++ b/docs-site/src/en/documentation-map.md
@@ -1,0 +1,22 @@
+# Documentation Map
+
+> 中文版本：[文档地图](../zh/documentation-map.md)
+
+This handbook is being assembled incrementally. While the core documents are
+migrated into bilingual chapters, this map points to where each one currently
+lives in the repository so everything is reachable from a single place.
+
+| Document            | Description                                            | Current location |
+| ------------------- | ----------------------------------------------------- | ---------------- |
+| README              | Project introduction, features, and quick start       | [README.md](https://github.com/talkincode/toughradius/blob/main/README.md) |
+| Agent guide         | AI-agent development guide and working rules           | [AGENT.md](https://github.com/talkincode/toughradius/blob/main/AGENT.md) |
+| Security policy     | Supported versions and vulnerability reporting         | [SECURITY.md](https://github.com/talkincode/toughradius/blob/main/SECURITY.md) |
+| Feature checklist   | Feature scope baseline (`TR-F` IDs)                    | [docs/feature-checklist.md](https://github.com/talkincode/toughradius/blob/main/docs/feature-checklist.md) · [English](https://github.com/talkincode/toughradius/blob/main/docs/feature-checklist.en.md) |
+| Roadmap             | Long-term roadmap and milestones                       | [docs/roadmap.md](https://github.com/talkincode/toughradius/blob/main/docs/roadmap.md) |
+| RFC index           | Protocol standards index used by the project           | [docs/rfcs/README.md](https://github.com/talkincode/toughradius/blob/main/docs/rfcs/README.md) |
+
+> **Migration plan.** The README, agent guide, and security policy are migrated
+> into bilingual chapters first; the feature checklist, roadmap, and RFC index
+> follow with cross-linked English/中文 sections. As each document moves into the
+> handbook, its original file keeps a short pointer back to the corresponding
+> chapter so there is a single source of truth.

--- a/docs-site/src/en/gitbook-coexistence.md
+++ b/docs-site/src/en/gitbook-coexistence.md
@@ -1,0 +1,41 @@
+# mdbook & GitBook Coexistence
+
+> 中文版本：[mdbook 与 GitBook 并存](../zh/gitbook-coexistence.md)
+
+ToughRADIUS already publishes documentation through **GitBook**
+(`docs.toughradius.net` and `www.toughradius.net`). This section records the
+decision (roadmap item **M13.0**) for how the new mdBook handbook relates to that
+existing pipeline.
+
+## Decision: coexistence, not replacement
+
+The mdBook handbook **coexists** with GitBook. It does not replace or disable the
+GitBook site. The two pipelines are kept separate and non-conflicting:
+
+- **mdBook handbook** — lives in the repository under `docs-site/`, is written in
+  bilingual chapters, and is built and link-checked by CI on every pull request.
+  It is the canonical, version-controlled, review-gated home for documentation
+  that must evolve together with the code.
+- **GitBook site** — synchronizes from the repository through GitBook's own GitHub
+  integration (an external service). There is **no GitBook configuration committed
+  to this repository** (`.gitbook.yaml`, `book.json`, and a GitBook `SUMMARY.md`
+  are all absent), so adding `docs-site/` does not change how GitBook builds.
+
+Because the mdBook sources are confined to `docs-site/` and GitBook is configured
+externally, the two systems do not share a build step and cannot break each other.
+
+## Single source of truth
+
+To avoid content drift between the two pipelines, every document has exactly one
+canonical home. As scattered documents are migrated into the handbook
+(roadmap items M13.2 / M13.3), the original file keeps a short pointer back to the
+corresponding chapter instead of duplicating its content.
+
+## Build and validation
+
+- Local: `mdbook build docs-site` produces the static site in `docs-site/book/`,
+  and `mdbook serve docs-site` previews it with live reload.
+- CI: a dedicated job builds the handbook and runs an **offline link check** over
+  the generated HTML, so a build failure or a broken internal link fails the
+  pipeline (roadmap item M13.4). The build output (`docs-site/book/`) is a build
+  artifact and is not committed.

--- a/docs-site/src/en/overview.md
+++ b/docs-site/src/en/overview.md
@@ -1,0 +1,41 @@
+# Overview
+
+> 中文版本：[概述](../zh/overview.md)
+
+ToughRADIUS is a powerful, open-source RADIUS server written in Go, designed for
+ISPs, enterprise networks, and carriers. It implements the standard RADIUS
+protocols together with RadSec (RADIUS over TLS) and ships with a modern React
+Admin web management interface.
+
+## Core capabilities
+
+- **Standard RADIUS** — full RFC 2865 (authentication) and RFC 2866 (accounting)
+  support.
+- **RadSec** — TLS-encrypted RADIUS over TCP (RFC 6614).
+- **Dynamic authorization** — CoA and Disconnect messages (RFC 5176).
+- **EAP suite** — EAP-TLS, PEAPv0/EAP-MSCHAPv2, and EAP-TTLS inner methods, with
+  more methods tracked on the roadmap.
+- **Multi-vendor support** — compatible with Cisco, MikroTik, Huawei, and other
+  major network devices through vendor-specific attributes (VSAs).
+- **Modern management UI** — a React Admin dashboard for users, profiles, online
+  sessions, accounting, and audit logs.
+- **Multi-database** — PostgreSQL (default) and SQLite (pure Go, no CGO).
+
+## Service model
+
+The server runs several independent services concurrently; if any one fails, the
+process exits so a supervisor can restart it cleanly.
+
+| Service          | Protocol / Port      | Purpose                              |
+| ---------------- | -------------------- | ------------------------------------ |
+| Web / Admin API  | HTTP, TCP `1816`     | Management UI and REST API           |
+| RADIUS Auth      | UDP `1812`           | Authentication                       |
+| RADIUS Acct      | UDP `1813`           | Accounting                           |
+| RadSec           | TLS over TCP `2083`  | Encrypted RADIUS transport           |
+
+## Where to go next
+
+- [Documentation Map](./documentation-map.md) — find the existing README, agent
+  guide, security policy, feature checklist, roadmap, and RFC index.
+- [mdbook & GitBook Coexistence](./gitbook-coexistence.md) — how this handbook
+  relates to the GitBook site and the single-source-of-truth policy.

--- a/docs-site/src/introduction.md
+++ b/docs-site/src/introduction.md
@@ -1,0 +1,72 @@
+# ToughRADIUS Handbook
+
+Welcome to the **ToughRADIUS Handbook** — the canonical, in-repository, bilingual
+documentation site for the [ToughRADIUS](https://github.com/talkincode/toughradius)
+RADIUS server. It is built with [mdBook](https://rust-lang.github.io/mdBook/) and
+lives in the repository under `docs-site/`, so the documentation is versioned,
+reviewed, and validated by CI together with the code it describes.
+
+The handbook is organized into two mirrored language sections. Pick a language to
+begin:
+
+- **English** — start with the [Overview](./en/overview.md).
+- **中文** — 从[概述](./zh/overview.md)开始。
+
+Each chapter exists in both languages with a matching structure, and the pages
+cross-link to their counterparts so you can switch language at any point.
+
+> **Relationship to the existing GitBook site.** ToughRADIUS also publishes
+> documentation through GitBook (`docs.toughradius.net` / `www.toughradius.net`).
+> This mdBook handbook **coexists** with GitBook rather than replacing it; see
+> [mdbook & GitBook Coexistence](./en/gitbook-coexistence.md) /
+> [mdbook 与 GitBook 并存](./zh/gitbook-coexistence.md) for the single-source-of-truth
+> policy and the boundary between the two pipelines.
+
+## Build it locally
+
+```bash
+# Install mdBook (https://rust-lang.github.io/mdBook/guide/installation.html)
+cargo install mdbook            # or: brew install mdbook
+
+# Build the static site into docs-site/book/
+mdbook build docs-site
+
+# Or serve with live reload at http://localhost:3000
+mdbook serve docs-site
+```
+
+---
+
+# ToughRADIUS 使用手册
+
+欢迎来到 **ToughRADIUS 使用手册** —— 这是
+[ToughRADIUS](https://github.com/talkincode/toughradius) RADIUS 服务器
+随仓库维护的中英文双语文档站点。它基于
+[mdBook](https://rust-lang.github.io/mdBook/) 构建，位于仓库的 `docs-site/`
+目录下，因此文档与代码一起被版本化、评审，并由 CI 校验。
+
+手册分为结构一一对应的两个语言区。请选择语言开始阅读：
+
+- **English** — 从 [Overview](./en/overview.md) 开始。
+- **中文** — 从[概述](./zh/overview.md)开始。
+
+每个章节都提供中英文两个版本且结构对应，页面之间相互交叉链接，方便随时切换语言。
+
+> **与现有 GitBook 站点的关系。** ToughRADIUS 目前还通过 GitBook 发布文档
+> （`docs.toughradius.net` / `www.toughradius.net`）。本 mdBook 手册与 GitBook
+> **并存**而非替代；单一事实来源策略与两套管线的边界详见
+> [mdbook 与 GitBook 并存](./zh/gitbook-coexistence.md) /
+> [mdbook & GitBook Coexistence](./en/gitbook-coexistence.md)。
+
+## 本地构建
+
+```bash
+# 安装 mdBook（https://rust-lang.github.io/mdBook/guide/installation.html）
+cargo install mdbook            # 或：brew install mdbook
+
+# 将静态站点构建到 docs-site/book/
+mdbook build docs-site
+
+# 或开启热重载预览，访问 http://localhost:3000
+mdbook serve docs-site
+```

--- a/docs-site/src/zh/documentation-map.md
+++ b/docs-site/src/zh/documentation-map.md
@@ -1,0 +1,19 @@
+# 文档地图
+
+> English version: [Documentation Map](../en/documentation-map.md)
+
+本手册采用分批收编的方式构建。在核心文档逐步迁移为双语章节之前，本页先列出它们
+当前在仓库中的位置，使所有文档都能从同一入口访问。
+
+| 文档              | 说明                                       | 当前位置 |
+| ----------------- | ------------------------------------------ | -------- |
+| README            | 项目介绍、特性与快速上手                    | [README.md](https://github.com/talkincode/toughradius/blob/main/README.md) |
+| Agent 指南        | AI Agent 开发指南与协作规则                 | [AGENT.md](https://github.com/talkincode/toughradius/blob/main/AGENT.md) |
+| 安全策略          | 受支持版本与漏洞上报流程                     | [SECURITY.md](https://github.com/talkincode/toughradius/blob/main/SECURITY.md) |
+| 功能清单          | 功能范围基线（`TR-F` 编号）                 | [docs/feature-checklist.md](https://github.com/talkincode/toughradius/blob/main/docs/feature-checklist.md) · [English](https://github.com/talkincode/toughradius/blob/main/docs/feature-checklist.en.md) |
+| 路线图            | 长期路线图与里程碑                          | [docs/roadmap.md](https://github.com/talkincode/toughradius/blob/main/docs/roadmap.md) |
+| RFC 索引          | 项目使用的协议标准索引                       | [docs/rfcs/README.md](https://github.com/talkincode/toughradius/blob/main/docs/rfcs/README.md) |
+
+> **迁移计划。** 先迁移 README、Agent 指南与安全策略为双语章节；随后收编功能清单、
+> 路线图与 RFC 索引，并建立中英文交叉链接。每份文档迁入手册后，其原始文件会保留
+> 一个指向对应章节的简短入口，以保证单一事实来源。

--- a/docs-site/src/zh/gitbook-coexistence.md
+++ b/docs-site/src/zh/gitbook-coexistence.md
@@ -1,0 +1,36 @@
+# mdbook 与 GitBook 并存
+
+> English version: [mdbook & GitBook Coexistence](../en/gitbook-coexistence.md)
+
+ToughRADIUS 目前已经通过 **GitBook** 发布文档（`docs.toughradius.net` 与
+`www.toughradius.net`）。本节记录路线图条目 **M13.0** 的决策：新的 mdBook 手册
+与既有 GitBook 管线如何相处。
+
+## 决策：并存而非替代
+
+mdBook 手册与 GitBook **并存**，不替代、也不停用 GitBook 站点。两套管线相互独立、
+互不冲突：
+
+- **mdBook 手册** —— 位于仓库的 `docs-site/` 目录，以双语章节编写，并在每个 Pull
+  Request 上由 CI 构建与坏链校验。它是需要与代码同步演进的文档的权威来源：受版本
+  控制、走评审门禁。
+- **GitBook 站点** —— 通过 GitBook 自有的 GitHub 集成（外部服务）从仓库同步。
+  仓库中**没有提交任何 GitBook 配置**（`.gitbook.yaml`、`book.json` 以及 GitBook
+  的 `SUMMARY.md` 均不存在），因此新增 `docs-site/` 不会改变 GitBook 的构建方式。
+
+由于 mdBook 源文件被限制在 `docs-site/` 内，而 GitBook 在外部配置，两套系统不共享
+构建步骤，也不会相互破坏。
+
+## 单一事实来源
+
+为避免两套管线之间出现内容漂移，每份文档只有唯一的权威位置。随着散落文档逐步迁入
+手册（路线图条目 M13.2 / M13.3），原始文件会保留一个指向对应章节的简短入口，而不是
+复制其内容。
+
+## 构建与校验
+
+- 本地：`mdbook build docs-site` 会在 `docs-site/book/` 生成静态站点；
+  `mdbook serve docs-site` 可开启热重载预览。
+- CI：一个独立的任务负责构建手册，并对生成的 HTML 执行**离线坏链检查**，因此构建
+  失败或内部坏链都会让流水线变红（路线图条目 M13.4）。构建产物（`docs-site/book/`）
+  属于构建工件，不纳入版本控制。

--- a/docs-site/src/zh/overview.md
+++ b/docs-site/src/zh/overview.md
@@ -1,0 +1,37 @@
+# 概述
+
+> English version: [Overview](../en/overview.md)
+
+ToughRADIUS 是一款使用 Go 语言编写、功能强大的开源 RADIUS 服务器，面向 ISP、
+企业网络与运营商场景。它实现了标准 RADIUS 协议，并支持 RadSec（RADIUS over TLS），
+同时附带基于 React Admin 的现代化 Web 管理界面。
+
+## 核心能力
+
+- **标准 RADIUS** —— 完整支持 RFC 2865（认证）与 RFC 2866（计费）。
+- **RadSec** —— 基于 TCP 的 TLS 加密 RADIUS（RFC 6614）。
+- **动态授权** —— CoA 与 Disconnect 报文（RFC 5176）。
+- **EAP 套件** —— EAP-TLS、PEAPv0/EAP-MSCHAPv2 以及 EAP-TTLS 内层方法，更多方法
+  在路线图中持续推进。
+- **多厂商支持** —— 通过厂商私有属性（VSA）兼容 Cisco、MikroTik、华为等主流网络设备。
+- **现代化管理界面** —— 基于 React Admin 的控制台，管理用户、套餐、在线会话、计费与审计日志。
+- **多数据库** —— PostgreSQL（默认）与 SQLite（纯 Go，无需 CGO）。
+
+## 服务模型
+
+服务器以并发方式运行多个相互独立的服务；任意一个服务失败都会让进程退出，便于由
+守护进程干净地重启。
+
+| 服务             | 协议 / 端口          | 用途                                 |
+| ---------------- | -------------------- | ------------------------------------ |
+| Web / Admin API  | HTTP，TCP `1816`     | 管理界面与 REST API                  |
+| RADIUS 认证      | UDP `1812`           | 认证                                 |
+| RADIUS 计费      | UDP `1813`           | 计费                                 |
+| RadSec           | TLS over TCP `2083`  | 加密的 RADIUS 传输                    |
+
+## 下一步
+
+- [文档地图](./documentation-map.md) —— 找到现有的 README、Agent 指南、安全策略、
+  功能清单、路线图与 RFC 索引。
+- [mdbook 与 GitBook 并存](./gitbook-coexistence.md) —— 本手册与 GitBook 站点的关系，
+  以及单一事实来源策略。

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -38,7 +38,7 @@
 | M10 | EAP-TLS 1.3 / RFC 9190 升级 | TR-F004 | P2 | 计划中 |
 | M11 | TEAP 隧道认证（中长期） | TR-F004 | P3 | 计划中 |
 | M12 | EAP-PWD 口令认证（按需） | TR-F004 | P3 | 计划中 |
-| M13 | 双语文档站点（mdbook） | TR-F023 | P2 | 计划中 |
+| M13 | 双语文档站点（mdbook） | TR-F023 | P2 | 进行中 |
 
 ---
 
@@ -271,11 +271,11 @@
 - **技能**：文档工程为主；复用 `.agents/skills/reference-rfc/SKILL.md` 维护协议资料索引、`.agents/skills/align-feature-checklist/SKILL.md` 保持中英文同步。
 
 子任务：
-- [ ] M13.0 评估与现有 GitBook 发布的关系（替代 / 并存），确定单一事实来源与发布管线边界
-- [ ] M13.1 mdbook 骨架：`book.toml` + `src/`（zh / en 双语目录）+ 本地构建（`mdbook build`）
+- [x] M13.0 评估与现有 GitBook 发布的关系（替代 / 并存），确定单一事实来源与发布管线边界 —— 决策：**并存**。mdbook 为随仓库维护、CI 校验的双语权威手册（置于独立目录 `docs-site/`）；GitBook 经其 GitHub 集成在外部同步（仓库无 `.gitbook.yaml`/`book.json`/GitBook `SUMMARY.md`），两套管线不共享构建步骤、互不冲突；迁移采用「迁入手册 + 原文件留指针」保证单一事实来源。决策已写入站点章节 `gitbook-coexistence`。
+- [x] M13.1 mdbook 骨架：`book.toml` + `src/`（zh / en 双语目录）+ 本地构建（`mdbook build`）—— `docs-site/book.toml`（仅 `[output.html]`，扁平输出 `docs-site/book/`）+ `src/SUMMARY.md`（English 与 中文 两个 part，章节一一对应）+ `src/{en,zh}/{overview,documentation-map,gitbook-coexistence}.md` + 双语 `introduction.md`。本地 `mdbook build docs-site` 通过。**注意**：mdbook 0.5.3 不支持原生 `[language.*]` 多语言（"unknown field language"），故采用「单 book + 两 part」结构实现双语。
 - [ ] M13.2 迁移核心文档（README / AGENT / SECURITY）为双语章节，原文件保留指向站点的入口
 - [ ] M13.3 收编功能清单 / 路线图 / RFC 索引为站点章节，建立中英文交叉链接
-- [ ] M13.4 CI 增加 `mdbook build` 产物校验（构建失败或坏链即红）
+- [x] M13.4 CI 增加 `mdbook build` 产物校验（构建失败或坏链即红）—— `.github/workflows/ci.yml` 新增独立 `docs` 任务：`peaceiris/actions-mdbook`（钉 0.5.3 与本地一致）→ `mdbook build docs-site` → `lychee --offline`（经 `taiki-e/install-action` 安装）对生成 HTML 做离线坏链校验。构建失败或内部坏链均使流水线变红；`--offline` 跳过 http(s) 链接避免网络抖动。**注意**：未用 `mdbook-linkcheck`（0.7.7 与 mdbook 0.5.3 的 RenderContext 不兼容，"missing field sections"），改用 lychee（与渲染协议解耦）。
 - [ ] M13.5 （可选）GitHub Pages 部署工作流
 
 验收口径：`mdbook build` 在 CI 通过且无坏链，中英文章节一一对应，核心散落文档可从站点统一访问；**验收由 CI 构建用例背书**。


### PR DESCRIPTION
## What & why

Scaffolds the **bilingual (English / 中文) mdBook handbook** requested for the docs
site, and wires a CI gate that builds it and checks links. This is the first
closed loop of milestone **M13 — 双语文档站点（mdbook）** (`TR-F023`, P2), covering
subtasks **M13.0**, **M13.1**, and **M13.4**.

## Scope (this PR)

- **M13.0 — GitBook relationship decision.** mdBook **coexists** with the existing
  external GitBook pipeline (`docs.toughradius.net` / `www.toughradius.net`). There
  is no in-repo GitBook config (`.gitbook.yaml` / `book.json` / GitBook `SUMMARY.md`
  are absent), so the two pipelines share no build step and cannot conflict. The
  decision (incl. the single-source-of-truth policy) is recorded as a site chapter.
- **M13.1 — mdBook skeleton.** `docs-site/book.toml` (HTML-only, flat
  `docs-site/book/` output) + `src/SUMMARY.md` with two mirrored language parts +
  `src/{en,zh}/{overview,documentation-map,gitbook-coexistence}.md` + a bilingual
  `introduction.md`. Chapters cross-link to their counterparts. `mdbook build
  docs-site` passes locally.
- **M13.4 — CI validation.** New independent `docs` job in `.github/workflows/ci.yml`:
  `peaceiris/actions-mdbook` (pinned `0.5.3`, matching local) → `mdbook build
  docs-site` → `lychee --offline` (installed via `taiki-e/install-action`) over the
  generated HTML. A build failure **or** a broken internal link fails CI;
  `--offline` skips http(s) links so the gate never flakes on the network.

## Deferred (later M13 batches)

- M13.2 migrate README / AGENT / SECURITY into bilingual chapters (leave pointers).
- M13.3 collect feature checklist / roadmap / RFC index with CN–EN cross-links.
- M13.5 (optional) GitHub Pages deploy.

The site provides a **Documentation Map** chapter linking to the scattered docs in
the meantime, so they are reachable from one place before full migration.

## Notable technical decisions

- **No native multilingual.** mdBook 0.5.3 rejects `[language.*]` ("unknown field
  `language`"), so the bilingual structure is a single book with two `SUMMARY.md`
  parts (`src/en/*` + `src/zh/*`) — the structure the roadmap asks for.
- **lychee instead of mdbook-linkcheck.** `mdbook-linkcheck` 0.7.7 is incompatible
  with mdBook 0.5.3 (RenderContext "missing field `sections`"). lychee is decoupled
  from mdBook's renderer protocol, so it is a robust offline link gate.
- Keeping `book.toml` HTML-only preserves a flat `docs-site/book/` output (a second
  `[output.*]` backend would nest HTML under `book/html/`). Build output is
  gitignored.

## Validation

- `mdbook build docs-site` → clean (flat `docs-site/book/`, `en/` + `zh/` chapters).
- `lychee --offline --root-dir <book> 'docs-site/book/**/*.html'` → **0 errors**
  (242 OK, 50 http links excluded by offline mode).
- `python -c "yaml.safe_load(...)"` on `ci.yml` → valid; jobs include `docs`.

## Roadmap grooming

Checked off M13.0 / M13.1 / M13.4 with summaries + the two compatibility notes;
M13 overview status → 进行中.

Refs: `TR-F023`.
