### PR TITLE
docs(godoc): M4.12 batch13 plugins package comment

### DIFF
--- a/internal/radiusd/plugins/doc.go
+++ b/internal/radiusd/plugins/doc.go
@@ -1,0 +1,10 @@
+// Package plugins wires ToughRADIUS plugin implementations into the runtime
+// registries used by the authentication, accounting, and EAP pipelines.
+//
+// The package composes concrete validators, policy checkers, response
+// enhancers, accounting handlers, and EAP handlers, then registers them through
+// the shared registry package during process startup.
+//
+// Registration is dependency-aware: components that require repositories or
+// config providers are only enabled when those dependencies are available.
+package plugins


### PR DESCRIPTION
# Summary

## Roadmap Mapping (Required for agent tasks)

- Milestone subtask: `M4.12`
- Feature ID(s): `TR-F024`
- Out-of-scope non-goals checked: `TR-N001` `TR-N002` `TR-N003` `TR-N004` `TR-N005`

## What Changed

- Add package-level `doc.go` comment for `internal/radiusd/plugins`.
- Clarify package contract: this package wires auth/accounting/EAP plugin implementations into shared registries and only enables dependency-aware components when required dependencies are available.
- No runtime behavior change (documentation-only).

## Acceptance Criteria Covered

- [x] The change only covers the mapped `TR-F` scope
- [ ] Protocol behavior updates include RFC clause references in code/tests/PR description
- [ ] Protocol or E2E behavior changes include CI-runnable acceptance tests under `test/integration/`

## Verification

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`
- [ ] `cd web && npm run build` (required only when frontend files changed)

## Risks and Rollback

- Risk level: `low`
- Main risk: None; comments-only change.
- Rollback plan: Revert this commit.

## Reviewer Notes

- Suggested review order (files/modules): `internal/radiusd/plugins/doc.go`
- Open questions / assumptions: none
