### PR TITLE
chore(M4.12): enforce exported godoc lint checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,13 +32,11 @@ linters:
     staticcheck:
       checks:
         - all
-        - "-ST1000" # Disable package comment requirement
+        - "-ST1000" # Keep package-comment check deferred; baseline debt is repo-wide.
         - "-ST1003" # Disable naming convention (Id vs ID, etc)
         - "-ST1005" # Disable error string format check
         - "-ST1006" # Disable receiver name style check
         - "-ST1016" # Disable receiver name consistency check
-        - "-ST1020" # Disable function comment format check
-        - "-ST1021" # Disable type comment format check
 
     gosec:
       excludes:

--- a/internal/domain/radius.go
+++ b/internal/domain/radius.go
@@ -84,8 +84,7 @@ func (RadiusUser) TableName() string {
 	return "radius_user"
 }
 
-// RadiusOnline
-// Radius RadiusOnline Recode
+// RadiusOnline stores active online session state tracked from accounting packets.
 type RadiusOnline struct {
 	ID                  int64     `json:"id,string"` // Primary key ID
 	Username            string    `gorm:"index" json:"username"`
@@ -149,8 +148,7 @@ func (RadiusSessionActionAudit) TableName() string {
 	return "radius_session_action_audit"
 }
 
-// RadiusAccounting
-// Radius Accounting Recode
+// RadiusAccounting stores finalized accounting records for session history.
 type RadiusAccounting struct {
 	ID                  int64     `json:"id,string"` // Primary key ID
 	Username            string    `gorm:"index" json:"username"`

--- a/internal/radiusd/plugins/accounting/interfaces.go
+++ b/internal/radiusd/plugins/accounting/interfaces.go
@@ -1,3 +1,4 @@
+// Package accounting defines pluggable accounting handlers and shared request context types.
 package accounting
 
 import (

--- a/internal/radiusd/plugins/auth/interfaces.go
+++ b/internal/radiusd/plugins/auth/interfaces.go
@@ -1,3 +1,4 @@
+// Package auth defines authentication pipeline interfaces and shared context types.
 package auth
 
 import (

--- a/internal/radiusd/plugins/eap/utils.go
+++ b/internal/radiusd/plugins/eap/utils.go
@@ -33,7 +33,7 @@ func ParseEAPMessage(packet *radius.Packet) (*EAPMessage, error) {
 	return eap, nil
 }
 
-// EncodeEAPMessage encodes an EAP message into bytes
+// Encode serializes an EAP message into wire-format bytes.
 func (msg *EAPMessage) Encode() []byte {
 	length := 5 // Code, Identifier, Length, and Type fields occupy 5 bytes
 	var data []byte

--- a/internal/radiusd/plugins/vendorparsers/interfaces.go
+++ b/internal/radiusd/plugins/vendorparsers/interfaces.go
@@ -1,3 +1,4 @@
+// Package vendorparsers defines vendor-specific request/response extension points.
 package vendorparsers
 
 import (

--- a/internal/radiusd/radius.go
+++ b/internal/radiusd/radius.go
@@ -61,11 +61,11 @@ type AuthRateUser struct {
 }
 
 type RadiusService struct {
-	appCtx        app.AppContext // Use interface instead of concrete type
-	authRate      *authRateLimiter
-	TaskPool      *ants.Pool
-	nasCache      *cachepkg.TTLCache[*domain.NetNas]
-	userCache     *cachepkg.TTLCache[*domain.RadiusUser]
+	appCtx    app.AppContext // Use interface instead of concrete type
+	authRate  *authRateLimiter
+	TaskPool  *ants.Pool
+	nasCache  *cachepkg.TTLCache[*domain.NetNas]
+	userCache *cachepkg.TTLCache[*domain.RadiusUser]
 
 	// New Repository Layer (v9 refactoring)
 	UserRepo       repository.UserRepository
@@ -90,11 +90,11 @@ func NewRadiusService(appCtx app.AppContext) *RadiusService {
 	// Initialize all repositories using injected context
 	db := appCtx.DB()
 	s := &RadiusService{
-		appCtx:        appCtx,
-		authRate:      newAuthRateLimiter(defaultAuthRateShards),
-		TaskPool:      pool,
-		nasCache:      cachepkg.NewTTLCache[*domain.NetNas](time.Minute, 512),
-		userCache:     cachepkg.NewTTLCache[*domain.RadiusUser](10*time.Second, 2048),
+		appCtx:    appCtx,
+		authRate:  newAuthRateLimiter(defaultAuthRateShards),
+		TaskPool:  pool,
+		nasCache:  cachepkg.NewTTLCache[*domain.NetNas](time.Minute, 512),
+		userCache: cachepkg.NewTTLCache[*domain.RadiusUser](10*time.Second, 2048),
 		// Initialize repository layer
 		UserRepo:       repogorm.NewGormUserRepository(db),
 		SessionRepo:    repogorm.NewGormSessionRepository(db),
@@ -252,9 +252,9 @@ func GetNetRadiusOnlineFromRequest(r *radius.Request, vr *VendorRequest, nas *do
 
 }
 
-// CheckAuthRateLimit
-// Authentication frequency detection, each user can only authenticate once every few seconds.
-// Backed by a sharded limiter so different users do not contend on a single global lock.
+// CheckAuthRateLimit enforces per-username authentication frequency limits.
+// Each username may authenticate only once every configured interval, backed by
+// a sharded limiter so different users do not contend on a single global lock.
 func (s *RadiusService) CheckAuthRateLimit(username string) error {
 	return s.authRate.check(username, time.Duration(RadiusAuthRateInterval)*time.Second)
 }

--- a/internal/radiusd/radius_acct.go
+++ b/internal/radiusd/radius_acct.go
@@ -13,7 +13,7 @@ import (
 	"layeh.com/radius/rfc2866"
 )
 
-// Accounting service
+// AcctService handles RADIUS Accounting-Request packets.
 type AcctService struct {
 	*RadiusService
 }

--- a/internal/radiusd/repository/gorm/accounting_repository.go
+++ b/internal/radiusd/repository/gorm/accounting_repository.go
@@ -1,3 +1,4 @@
+// Package gorm provides GORM-backed implementations of repository interfaces.
 package gorm
 
 import (

--- a/internal/radiusd/repository/interfaces.go
+++ b/internal/radiusd/repository/interfaces.go
@@ -1,3 +1,4 @@
+// Package repository defines storage interfaces used by the RADIUS pipeline.
 package repository
 
 import (

--- a/pkg/timeutil/timeutil.go
+++ b/pkg/timeutil/timeutil.go
@@ -61,32 +61,32 @@ func (t LocalTime) MarshalCSV() (string, error) {
 	return string(b), nil
 }
 
-// yyyy-MM-dd hh:mm:ss (year-month-day hour:minute:second)
+// FmtDatetimeString formats t as "2006-01-02 15:04:05".
 func FmtDatetimeString(t time.Time) string {
 	return t.Format(YYYYMMDDHHMMSS_LAYOUT)
 }
 
-// yyyy-MM-dd hh:mm (year-month-day hour:minute)
+// FmtDatetimeMString formats t as "2006-01-02 15:04".
 func FmtDatetimeMString(t time.Time) string {
 	return t.Format(YYYYMMDDHHMM_LAYOUT)
 }
 
-// yy-MM-dd (year-month-day)
+// FmtDateString formats t as "2006-01-02".
 func FmtDateString(t time.Time) string {
 	return t.Format(YYYYMMDD_LAYOUT)
 }
 
-// yyyyMMddhhmmss (yearmonthdayhourminutesecond)
+// FmtDatetime14String formats t as "20060102150405".
 func FmtDatetime14String(t time.Time) string {
 	return t.Format(Datetime14Layout)
 }
 
-// yyyyMMdd (yearmonthday)
+// FmtDatetime8String formats t as "20060102".
 func FmtDatetime8String(t time.Time) string {
 	return t.Format(Datetime8Layout)
 }
 
-// yyyyMM (yearmonth)
+// FmtDatetime6String formats t as "200601".
 func FmtDatetime6String(t time.Time) string {
 	return t.Format(Datetime6Layout)
 }

--- a/pkg/validutil/validutil.go
+++ b/pkg/validutil/validutil.go
@@ -87,40 +87,38 @@ func isMatch(exp *regexp.Regexp, val interface{}) bool {
 	}
 }
 
-// Verify phone numbers in mainland China. The following formats are supported.
-// 0578-12345678-1234
-// 057812345678-1234
-// If an extension number exists, the extension number ligature cannot be omitted.
+// IsCnPhone reports whether val matches a mainland China landline number.
+// Supported examples include 0578-12345678-1234 and 057812345678-1234.
 func IsCnPhone(val interface{}) bool {
 	return isMatch(cnPhone, val)
 }
 
-// Verify mobile phone numbers in  China
+// IsCnMobile reports whether val matches a mainland China mobile number.
 func IsCnMobile(val interface{}) bool {
 	return isMatch(cnMobile, val)
 }
 
-// Verify that a value is in a standard URL format. Supports formats such as IP and domain name.
+// IsURL reports whether val matches the accepted URL pattern.
 func IsURL(val interface{}) bool {
 	return isMatch(url, val)
 }
 
-// Verify that a value is an IP, verifies IP4 and IP6
+// IsIP reports whether val matches either IPv4 or IPv6.
 func IsIP(val interface{}) bool {
 	return isMatch(ip, val)
 }
 
-// Verify that a value is IP6
+// IsIP6 reports whether val matches IPv6.
 func IsIP6(val interface{}) bool {
 	return isMatch(ip6, val)
 }
 
-// Verify that a value is IP4.
+// IsIP4 reports whether val matches IPv4.
 func IsIP4(val interface{}) bool {
 	return isMatch(ip4, val)
 }
 
-// Verify that a value matches a mailbox.
+// IsEmail reports whether val matches the email pattern.
 func IsEmail(val interface{}) bool {
 	return isMatch(email, val)
 }

--- a/pkg/web/web.go
+++ b/pkg/web/web.go
@@ -38,7 +38,7 @@ func (d DateRange) ParseEnd() (time.Time, error) {
 	return time.Parse("2006-01-02 15:04:05", d.End)
 }
 
-// WEB parameters
+// WebForm stores merged path/query/form parameters and helper accessors.
 type WebForm struct {
 	FormItem interface{}
 	Posts    url.Values        `json:"-" form:"-" query:"-"`
@@ -186,7 +186,7 @@ type JsonOptions struct {
 	Value string `json:"value"`
 }
 
-// Quickly read parameters to avoid repeated error handling
+// ParamReader reads typed values from WebForm and records the first parse error.
 type ParamReader struct {
 	form      *WebForm
 	LastError error

--- a/pkg/web/webix.go
+++ b/pkg/web/webix.go
@@ -1,6 +1,6 @@
 package web
 
-// Webix table column definitions
+// WebixTableColumn defines a column descriptor for Webix table configuration.
 type WebixTableColumn struct {
 	Id         string      `json:"id,omitempty"`
 	Header     interface{} `json:"header,omitempty"`

--- a/web/static.go
+++ b/web/static.go
@@ -1,3 +1,4 @@
+// Package web embeds and serves the frontend static assets.
 package web
 
 import (


### PR DESCRIPTION
# Summary

## Roadmap Mapping (Required for agent tasks)

- Milestone subtask: `M4.12`
- Feature ID(s): `TR-F024`
- Out-of-scope non-goals checked: `TR-N001` `TR-N002` `TR-N003` `TR-N004` `TR-N005`

## What Changed

- Enabled staticcheck exported-doc gates by removing `-ST1020` and `-ST1021` from [`.golangci.yml`](.golangci.yml) while keeping `-ST1000` deferred to avoid forcing repo-wide package-comment backfill in this round.
- Backfilled/comment-normalized exported identifiers that blocked ST1020/ST1021 in touched modules:
  - `internal/domain` (`RadiusOnline`, `RadiusAccounting`)
  - `internal/radiusd` (`CheckAuthRateLimit`, `AcctService`, `EAPMessage.Encode`)
  - `pkg/timeutil` and `pkg/validutil` exported helpers
  - `pkg/web` exported types (`WebForm`, `ParamReader`, `WebixTableColumn`)
- Added a few package comments in newly touched subpackages (`plugins/accounting`, `plugins/auth`, `plugins/vendorparsers`, `repository`, `repository/gorm`, `web`) to keep staticcheck output stable after the lint-ratchet change.

## Acceptance Criteria Covered

- [x] The change only covers the mapped `TR-F` scope
- [ ] Protocol behavior updates include RFC clause references in code/tests/PR description
- [ ] Protocol or E2E behavior changes include CI-runnable acceptance tests under `test/integration/`

## Verification

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`
- [ ] `cd web && npm run build` (required only when frontend files changed)

## Risks and Rollback

- Risk level: `low`
- Main risk: stricter linting may fail future PRs until exported comment format is kept consistent.
- Rollback plan: revert this commit to restore previous lint behavior (`-ST1020`/`-ST1021` disabled).

## Reviewer Notes

- Suggested review order (files/modules): `.golangci.yml` -> `internal/domain/radius.go` -> `internal/radiusd/*` -> `pkg/timeutil`/`pkg/validutil`/`pkg/web`.
- Open questions / assumptions: package-level ST1000 is intentionally deferred in this batch and should be addressed in a dedicated follow-up.
