### PR TITLE
docs(adminapi): M4.12 batch6 user payload godoc backfill

### DIFF
--- a/internal/adminapi/users.go
+++ b/internal/adminapi/users.go
@@ -38,7 +38,13 @@ func escapeUserLikePattern(s string) string {
 	return s
 }
 
-// UserRequest Used to handle user data sent from frontend
+// UserRequest represents the request body for creating a RADIUS user via
+// POST /api/v1/users.
+//
+// It preserves compatibility with older clients that still send legacy keys
+// such as profileid, or mixed JSON types for flags (for example bool vs number
+// for bind_mac/bind_vlan and status). The handler normalizes those variants
+// before persisting the user.
 type UserRequest struct {
 	NodeID          interface{} `json:"node_id"`                                     // Can be int64 or string
 	ProfileID       interface{} `json:"profile_id" validate:"required"`              // Can be int64 or string
@@ -138,7 +144,12 @@ func (ur *UserRequest) toRadiusUser() *domain.RadiusUser {
 	return user
 }
 
-// UserUpdateRequest Used to handle user update data
+// UserUpdateRequest represents the request body for updating a RADIUS user via
+// PUT /api/v1/users/:id.
+//
+// Most fields are optional and are applied as partial updates. As with
+// UserRequest, legacy and mixed-type frontend payloads are accepted and
+// normalized so older admin clients remain compatible.
 type UserUpdateRequest struct {
 	NodeID                  interface{} `json:"node_id"`                                                 // Can be int64 or string
 	ProfileID               interface{} `json:"profile_id"`                                              // Can be int64 or string

--- a/internal/adminapi/users_import.go
+++ b/internal/adminapi/users_import.go
@@ -13,14 +13,20 @@ import (
 	"github.com/talkincode/toughradius/v9/pkg/common"
 )
 
-// ImportUserError describes a single row failure during batch import.
+// ImportUserError describes one failed input row during a batch user import.
+//
+// Row is 1-based within the parsed payload and Username may be empty when the
+// failure occurs before a username can be resolved (for example missing column).
 type ImportUserError struct {
 	Row      int    `json:"row"`
 	Username string `json:"username"`
 	Message  string `json:"message"`
 }
 
-// ImportUserResult summarizes the outcome of a batch user import.
+// ImportUserResult summarizes the outcome of a batch user import request.
+//
+// Success and Failed are per-row counts and Errors carries only failed rows so
+// callers can present actionable feedback without re-reading the source file.
 type ImportUserResult struct {
 	Total   int               `json:"total"`
 	Success int               `json:"success"`


### PR DESCRIPTION
## Summary
- milestone: `M4.12` (batch 6)
- feature id: `TR-F024`
- backfilled standard-library-style godoc for exported admin API payload/result types:
  - `UserRequest`, `UserUpdateRequest` in `internal/adminapi/users.go`
  - `ImportUserError`, `ImportUserResult` in `internal/adminapi/users_import.go`
- clarified compatibility contracts for legacy/mixed-type frontend payloads and import row-level error semantics

## Scope Boundary
- no runtime behavior changes
- no protocol changes, no schema changes
- no `TR-N001`~`TR-N005` non-goal expansion

## Quality Gates
- `go build ./...`
- `go test ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`
