### PR TITLE
docs(godoc): M4.12 batch11 plugin package comments

### DIFF
--- a/internal/radiusd/plugins/accounting/handlers/doc.go
+++ b/internal/radiusd/plugins/accounting/handlers/doc.go
@@ -1,0 +1,8 @@
+// Package handlers implements accounting event handlers used by the plugin
+// runner.
+//
+// The package maps Accounting-Request packet types and NAS state transitions to
+// focused handler functions that update online-session and accounting records
+// while preserving idempotent update semantics across start, interim, stop, and
+// accounting on/off flows.
+package handlers

--- a/internal/radiusd/plugins/auth/checkers/doc.go
+++ b/internal/radiusd/plugins/auth/checkers/doc.go
@@ -1,0 +1,7 @@
+// Package checkers implements post-credential authorization checks in the
+// authentication pipeline.
+//
+// These checks enforce account status, expiration policy, concurrent-session
+// limits, and MAC/VLAN bindings after password or EAP validation succeeds, so
+// Access-Accept is only produced when policy constraints are satisfied.
+package checkers

--- a/internal/radiusd/plugins/auth/enhancers/doc.go
+++ b/internal/radiusd/plugins/auth/enhancers/doc.go
@@ -1,0 +1,8 @@
+// Package enhancers implements Access-Accept attribute enrichment for
+// successful authentications.
+//
+// Enhancers add standard and vendor-specific response attributes such as
+// bandwidth policy, address pools, VLAN hints, and interoperability fields
+// required by supported NAS vendors while keeping the core auth pipeline
+// vendor-agnostic.
+package enhancers

--- a/internal/radiusd/plugins/auth/guards/doc.go
+++ b/internal/radiusd/plugins/auth/guards/doc.go
@@ -1,0 +1,7 @@
+// Package guards provides pipeline guards that shape authentication response
+// behavior.
+//
+// Guard hooks run around Access-Reject handling to apply cross-cutting
+// controls, such as deterministic reject delays, without duplicating that logic
+// in every validator or checker.
+package guards

--- a/internal/radiusd/plugins/auth/validators/doc.go
+++ b/internal/radiusd/plugins/auth/validators/doc.go
@@ -1,0 +1,8 @@
+// Package validators implements credential validation handlers for the RADIUS
+// authentication pipeline.
+//
+// Validators process protocol-specific credential formats, including PAP, CHAP,
+// and MS-CHAP variants, and return normalized auth outcomes that upstream
+// pipeline stages can map into policy checks, metrics tags, and final RADIUS
+// responses.
+package validators


### PR DESCRIPTION
## Summary
- Milestone: M4.12 (TR-F024)
- Add package-level godoc comments for five auth/accounting plugin packages:
  - `internal/radiusd/plugins/accounting/handlers`
  - `internal/radiusd/plugins/auth/checkers`
  - `internal/radiusd/plugins/auth/enhancers`
  - `internal/radiusd/plugins/auth/guards`
  - `internal/radiusd/plugins/auth/validators`
- Keep runtime behavior unchanged (comments-only patch).

## Validation
- `go run honnef.co/go/tools/cmd/staticcheck@latest -checks ST1000 ./internal/radiusd/plugins/accounting/handlers ./internal/radiusd/plugins/auth/checkers ./internal/radiusd/plugins/auth/enhancers ./internal/radiusd/plugins/auth/guards ./internal/radiusd/plugins/auth/validators`
- `go build ./...`
- `go test ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`
