### PR TITLE
docs(godoc): package comments for cache and utility packages (M4.12 batch 10)

### DIFF
--- a/internal/radiusd/cache/doc.go
+++ b/internal/radiusd/cache/doc.go
@@ -1,0 +1,7 @@
+// Package cache provides lightweight, concurrency-safe in-memory caches used by
+// RADIUS protocol hot paths.
+//
+// The package currently exposes a generic TTL cache that stores entries by
+// string key, evicts expired entries lazily, and bounds memory growth with a
+// configurable maximum entry count.
+package cache

--- a/pkg/excel/doc.go
+++ b/pkg/excel/doc.go
@@ -1,0 +1,7 @@
+// Package excel exports tabular structs to XLSX files for admin-side data
+// download workflows.
+//
+// It reflects exported struct fields, derives column names from db/json tags,
+// and writes rows to either a caller-provided path or a generated temporary
+// file.
+package excel

--- a/pkg/timeutil/doc.go
+++ b/pkg/timeutil/doc.go
@@ -1,0 +1,6 @@
+// Package timeutil provides shared time layouts and formatting/parsing helpers
+// used across API handlers, exports, and reporting paths.
+//
+// It centralizes ToughRADIUS date-time string conventions to keep serialized
+// timestamps consistent across JSON, CSV, and UI-facing outputs.
+package timeutil

--- a/pkg/validator/doc.go
+++ b/pkg/validator/doc.go
@@ -1,0 +1,7 @@
+// Package validator integrates go-playground/validator with Echo and normalizes
+// validation errors into a consistent API payload shape.
+//
+// The package registers project-specific tags (for example RADIUS status and
+// port constraints) and is intended for request payload validation in admin API
+// handlers.
+package validator

--- a/pkg/validutil/doc.go
+++ b/pkg/validutil/doc.go
@@ -1,0 +1,6 @@
+// Package validutil provides reusable string and format validation helpers used
+// by admin API input checks and domain-level guardrails.
+//
+// It includes pattern validators for contact/network identifiers and password
+// strength predicates shared by operator and user-management flows.
+package validutil


### PR DESCRIPTION
## Summary
- complete `M4.12` (`TR-F024`) batch 10 with package-level godoc backfill
- add standard-library-style `doc.go` comments for:
  - `internal/radiusd/cache`
  - `pkg/excel`
  - `pkg/timeutil`
  - `pkg/validator`
  - `pkg/validutil`
- verify targeted ST1000 metric for the touched packages

## Scope
- milestone: `M4.12`
- feature id: `TR-F024`
- non-goals touched: none (`TR-N001`~`TR-N005`)

## Verification
- `go build ./...`
- `go test ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`
- `go run honnef.co/go/tools/cmd/staticcheck@latest -checks ST1000 ./internal/radiusd/cache ./pkg/excel ./pkg/timeutil ./pkg/validator ./pkg/validutil`
