### PR TITLE
docs(radiusd/vendors): add VSA dictionary package comments (M4.12, TR-F024)

### DIFF
--- a/internal/radiusd/vendors/alcatel/doc.go
+++ b/internal/radiusd/vendors/alcatel/doc.go
@@ -1,0 +1,9 @@
+// Package alcatel provides the generated RADIUS dictionary of Vendor-Specific
+// Attributes (RFC 2865 §5.26) registered under SMI Network Management Private
+// Enterprise Code 3041 (the "alcatel" vendor namespace).
+//
+// The attribute value types and their _Add/_Get/_Gets/_Lookup/_Set/_Del
+// accessors are produced by radius-dict-gen and encode or decode these VSAs on a
+// radius.Packet. The generated code lives in generated.go and must not be edited
+// by hand; regenerate the dictionary instead.
+package alcatel

--- a/internal/radiusd/vendors/aruba/doc.go
+++ b/internal/radiusd/vendors/aruba/doc.go
@@ -1,0 +1,9 @@
+// Package aruba provides the generated RADIUS dictionary of Vendor-Specific
+// Attributes (RFC 2865 §5.26) registered under SMI Network Management Private
+// Enterprise Code 14823 (the "aruba" vendor namespace).
+//
+// The attribute value types and their _Add/_Get/_Gets/_Lookup/_Set/_Del
+// accessors are produced by radius-dict-gen and encode or decode these VSAs on a
+// radius.Packet. The generated code lives in generated.go and must not be edited
+// by hand; regenerate the dictionary instead.
+package aruba

--- a/internal/radiusd/vendors/cisco/doc.go
+++ b/internal/radiusd/vendors/cisco/doc.go
@@ -1,0 +1,9 @@
+// Package cisco provides the generated RADIUS dictionary of Vendor-Specific
+// Attributes (RFC 2865 §5.26) registered under SMI Network Management Private
+// Enterprise Code 9 (the "cisco" vendor namespace).
+//
+// The attribute value types and their _Add/_Get/_Gets/_Lookup/_Set/_Del
+// accessors are produced by radius-dict-gen and encode or decode these VSAs on a
+// radius.Packet. The generated code lives in generated.go and must not be edited
+// by hand; regenerate the dictionary instead.
+package cisco

--- a/internal/radiusd/vendors/f5/doc.go
+++ b/internal/radiusd/vendors/f5/doc.go
@@ -1,0 +1,9 @@
+// Package f5 provides the generated RADIUS dictionary of Vendor-Specific
+// Attributes (RFC 2865 §5.26) registered under SMI Network Management Private
+// Enterprise Code 3375 (the "f5" vendor namespace).
+//
+// The attribute value types and their _Add/_Get/_Gets/_Lookup/_Set/_Del
+// accessors are produced by radius-dict-gen and encode or decode these VSAs on a
+// radius.Packet. The generated code lives in generated.go and must not be edited
+// by hand; regenerate the dictionary instead.
+package f5

--- a/internal/radiusd/vendors/h3c/doc.go
+++ b/internal/radiusd/vendors/h3c/doc.go
@@ -1,0 +1,9 @@
+// Package h3c provides the generated RADIUS dictionary of Vendor-Specific
+// Attributes (RFC 2865 §5.26) registered under SMI Network Management Private
+// Enterprise Code 25506 (the "h3c" vendor namespace).
+//
+// The attribute value types and their _Add/_Get/_Gets/_Lookup/_Set/_Del
+// accessors are produced by radius-dict-gen and encode or decode these VSAs on a
+// radius.Packet. The generated code lives in generated.go and must not be edited
+// by hand; regenerate the dictionary instead.
+package h3c

--- a/internal/radiusd/vendors/hillstone/doc.go
+++ b/internal/radiusd/vendors/hillstone/doc.go
@@ -1,0 +1,9 @@
+// Package hillstone provides the generated RADIUS dictionary of Vendor-Specific
+// Attributes (RFC 2865 §5.26) registered under SMI Network Management Private
+// Enterprise Code 28557 (the "hillstone" vendor namespace).
+//
+// The attribute value types and their _Add/_Get/_Gets/_Lookup/_Set/_Del
+// accessors are produced by radius-dict-gen and encode or decode these VSAs on a
+// radius.Packet. The generated code lives in generated.go and must not be edited
+// by hand; regenerate the dictionary instead.
+package hillstone

--- a/internal/radiusd/vendors/huawei/doc.go
+++ b/internal/radiusd/vendors/huawei/doc.go
@@ -1,0 +1,9 @@
+// Package huawei provides the generated RADIUS dictionary of Vendor-Specific
+// Attributes (RFC 2865 §5.26) registered under SMI Network Management Private
+// Enterprise Code 2011 (the "huawei" vendor namespace).
+//
+// The attribute value types and their _Add/_Get/_Gets/_Lookup/_Set/_Del
+// accessors are produced by radius-dict-gen and encode or decode these VSAs on a
+// radius.Packet. The generated code lives in generated.go and must not be edited
+// by hand; regenerate the dictionary instead.
+package huawei

--- a/internal/radiusd/vendors/ikuai/doc.go
+++ b/internal/radiusd/vendors/ikuai/doc.go
@@ -1,0 +1,9 @@
+// Package ikuai provides the generated RADIUS dictionary of Vendor-Specific
+// Attributes (RFC 2865 §5.26) registered under SMI Network Management Private
+// Enterprise Code 10055 (the "ikuai" vendor namespace).
+//
+// The attribute value types and their _Add/_Get/_Gets/_Lookup/_Set/_Del
+// accessors are produced by radius-dict-gen and encode or decode these VSAs on a
+// radius.Packet. The generated code lives in generated.go and must not be edited
+// by hand; regenerate the dictionary instead.
+package ikuai

--- a/internal/radiusd/vendors/juniper/doc.go
+++ b/internal/radiusd/vendors/juniper/doc.go
@@ -1,0 +1,9 @@
+// Package juniper provides the generated RADIUS dictionary of Vendor-Specific
+// Attributes (RFC 2865 §5.26) registered under SMI Network Management Private
+// Enterprise Code 2636 (the "juniper" vendor namespace).
+//
+// The attribute value types and their _Add/_Get/_Gets/_Lookup/_Set/_Del
+// accessors are produced by radius-dict-gen and encode or decode these VSAs on a
+// radius.Packet. The generated code lives in generated.go and must not be edited
+// by hand; regenerate the dictionary instead.
+package juniper

--- a/internal/radiusd/vendors/microsoft/doc.go
+++ b/internal/radiusd/vendors/microsoft/doc.go
@@ -1,0 +1,9 @@
+// Package microsoft provides the generated RADIUS dictionary of Vendor-Specific
+// Attributes (RFC 2865 §5.26) registered under SMI Network Management Private
+// Enterprise Code 311 (the "microsoft" vendor namespace).
+//
+// The attribute value types and their _Add/_Get/_Gets/_Lookup/_Set/_Del
+// accessors are produced by radius-dict-gen and encode or decode these VSAs on a
+// radius.Packet. The generated code lives in generated.go and must not be edited
+// by hand; regenerate the dictionary instead.
+package microsoft

--- a/internal/radiusd/vendors/mikrotik/doc.go
+++ b/internal/radiusd/vendors/mikrotik/doc.go
@@ -1,0 +1,9 @@
+// Package mikrotik provides the generated RADIUS dictionary of Vendor-Specific
+// Attributes (RFC 2865 §5.26) registered under SMI Network Management Private
+// Enterprise Code 14988 (the "mikrotik" vendor namespace).
+//
+// The attribute value types and their _Add/_Get/_Gets/_Lookup/_Set/_Del
+// accessors are produced by radius-dict-gen and encode or decode these VSAs on a
+// radius.Packet. The generated code lives in generated.go and must not be edited
+// by hand; regenerate the dictionary instead.
+package mikrotik

--- a/internal/radiusd/vendors/pfSense/doc.go
+++ b/internal/radiusd/vendors/pfSense/doc.go
@@ -1,0 +1,9 @@
+// Package pfSense provides the generated RADIUS dictionary of Vendor-Specific
+// Attributes (RFC 2865 §5.26) registered under SMI Network Management Private
+// Enterprise Code 13644 (the "pfSense" vendor namespace).
+//
+// The attribute value types and their _Add/_Get/_Gets/_Lookup/_Set/_Del
+// accessors are produced by radius-dict-gen and encode or decode these VSAs on a
+// radius.Packet. The generated code lives in generated.go and must not be edited
+// by hand; regenerate the dictionary instead.
+package pfSense

--- a/internal/radiusd/vendors/radback/doc.go
+++ b/internal/radiusd/vendors/radback/doc.go
@@ -1,0 +1,9 @@
+// Package radback provides the generated RADIUS dictionary of Vendor-Specific
+// Attributes (RFC 2865 §5.26) registered under SMI Network Management Private
+// Enterprise Code 2352 (the "radback" vendor namespace).
+//
+// The attribute value types and their _Add/_Get/_Gets/_Lookup/_Set/_Del
+// accessors are produced by radius-dict-gen and encode or decode these VSAs on a
+// radius.Packet. The generated code lives in generated.go and must not be edited
+// by hand; regenerate the dictionary instead.
+package radback

--- a/internal/radiusd/vendors/unix/doc.go
+++ b/internal/radiusd/vendors/unix/doc.go
@@ -1,0 +1,9 @@
+// Package unix provides the generated RADIUS dictionary of Vendor-Specific
+// Attributes (RFC 2865 §5.26) registered under SMI Network Management Private
+// Enterprise Code 4 (the "unix" vendor namespace).
+//
+// The attribute value types and their _Add/_Get/_Gets/_Lookup/_Set/_Del
+// accessors are produced by radius-dict-gen and encode or decode these VSAs on a
+// radius.Packet. The generated code lives in generated.go and must not be edited
+// by hand; regenerate the dictionary instead.
+package unix

--- a/internal/radiusd/vendors/zte/doc.go
+++ b/internal/radiusd/vendors/zte/doc.go
@@ -1,0 +1,9 @@
+// Package zte provides the generated RADIUS dictionary of Vendor-Specific
+// Attributes (RFC 2865 §5.26) registered under SMI Network Management Private
+// Enterprise Code 3902 (the "zte" vendor namespace).
+//
+// The attribute value types and their _Add/_Get/_Gets/_Lookup/_Set/_Del
+// accessors are produced by radius-dict-gen and encode or decode these VSAs on a
+// radius.Packet. The generated code lives in generated.go and must not be edited
+// by hand; regenerate the dictionary instead.
+package zte


### PR DESCRIPTION
## Summary

Milestone **M4.12** (incremental godoc backfill) — batch 13. Feature **TR-F024**.

Backfills standard-library-style **package comments** for the 15 generated vendor Vendor-Specific Attribute (VSA) dictionary packages under `internal/radiusd/vendors/*`:

`alcatel, aruba, cisco, f5, h3c, hillstone, huawei, ikuai, juniper, microsoft, mikrotik, pfSense, radback, unix, zte`

This closes the remaining `ST1000` (package-comment) gap across the entire `internal/radiusd/vendors` subtree.

## Approach
- Each comment lives in a **separate, non-generated `doc.go`** so it survives `radius-dict-gen` regeneration of `generated.go` (which carries `// Code generated … DO NOT EDIT.`). No in-repo generator script wipes these dirs.
- Each comment identifies the package by its **SMI Network Management Private Enterprise Code** (the precise term from **RFC 2865 §5.26**) plus the numeric vendor code as the source of truth — deliberately **not** asserting corporate/legal vendor names — and describes the generated `_Add/_Get/_Gets/_Lookup/_Set/_Del` accessor API that encodes/decodes the vendor's VSAs on a `radius.Packet`.

Example (`huawei`):
```
// Package huawei provides the generated RADIUS dictionary of Vendor-Specific
// Attributes (RFC 2865 §5.26) registered under SMI Network Management Private
// Enterprise Code 2011 (the "huawei" vendor namespace).
// ...
```

## Scope / ratchet
- The **global `ST1000` gate stays deferred** in `.golangci.yml` because repo-wide debt remains (`internal/app`, `internal/domain`, `internal/webserver`, `internal/radiusd/plugins`). Following prior batches, verification is a targeted standalone run rather than a global flip.

## Quality gates
- `gofmt -l` clean
- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./...` ✅ (all pass)
- `golangci-lint run` v2.12.2 → **0 issues**
- `staticcheck -checks ST1000 ./internal/radiusd/vendors/...` → **clean**

## Spec reference
- RFC 2865 §5.26 (Vendor-Specific, Attribute 26) — `docs/rfcs/rfc2865-radius-authentication.txt`

Docs-only change; no protocol/runtime behavior affected.