### PR TITLE
docs(godoc): M4.12 batch12 eap package comments

### DIFF
--- a/internal/radiusd/plugins/eap/doc.go
+++ b/internal/radiusd/plugins/eap/doc.go
@@ -1,0 +1,7 @@
+// Package eap provides the shared EAP authentication orchestration layer for
+// ToughRADIUS.
+//
+// It defines message/state abstractions, method handler interfaces, and the
+// coordinator that dispatches EAP rounds to registered handlers while
+// preserving per-session state across RADIUS request/response exchanges.
+package eap

--- a/internal/radiusd/plugins/eap/handlers/doc.go
+++ b/internal/radiusd/plugins/eap/handlers/doc.go
@@ -1,0 +1,7 @@
+// Package handlers implements concrete EAP method handlers used by the
+// coordinator in package eap.
+//
+// It contains classic challenge methods and TLS-based tunneled methods
+// (EAP-TLS, PEAP, EAP-TTLS), including handshake progression, fragmentation,
+// and method-specific success/failure contracts.
+package handlers

--- a/internal/radiusd/plugins/eap/statemanager/doc.go
+++ b/internal/radiusd/plugins/eap/statemanager/doc.go
@@ -1,0 +1,6 @@
+// Package statemanager provides EAP state storage implementations.
+//
+// The in-memory manager keeps per-session EAP handshake state with TTL-based
+// expiry and background cleanup so abandoned handshakes do not accumulate
+// unbounded memory.
+package statemanager

--- a/internal/radiusd/plugins/vendorparsers/parsers/doc.go
+++ b/internal/radiusd/plugins/vendorparsers/parsers/doc.go
@@ -1,0 +1,6 @@
+// Package parsers provides vendor parser implementations for the
+// vendorparsers plugin.
+//
+// It registers the default parser and vendor-specific parsers that normalize
+// incoming RADIUS request attributes into a common VendorRequest model.
+package parsers


### PR DESCRIPTION
## Summary
- M4.12 / TR-F024 增量批次 12：为以下包补齐标准库风格包级 `doc.go` 注释（comments-only，零逻辑改动）
  - `internal/radiusd/plugins/eap`
  - `internal/radiusd/plugins/eap/handlers`
  - `internal/radiusd/plugins/eap/statemanager`
  - `internal/radiusd/plugins/vendorparsers/parsers`
- 目标是继续按包推进 ST1000（包注释）债务的可回滚增量收敛。

## Milestone / Feature
- Milestone: M4.12
- Feature: TR-F024

## Non-goals / Scope boundary
- 不改运行逻辑、不改协议行为、不改接口签名。
- 不在本 PR 全局开启 ST1000，只做按包增量补齐。

## Verification
- `go run honnef.co/go/tools/cmd/staticcheck@latest -checks ST1000 ./internal/radiusd/plugins/eap/... ./internal/radiusd/plugins/vendorparsers/parsers/...`
- `go build ./...`
- `go test ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`

## Acceptance / Risk
- 仅文档注释改动，风险极低，可直接回滚。
