### PR TITLE
docs(godoc): package comments for radiusd and pkg/web (M4.12 batch 8)

### DIFF
--- a/internal/radiusd/doc.go
+++ b/internal/radiusd/doc.go
@@ -1,0 +1,12 @@
+// Package radiusd implements ToughRADIUS protocol-serving pipelines.
+//
+// The package hosts the authentication, accounting, and dynamic authorization
+// (CoA/Disconnect) request stages used by UDP RADIUS and RadSec frontends. It
+// composes plugin runners, validators, checkers, and response enhancers to keep
+// protocol handling extensible while preserving stable error mapping and
+// metrics semantics.
+//
+// The package-level entry points are designed for server startup wiring, while
+// subpackages under internal/radiusd/plugins and internal/radiusd/repository
+// provide pluggable method handlers and persistence interfaces.
+package radiusd

--- a/pkg/web/doc.go
+++ b/pkg/web/doc.go
@@ -1,0 +1,7 @@
+// Package web provides HTTP-layer helpers shared by the admin web server.
+//
+// It contains composable middleware and handlers for request metrics, reverse
+// proxying, long-lived server-sent events streams, and prequery caching
+// behavior. These helpers are framework-oriented utilities and keep business
+// rules in adminapi/app packages.
+package web


### PR DESCRIPTION
# Summary

## Roadmap Mapping (Required for agent tasks)

- Milestone subtask: `M4.12`
- Feature ID(s): `TR-F024`
- Out-of-scope non-goals checked: `TR-N001` `TR-N002` `TR-N003` `TR-N004` `TR-N005`

## What Changed

- Added `internal/radiusd/doc.go` package comment describing the protocol-serving scope, extension points, and relation to plugin/repository subpackages.
- Added `pkg/web/doc.go` package comment describing HTTP helper responsibilities and boundary with business-layer packages.
- Verified targeted lint-ratchet signal with `staticcheck -checks ST1000 ./internal/radiusd ./pkg/web`.

## Acceptance Criteria Covered

- [x] The change only covers the mapped `TR-F` scope
- [x] Protocol behavior updates include RFC clause references in code/tests/PR description
- [x] Protocol or E2E behavior changes include CI-runnable acceptance tests under `test/integration/`

## Verification

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`
- [ ] `cd web && npm run build` (required only when frontend files changed)

## Risks and Rollback

- Risk level: `low`
- Main risk: Package comment wording drift from implementation responsibilities.
- Rollback plan: Revert commit `caa4a45c` to drop newly added `doc.go` files.

## Reviewer Notes

- Suggested review order (files/modules): `internal/radiusd/doc.go` -> `pkg/web/doc.go`
- Open questions / assumptions: none.
