### PR TITLE
feat(agents): converge roadmap quality metrics (M4.8)

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -76,6 +76,24 @@
 - **PR 模板**：agent 任务 PR 默认使用 [`.github/pull_request_template.md`](../.github/pull_request_template.md)，完整填写里程碑子任务、`TR-F`、验收与门禁结果。
 - **审查清单**：review gate 按 [`.github/review-checklists/agent-roadmap.md`](../.github/review-checklists/agent-roadmap.md) 逐项判定，避免凭主观印象放行。
 
+### Agent 质量度量（M4.8 / TR-F022）
+
+为收敛 agent 产出质量，仓库提供脚本 `scripts/agent-roadmap-quality-metrics.sh`，统一统计：
+
+- **CI 通过率**：统计窗口内、已合并 `agent-roadmap` PR 关联的已完成 CI 工作流运行（`success / total`）。
+- **回滚率**：统计窗口内、已合并 `agent-roadmap` PR 中，其合并提交随后被 `main` 上 `This reverts commit <sha>` 回滚的比例。
+
+示例：
+
+```bash
+scripts/agent-roadmap-quality-metrics.sh \
+  --days 30 \
+  --json-output .agents/reports/agent-roadmap-quality.json \
+  --markdown-output .agents/reports/agent-roadmap-quality.md
+```
+
+建议每轮自动委托开发结束后执行一次，并在回滚率或失败 CI 增高时优先做根因修复，不扩展新范围。
+
 ### 上游 radius 库跟踪（手动）
 
 核心库 `layeh.com/radius` 经 `go.mod` `replace` 指向组织 fork `github.com/talkincode/radius`。无自动巡检 workflow，按 `skills/sync-upstream-radius/SKILL.md` 的步骤定期人工核对上游是否有安全 / 协议修复并决定是否同步。

--- a/scripts/agent-roadmap-quality-metrics.sh
+++ b/scripts/agent-roadmap-quality-metrics.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DAYS=30
+PR_LIMIT=200
+RUN_LIMIT=500
+REPO=""
+JSON_OUTPUT=""
+MARKDOWN_OUTPUT=""
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/agent-roadmap-quality-metrics.sh [options]
+
+Collect quality metrics for merged PRs labeled `agent-roadmap`.
+
+Options:
+  --days <n>              Time window in days (default: 30)
+  --pr-limit <n>          Max closed PRs fetched (default: 200)
+  --run-limit <n>         Max CI workflow runs fetched (default: 500)
+  --repo <owner/name>     GitHub repository (default: current gh repo)
+  --json-output <path>    Write full JSON report to file
+  --markdown-output <path> Write markdown summary to file
+  -h, --help              Show this help message
+USAGE
+}
+
+while (($# > 0)); do
+  case "$1" in
+    --days)
+      DAYS="$2"
+      shift 2
+      ;;
+    --pr-limit)
+      PR_LIMIT="$2"
+      shift 2
+      ;;
+    --run-limit)
+      RUN_LIMIT="$2"
+      shift 2
+      ;;
+    --repo)
+      REPO="$2"
+      shift 2
+      ;;
+    --json-output)
+      JSON_OUTPUT="$2"
+      shift 2
+      ;;
+    --markdown-output)
+      MARKDOWN_OUTPUT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! [[ "$DAYS" =~ ^[0-9]+$ ]] || [ "$DAYS" -lt 1 ]; then
+  echo "--days must be a positive integer" >&2
+  exit 1
+fi
+if ! [[ "$PR_LIMIT" =~ ^[0-9]+$ ]] || [ "$PR_LIMIT" -lt 1 ]; then
+  echo "--pr-limit must be a positive integer" >&2
+  exit 1
+fi
+if ! [[ "$RUN_LIMIT" =~ ^[0-9]+$ ]] || [ "$RUN_LIMIT" -lt 1 ]; then
+  echo "--run-limit must be a positive integer" >&2
+  exit 1
+fi
+
+for cmd in gh jq git; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Missing required command: $cmd" >&2
+    exit 1
+  fi
+done
+
+if [ -z "$REPO" ]; then
+  REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+fi
+
+compute_since_iso() {
+  local days="$1"
+  if date -u -d "-$days days" '+%Y-%m-%dT%H:%M:%SZ' >/dev/null 2>&1; then
+    date -u -d "-$days days" '+%Y-%m-%dT%H:%M:%SZ'
+    return
+  fi
+
+  if date -u -v-"$days"d '+%Y-%m-%dT%H:%M:%SZ' >/dev/null 2>&1; then
+    date -u -v-"$days"d '+%Y-%m-%dT%H:%M:%SZ'
+    return
+  fi
+
+  echo "Unable to compute since timestamp with system date command" >&2
+  exit 1
+}
+
+SINCE_ISO=$(compute_since_iso "$DAYS")
+GENERATED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+
+PRS_JSON=$(gh pr list \
+  --repo "$REPO" \
+  --state closed \
+  --label agent-roadmap \
+  --limit "$PR_LIMIT" \
+  --json number,title,state,createdAt,closedAt,mergedAt,headRefName,mergeCommit,url)
+
+MERGED_PRS_JSON=$(jq --arg since "$SINCE_ISO" '[
+  .[]
+  | select(.state == "MERGED")
+  | select(.mergedAt != null and .mergedAt >= $since)
+]' <<<"$PRS_JSON")
+
+CI_RUNS_JSON=$(gh run list \
+  --repo "$REPO" \
+  --workflow CI \
+  --event pull_request \
+  --limit "$RUN_LIMIT" \
+  --json databaseId,headBranch,createdAt,status,conclusion,attempt,url)
+
+MAIN_REF="origin/main"
+if ! git rev-parse --verify "$MAIN_REF" >/dev/null 2>&1; then
+  MAIN_REF="main"
+fi
+
+REVERTED_SHA_JSON=$(git log "$MAIN_REF" --format=%B 2>/dev/null \
+  | sed -nE 's/^This reverts commit ([0-9a-f]{40})\.?$/\1/p' \
+  | sort -u \
+  | jq -Rsc 'split("\n") | map(select(length > 0))')
+
+REPORT_JSON=$(jq -n \
+  --arg repo "$REPO" \
+  --arg generatedAt "$GENERATED_AT" \
+  --arg since "$SINCE_ISO" \
+  --argjson days "$DAYS" \
+  --argjson mergedPRs "$MERGED_PRS_JSON" \
+  --argjson ciRuns "$CI_RUNS_JSON" \
+  --argjson revertedSHAs "$REVERTED_SHA_JSON" '
+  def pct($n; $d):
+    if $d == 0 then 0 else ((($n * 10000) / $d) | round) / 100 end;
+
+  def runs_for_pr($pr):
+    $ciRuns
+    | map(
+        select(.headBranch == $pr.headRefName)
+        | select(.status == "completed")
+        | select(.createdAt >= $pr.createdAt and .createdAt <= $pr.closedAt)
+      );
+
+  ($mergedPRs
+    | map(
+        . as $pr
+        | (runs_for_pr($pr)) as $runs
+        | ($pr.mergeCommit.oid // "") as $mergeOID
+        | $pr + {
+            ci: {
+              totalRuns: ($runs | length),
+              successRuns: ($runs | map(select(.conclusion == "success")) | length),
+              failedRuns: ($runs | map(select(.conclusion != "success")) | length),
+              rerunRuns: ($runs | map(select((.attempt // 1) > 1)) | length)
+            },
+            reverted: ($mergeOID != "" and ($revertedSHAs | index($mergeOID) != null))
+          }
+      )) as $items
+  | ($items | map(.ci.totalRuns) | add // 0) as $ciTotal
+  | ($items | map(.ci.successRuns) | add // 0) as $ciSuccess
+  | ($items | map(.ci.failedRuns) | add // 0) as $ciFailed
+  | ($items | map(.ci.rerunRuns) | add // 0) as $ciRerun
+  | ($items | map(select(.reverted)) | length) as $rollbackCount
+  | {
+      repo: $repo,
+      generatedAt: $generatedAt,
+      window: {
+        days: $days,
+        since: $since
+      },
+      metricDefinition: {
+        ciPassRate: "completed CI workflow runs tied to merged agent-roadmap PRs in window",
+        rollbackRate: "merged agent-roadmap PRs whose merge commit is later reverted on main"
+      },
+      mergedPRCount: ($items | length),
+      ci: {
+        totalRuns: $ciTotal,
+        successRuns: $ciSuccess,
+        failedRuns: $ciFailed,
+        rerunRuns: $ciRerun,
+        prsWithNoCompletedRuns: ($items | map(select(.ci.totalRuns == 0)) | length),
+        prsWithFailedRuns: ($items | map(select(.ci.failedRuns > 0)) | length),
+        passRatePct: pct($ciSuccess; $ciTotal)
+      },
+      rollback: {
+        revertedPRCount: $rollbackCount,
+        ratePct: pct($rollbackCount; ($items | length))
+      },
+      prs: $items
+    }
+')
+
+if [ -n "$JSON_OUTPUT" ]; then
+  mkdir -p "$(dirname "$JSON_OUTPUT")"
+  printf '%s\n' "$REPORT_JSON" > "$JSON_OUTPUT"
+fi
+
+SUMMARY_MD=$(
+  jq -r '
+    def yn($v): if $v then "yes" else "no" end;
+
+    "# Agent Roadmap Quality Metrics\n\n" +
+    "- Repo: `" + .repo + "`\n" +
+    "- Window: last " + (.window.days|tostring) + " days (since `" + .window.since + "`)\n" +
+    "- Generated at: `" + .generatedAt + "`\n\n" +
+    "## Summary\n\n" +
+    "| Metric | Value |\n" +
+    "| --- | --- |\n" +
+    "| Merged agent-roadmap PRs | " + (.mergedPRCount|tostring) + " |\n" +
+    "| CI pass rate | " + (.ci.passRatePct|tostring) + "% (" + (.ci.successRuns|tostring) + "/" + (.ci.totalRuns|tostring) + " completed runs) |\n" +
+    "| CI rerun runs (`attempt > 1`) | " + (.ci.rerunRuns|tostring) + " |\n" +
+    "| PRs with failed CI runs | " + (.ci.prsWithFailedRuns|tostring) + " |\n" +
+    "| PRs with no completed CI run | " + (.ci.prsWithNoCompletedRuns|tostring) + " |\n" +
+    "| Rollback rate | " + (.rollback.ratePct|tostring) + "% (" + (.rollback.revertedPRCount|tostring) + "/" + (.mergedPRCount|tostring) + " merged PRs) |\n\n" +
+    "## Definitions\n\n" +
+    "- CI pass rate: " + .metricDefinition.ciPassRate + ".\n" +
+    "- Rollback rate: " + .metricDefinition.rollbackRate + ".\n\n" +
+    "## PR Breakdown\n\n" +
+    "| PR | CI success/total | Rerun runs | Reverted |\n" +
+    "| --- | --- | --- | --- |\n" +
+    (
+      if (.prs | length) == 0 then
+        "| (none) | 0/0 | 0 | no |\n"
+      else
+        (.prs
+          | sort_by(.number)
+          | reverse
+          | map(
+              "| [#" + (.number|tostring) + "](" + .url + ") | " +
+              (.ci.successRuns|tostring) + "/" + (.ci.totalRuns|tostring) + " | " +
+              (.ci.rerunRuns|tostring) + " | " + yn(.reverted) + " |"
+            )
+          | join("\n")
+        ) + "\n"
+      end
+    )
+  ' <<<"$REPORT_JSON"
+)
+
+if [ -n "$MARKDOWN_OUTPUT" ]; then
+  mkdir -p "$(dirname "$MARKDOWN_OUTPUT")"
+  printf '%s\n' "$SUMMARY_MD" > "$MARKDOWN_OUTPUT"
+fi
+
+printf '%s\n' "$SUMMARY_MD"


### PR DESCRIPTION
## Summary
- deliver M4.8 (TR-F022) with a reusable quality-metrics script for auto-delegation output
- add `scripts/agent-roadmap-quality-metrics.sh` to compute CI pass rate and rollback rate for merged `agent-roadmap` PRs
- document metric definitions and usage in `.agents/README.md`

## Milestone / Feature Mapping
- Milestone subtask: `M4.8`
- Feature IDs: `TR-F022`

## Non-goals / Boundaries
- no product runtime behavior changes
- no CI workflow mutation; this round only delivers a local/automation metric collector and documentation

## Verification
- `scripts/agent-roadmap-quality-metrics.sh --days 30 --json-output /tmp/agent-roadmap-quality.json --markdown-output /tmp/agent-roadmap-quality.md`
- `go build ./...`
- `go test ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`

## Risks / Rollback
- risk is low and limited to script/reporting logic
- rollback by reverting this PR if metric definition needs adjustment
