### PR TITLE
docs(gitbook): add .gitbook.yaml + dual-compatible SUMMARY for a friendly GitBook site

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -1,0 +1,14 @@
+# GitBook configuration.
+#
+# GitBook and mdBook render the SAME bilingual sources under docs-site/src/:
+# mdBook is driven by docs-site/book.toml, GitBook by this file. Both read the
+# shared docs-site/src/SUMMARY.md, so the handbook is a single source of truth
+# and the two published sites cannot drift apart.
+#
+# `root` points GitBook at the handbook sources; `structure` paths below are
+# resolved relative to that root.
+root: ./docs-site/src/
+
+structure:
+  readme: introduction.md
+  summary: SUMMARY.md

--- a/docs-site/src/SUMMARY.md
+++ b/docs-site/src/SUMMARY.md
@@ -2,18 +2,13 @@
 
 [Introduction / 引言](./introduction.md)
 
-# English
-
-- [Overview](./en/overview.md)
-- [Security Policy](./en/security-policy.md)
-- [Documentation Map](./en/documentation-map.md)
-- [Protocol & RFC Reference](./en/rfc-index.md)
-- [mdbook & GitBook Coexistence](./en/gitbook-coexistence.md)
-
-# 中文
-
-- [概述](./zh/overview.md)
-- [安全策略](./zh/security-policy.md)
-- [文档地图](./zh/documentation-map.md)
-- [协议与 RFC 索引](./zh/rfc-index.md)
-- [mdbook 与 GitBook 并存](./zh/gitbook-coexistence.md)
+- [English](./en/overview.md)
+  - [Security Policy](./en/security-policy.md)
+  - [Documentation Map](./en/documentation-map.md)
+  - [Protocol & RFC Reference](./en/rfc-index.md)
+  - [mdbook & GitBook Coexistence](./en/gitbook-coexistence.md)
+- [中文](./zh/overview.md)
+  - [安全策略](./zh/security-policy.md)
+  - [文档地图](./zh/documentation-map.md)
+  - [协议与 RFC 索引](./zh/rfc-index.md)
+  - [mdbook 与 GitBook 并存](./zh/gitbook-coexistence.md)

--- a/docs-site/src/en/gitbook-coexistence.md
+++ b/docs-site/src/en/gitbook-coexistence.md
@@ -17,12 +17,16 @@ GitBook site. The two pipelines are kept separate and non-conflicting:
   It is the canonical, version-controlled, review-gated home for documentation
   that must evolve together with the code.
 - **GitBook site** — synchronizes from the repository through GitBook's own GitHub
-  integration (an external service). There is **no GitBook configuration committed
-  to this repository** (`.gitbook.yaml`, `book.json`, and a GitBook `SUMMARY.md`
-  are all absent), so adding `docs-site/` does not change how GitBook builds.
+  integration (an external service). It is configured by a committed
+  **`.gitbook.yaml`** at the repository root, which points GitBook at the same
+  `docs-site/src/` sources, uses `introduction.md` as the landing page, and reads
+  the **shared `SUMMARY.md`** as its table of contents. GitBook therefore renders
+  the curated bilingual handbook instead of inferring a tree from the whole repo.
 
-Because the mdBook sources are confined to `docs-site/` and GitBook is configured
-externally, the two systems do not share a build step and cannot break each other.
+Both pipelines build from the **same** `docs-site/src/` sources, but each keeps its
+own independent configuration (`book.toml` for mdBook, `.gitbook.yaml` for GitBook).
+They do not share a build step and cannot break each other, yet they never drift
+because they read the same chapters and the same `SUMMARY.md`.
 
 ## Where each site is served
 
@@ -40,9 +44,22 @@ The two pipelines publish to **separate** domains, so they never shadow each oth
 ## Single source of truth
 
 To avoid content drift between the two pipelines, every document has exactly one
-canonical home. As scattered documents are migrated into the handbook
+canonical home. Because mdBook and GitBook now read the **same** `docs-site/src/`
+chapters and the same `SUMMARY.md`, the handbook sources are the single source for
+both rendered sites. As scattered documents are migrated into the handbook
 (roadmap items M13.2 / M13.3), the original file keeps a short pointer back to the
 corresponding chapter instead of duplicating its content.
+
+## Editing the shared table of contents
+
+`docs-site/src/SUMMARY.md` is read by **both** tools, so keep it to the subset of
+Markdown that they parse the same way: a top `# Summary` title, a non-bulleted
+`[Introduction / 引言](./introduction.md)` landing link, and **nested bullet lists**
+for grouping. The two language sections are expressed as top-level entries
+(`- [English](./en/overview.md)` and `- [中文](./zh/overview.md)`) with their pages
+nested beneath them. Avoid `#` / `##` part headers for grouping: mdBook only groups
+on `#` while GitBook only groups on `##`, so a nested list is the one form that both
+render identically.
 
 ## Build and validation
 

--- a/docs-site/src/zh/gitbook-coexistence.md
+++ b/docs-site/src/zh/gitbook-coexistence.md
@@ -14,12 +14,14 @@ mdBook 手册与 GitBook **并存**，不替代、也不停用 GitBook 站点。
 - **mdBook 手册** —— 位于仓库的 `docs-site/` 目录，以双语章节编写，并在每个 Pull
   Request 上由 CI 构建与坏链校验。它是需要与代码同步演进的文档的权威来源：受版本
   控制、走评审门禁。
-- **GitBook 站点** —— 通过 GitBook 自有的 GitHub 集成（外部服务）从仓库同步。
-  仓库中**没有提交任何 GitBook 配置**（`.gitbook.yaml`、`book.json` 以及 GitBook
-  的 `SUMMARY.md` 均不存在），因此新增 `docs-site/` 不会改变 GitBook 的构建方式。
+- **GitBook 站点** —— 通过 GitBook 自有的 GitHub 集成（外部服务）从仓库同步。它由仓库
+  根目录提交的 **`.gitbook.yaml`** 配置：将 GitBook 指向同一份 `docs-site/src/` 源文件，
+  以 `introduction.md` 作为首页，并读取**共享的 `SUMMARY.md`** 作为目录。因此 GitBook
+  渲染的是经过整理的双语手册，而不是从整个仓库推断出的目录树。
 
-由于 mdBook 源文件被限制在 `docs-site/` 内，而 GitBook 在外部配置，两套系统不共享
-构建步骤，也不会相互破坏。
+两套管线都从**同一份** `docs-site/src/` 源文件构建，但各自保留独立配置（mdBook 用
+`book.toml`，GitBook 用 `.gitbook.yaml`）。它们不共享构建步骤、不会相互破坏；同时由于
+读取相同的章节与同一个 `SUMMARY.md`，也不会发生内容漂移。
 
 ## 各站点的对外地址
 
@@ -35,9 +37,19 @@ mdBook 手册与 GitBook **并存**，不替代、也不停用 GitBook 站点。
 
 ## 单一事实来源
 
-为避免两套管线之间出现内容漂移，每份文档只有唯一的权威位置。随着散落文档逐步迁入
-手册（路线图条目 M13.2 / M13.3），原始文件会保留一个指向对应章节的简短入口，而不是
-复制其内容。
+为避免两套管线之间出现内容漂移，每份文档只有唯一的权威位置。由于 mdBook 与 GitBook
+现在读取**同一份** `docs-site/src/` 章节与同一个 `SUMMARY.md`，手册源文件即是两个渲染
+站点的单一事实来源。随着散落文档逐步迁入手册（路线图条目 M13.2 / M13.3），原始文件会
+保留一个指向对应章节的简短入口，而不是复制其内容。
+
+## 编辑共享目录
+
+`docs-site/src/SUMMARY.md` 会被**两个**工具同时读取，因此只能使用两者解析方式一致的
+Markdown 子集：顶部的 `# Summary` 标题、一个非列表项的首页链接
+`[Introduction / 引言](./introduction.md)`，以及用于分组的**嵌套列表**。两个语言分区
+表示为顶层条目（`- [English](./en/overview.md)` 与 `- [中文](./zh/overview.md)`），其余
+页面嵌套其下。请避免使用 `#` / `##` 标题来分组：mdBook 只按 `#` 分组，而 GitBook 只按
+`##` 分组，因此嵌套列表是两者渲染方式完全一致的唯一形式。
 
 ## 构建与校验
 


### PR DESCRIPTION
## What & why

The GitBook site had **no committed configuration**, so GitBook inferred its table of
contents from the *entire repository* tree (showing `AGENT.md`, raw RFC `.txt` files,
etc.) — unfriendly and noisy. This PR makes GitBook render the same curated bilingual
handbook that mdBook publishes, from a single shared source.

User request: *定义 `.gitbook.yaml` 和 SUMMARY，让 GitBook 文档更友好.*

## Changes

- **Add `/.gitbook.yaml`** (repo root):
  - `root: ./docs-site/src/` — GitBook reads the handbook sources (clean URLs like
    `/en/overview`), not the whole repo.
  - `structure.readme: introduction.md` — the bilingual welcome page is the landing.
  - `structure.summary: SUMMARY.md` — GitBook uses the **same** TOC file as mdBook.
- **Convert `docs-site/src/SUMMARY.md`** from `#` part headers to a **nested list**:
  `English` / `中文` are top-level entries (linking to each language's overview) with
  their pages nested beneath. mdBook groups only on `#`, GitBook only on `##`, so a
  nested list is the **one form both render identically** — keeping a single source
  of truth with no second TOC to drift.
- **Update `gitbook-coexistence.md` (en + zh)**: it previously stated "no GitBook
  configuration is committed"; now it documents the committed `.gitbook.yaml`, the
  shared-source model, and a "do not use `#`/`##` part headers" editing constraint.

## Result

| Site | Before | After |
| --- | --- | --- |
| GitBook | infers TOC from whole repo (AGENT.md, RFC `.txt`, …) | curated bilingual handbook only |
| mdBook | `#` part dividers, flat lists | clean numbered tree (`1. English` → overview, `1.1 …`) |

Both pipelines now build from the same `docs-site/src/` chapters + `SUMMARY.md`.

## Validation

- `.gitbook.yaml` parses as valid YAML.
- `mdbook build docs-site` — green; nested SUMMARY renders as a numbered tree (verified
  in the generated `toc-*.js`).
- `lychee --offline` over the built HTML — **0 errors** (152 unique links).

## Scope / notes

- Docs/config only — no Go or frontend code touched; CI docs gate unaffected.
- Roadmap: **M13** (handbook) docs polish; relates to **TR-F023** (docs capability).
- The GitBook *space* must sync `main` for this config to take effect; that is a
  GitBook-side setting outside the repo. No DNS/domain changes here (the Pages vs.
  GitBook domain split documented in the coexistence chapter is unchanged).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
