### PR TITLE
docs(handbook): migrate SECURITY.md into bilingual chapter (M13.2 batch 1)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,19 +1,12 @@
 # Security Policy
 
-## Security Advisories
+The ToughRADIUS security policy and security advisories now live in the
+bilingual handbook (`docs-site/`), which is version-controlled and validated by
+CI together with the code. This file keeps a short pointer so there is a single
+source of truth:
 
-### XSS Vulnerability Fix (v8.0.8)
+- **English** — [Security Policy](docs-site/src/en/security-policy.md)
+- **中文** — [安全策略](docs-site/src/zh/security-policy.md)
 
-We have released a new version (v8.0.8) that addresses a critical security vulnerability related to cross-site scripting (XSS). The issue was found in the `errmsg` parameter handling in the login endpoint.
-
-| Item                   | Details                             |
-| ---------------------- | ----------------------------------- |
-| **Vulnerability Type** | Cross-Site Scripting (XSS)          |
-| **Severity**           | Critical                            |
-| **Affected Versions**  | v8.0.1 ~ v8.0.7                     |
-| **Fixed Version**      | v8.0.8                              |
-| **Affected Component** | Login endpoint (`errmsg` parameter) |
-
-#### Recommended Actions
-
-We strongly recommend all users to update to the latest version immediately. You can update your project by following the instructions in our documentation.
+Please refer to those chapters for the current security advisories and the
+recommended update actions.

--- a/docs-site/src/SUMMARY.md
+++ b/docs-site/src/SUMMARY.md
@@ -5,11 +5,13 @@
 # English
 
 - [Overview](./en/overview.md)
+- [Security Policy](./en/security-policy.md)
 - [Documentation Map](./en/documentation-map.md)
 - [mdbook & GitBook Coexistence](./en/gitbook-coexistence.md)
 
 # 中文
 
 - [概述](./zh/overview.md)
+- [安全策略](./zh/security-policy.md)
 - [文档地图](./zh/documentation-map.md)
 - [mdbook 与 GitBook 并存](./zh/gitbook-coexistence.md)

--- a/docs-site/src/en/documentation-map.md
+++ b/docs-site/src/en/documentation-map.md
@@ -10,7 +10,7 @@ lives in the repository so everything is reachable from a single place.
 | ------------------- | ----------------------------------------------------- | ---------------- |
 | README              | Project introduction, features, and quick start       | [README.md](https://github.com/talkincode/toughradius/blob/main/README.md) |
 | Agent guide         | AI-agent development guide and working rules           | [AGENT.md](https://github.com/talkincode/toughradius/blob/main/AGENT.md) |
-| Security policy     | Supported versions and vulnerability reporting         | [SECURITY.md](https://github.com/talkincode/toughradius/blob/main/SECURITY.md) |
+| Security policy     | Security advisories and update guidance                | [Security Policy](./security-policy.md) (canonical) · [SECURITY.md](https://github.com/talkincode/toughradius/blob/main/SECURITY.md) (pointer) |
 | Feature checklist   | Feature scope baseline (`TR-F` IDs)                    | [docs/feature-checklist.md](https://github.com/talkincode/toughradius/blob/main/docs/feature-checklist.md) · [English](https://github.com/talkincode/toughradius/blob/main/docs/feature-checklist.en.md) |
 | Roadmap             | Long-term roadmap and milestones                       | [docs/roadmap.md](https://github.com/talkincode/toughradius/blob/main/docs/roadmap.md) |
 | RFC index           | Protocol standards index used by the project           | [docs/rfcs/README.md](https://github.com/talkincode/toughradius/blob/main/docs/rfcs/README.md) |

--- a/docs-site/src/en/security-policy.md
+++ b/docs-site/src/en/security-policy.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+> 中文版本：[安全策略](../zh/security-policy.md)
+
+This chapter is the canonical home for ToughRADIUS security advisories and the
+guidance that goes with them. The repository's
+[`SECURITY.md`](https://github.com/talkincode/toughradius/blob/main/SECURITY.md)
+keeps a short pointer back to this chapter so there is a single source of truth.
+
+## Security advisories
+
+### XSS vulnerability fix (v8.0.8)
+
+Version **v8.0.8** addresses a critical cross-site scripting (XSS) vulnerability.
+The issue was found in the `errmsg` parameter handling in the login endpoint.
+
+| Item               | Details                             |
+| ------------------ | ----------------------------------- |
+| Vulnerability type | Cross-Site Scripting (XSS)          |
+| Severity           | Critical                            |
+| Affected versions  | v8.0.1 – v8.0.7                     |
+| Fixed version      | v8.0.8                              |
+| Affected component | Login endpoint (`errmsg` parameter) |
+
+#### Recommended actions
+
+We strongly recommend that all users update to the latest version immediately.
+See the [Documentation Map](./documentation-map.md) for the README and build
+instructions you can follow to upgrade your deployment.

--- a/docs-site/src/zh/documentation-map.md
+++ b/docs-site/src/zh/documentation-map.md
@@ -9,7 +9,7 @@
 | ----------------- | ------------------------------------------ | -------- |
 | README            | 项目介绍、特性与快速上手                    | [README.md](https://github.com/talkincode/toughradius/blob/main/README.md) |
 | Agent 指南        | AI Agent 开发指南与协作规则                 | [AGENT.md](https://github.com/talkincode/toughradius/blob/main/AGENT.md) |
-| 安全策略          | 受支持版本与漏洞上报流程                     | [SECURITY.md](https://github.com/talkincode/toughradius/blob/main/SECURITY.md) |
+| 安全策略          | 安全公告与升级指引                          | [安全策略](./security-policy.md)（权威） · [SECURITY.md](https://github.com/talkincode/toughradius/blob/main/SECURITY.md)（指针） |
 | 功能清单          | 功能范围基线（`TR-F` 编号）                 | [docs/feature-checklist.md](https://github.com/talkincode/toughradius/blob/main/docs/feature-checklist.md) · [English](https://github.com/talkincode/toughradius/blob/main/docs/feature-checklist.en.md) |
 | 路线图            | 长期路线图与里程碑                          | [docs/roadmap.md](https://github.com/talkincode/toughradius/blob/main/docs/roadmap.md) |
 | RFC 索引          | 项目使用的协议标准索引                       | [docs/rfcs/README.md](https://github.com/talkincode/toughradius/blob/main/docs/rfcs/README.md) |

--- a/docs-site/src/zh/security-policy.md
+++ b/docs-site/src/zh/security-policy.md
@@ -1,0 +1,27 @@
+# 安全策略
+
+> English version: [Security Policy](../en/security-policy.md)
+
+本章是 ToughRADIUS 安全公告及其配套指引的权威归处。仓库根目录的
+[`SECURITY.md`](https://github.com/talkincode/toughradius/blob/main/SECURITY.md)
+保留一个指向本章的简短指针，以保证单一事实来源。
+
+## 安全公告
+
+### XSS 漏洞修复（v8.0.8）
+
+**v8.0.8** 版本修复了一个严重的跨站脚本（XSS）漏洞。该问题位于登录接口对
+`errmsg` 参数的处理。
+
+| 项目     | 详情                          |
+| -------- | ----------------------------- |
+| 漏洞类型 | 跨站脚本（XSS）               |
+| 严重程度 | 严重                          |
+| 影响版本 | v8.0.1 – v8.0.7              |
+| 修复版本 | v8.0.8                        |
+| 受影响组件 | 登录接口（`errmsg` 参数）    |
+
+#### 建议措施
+
+强烈建议所有用户立即升级到最新版本。可参考[文档地图](./documentation-map.md)
+中的 README 与构建说明完成部署升级。

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -273,7 +273,7 @@
 子任务：
 - [x] M13.0 评估与现有 GitBook 发布的关系（替代 / 并存），确定单一事实来源与发布管线边界 —— 决策：**并存**。mdbook 为随仓库维护、CI 校验的双语权威手册（置于独立目录 `docs-site/`）；GitBook 经其 GitHub 集成在外部同步（仓库无 `.gitbook.yaml`/`book.json`/GitBook `SUMMARY.md`），两套管线不共享构建步骤、互不冲突；迁移采用「迁入手册 + 原文件留指针」保证单一事实来源。决策已写入站点章节 `gitbook-coexistence`。
 - [x] M13.1 mdbook 骨架：`book.toml` + `src/`（zh / en 双语目录）+ 本地构建（`mdbook build`）—— `docs-site/book.toml`（仅 `[output.html]`，扁平输出 `docs-site/book/`）+ `src/SUMMARY.md`（English 与 中文 两个 part，章节一一对应）+ `src/{en,zh}/{overview,documentation-map,gitbook-coexistence}.md` + 双语 `introduction.md`。本地 `mdbook build docs-site` 通过。**注意**：mdbook 0.5.3 不支持原生 `[language.*]` 多语言（"unknown field language"），故采用「单 book + 两 part」结构实现双语。
-- [ ] M13.2 迁移核心文档（README / AGENT / SECURITY）为双语章节，原文件保留指向站点的入口
+- [ ] M13.2 迁移核心文档（README / AGENT / SECURITY）为双语章节，原文件保留指向站点的入口<br/>进行中（分批迁移）：批次 1 已迁移 `SECURITY.md` —— 新增双语章节 `docs-site/src/{en,zh}/security-policy.md`（忠实呈现 v8.0.8 XSS 公告与升级建议、互为中英文交叉链接），登记进 `SUMMARY.md`（置于 Overview/概述 之后），并更新 `documentation-map` 的安全策略条目指向手册章节（标注「权威/指针」）；按 M13.0「迁入手册 + 原文件留指针」决策，将根目录 `SECURITY.md` 收敛为指向双语章节的简短指针。门禁：`mdbook build docs-site` 通过、lychee `--offline` 离线坏链校验 0 错误。余 `README`（与既有 `overview` 章节有重叠）、`AGENT`（1271 行且被 agent 护栏引用，需谨慎，避免指针化破坏工具链引用）待后续批次。
 - [ ] M13.3 收编功能清单 / 路线图 / RFC 索引为站点章节，建立中英文交叉链接
 - [x] M13.4 CI 增加 `mdbook build` 产物校验（构建失败或坏链即红）—— `.github/workflows/ci.yml` 新增独立 `docs` 任务：`peaceiris/actions-mdbook`（钉 0.5.3 与本地一致）→ `mdbook build docs-site` → `lychee --offline`（经 `taiki-e/install-action` 安装）对生成 HTML 做离线坏链校验。构建失败或内部坏链均使流水线变红；`--offline` 跳过 http(s) 链接避免网络抖动。**注意**：未用 `mdbook-linkcheck`（0.7.7 与 mdbook 0.5.3 的 RenderContext 不兼容，"missing field sections"），改用 lychee（与渲染协议解耦）。
 - [ ] M13.5 （可选）GitHub Pages 部署工作流


### PR DESCRIPTION
## What & why

**M13.2 batch 1** (bilingual docs-site migration, `TR-F023`) — migrate **`SECURITY.md`** into a bilingual handbook chapter, leaving the original file as a short pointer per the **M13.0** single-source-of-truth decision (迁入手册 + 原文件留指针).

This is the user's flagship documentation deliverable. M13.2 is migrated in batches (sanctioned by the milestone's "先骨架与导航，再分批迁移" boundary). `SECURITY.md` (19 lines, self-contained) is the cleanest first target; `README` (overlaps the existing `overview` chapter) and `AGENT.md` (1271 lines, referenced by the agent guardrails) are deferred to later batches where they need careful handling.

## Changes

- **New bilingual chapter**: `docs-site/src/en/security-policy.md` + `docs-site/src/zh/security-policy.md` — faithfully render the v8.0.8 XSS advisory (vulnerability table + recommended actions), cross-linked EN↔中文 in the established chapter style.
- **`docs-site/src/SUMMARY.md`** — register the chapter under both language parts (after Overview / 概述).
- **`docs-site/src/{en,zh}/documentation-map.md`** — repoint the Security-policy row to the handbook chapter (labelled canonical) with `SECURITY.md` noted as the pointer.
- **`SECURITY.md`** — reduced to a short bilingual pointer to the handbook chapters (content now lives canonically in the handbook; no information lost — the EN chapter preserves the advisory verbatim).
- **`docs/roadmap.md`** — annotate M13.2 with batch-1 progress (kept `[ ]`; README/AGENT remain).

No code changes; documentation only.

## Quality gates

- `mdbook build docs-site` → OK; `docs-site/book/en/security-policy.html` and `…/zh/…` generated.
- `lychee --offline --root-dir "$PWD/docs-site/book" 'docs-site/book/**/*.html'` → **0 errors** (302 OK, 56 excluded http(s)) — the CI `docs` gate passes; all EN↔中文 and documentation-map cross-links resolve.
- Build output `docs-site/book/` remains gitignored.

Refs: `TR-F023`, roadmap **M13.2** (batch 1).
