### PR TITLE
docs(godoc): M4.12 batch15 package comments for core layers

### DIFF
--- a/internal/app/doc.go
+++ b/internal/app/doc.go
@@ -1,0 +1,7 @@
+// Package app wires ToughRADIUS runtime dependencies and process lifecycle.
+//
+// It owns application bootstrap, database migration, dynamic configuration,
+// profile cache refresh, scheduled background jobs, and metrics/logging setup.
+// Web handlers and protocol services consume this package through small
+// provider interfaces so startup and test wiring remain centralized.
+package app

--- a/internal/domain/doc.go
+++ b/internal/domain/doc.go
@@ -1,0 +1,7 @@
+// Package domain defines ToughRADIUS persistence models and table registry.
+//
+// Types in this package map authentication, accounting, user, profile, NAS,
+// node, and system entities to GORM-backed storage. The Tables export provides
+// the canonical migration set used by bootstrap and tests to keep schema
+// evolution consistent across PostgreSQL and SQLite.
+package domain

--- a/internal/webserver/doc.go
+++ b/internal/webserver/doc.go
@@ -1,0 +1,7 @@
+// Package webserver hosts the ToughRADIUS admin HTTP server and middleware.
+//
+// It builds the Echo runtime, serves the embedded React Admin UI, applies JWT
+// authentication and request guards, and registers operational endpoints such as
+// readiness checks. Business logic remains in adminapi/app packages while this
+// package provides transport, middleware, and route plumbing.
+package webserver


### PR DESCRIPTION
# Summary

## Roadmap Mapping (Required for agent tasks)

- Milestone subtask: `M4.12`
- Feature ID(s): `TR-F024`
- Out-of-scope non-goals checked: `TR-N001` `TR-N002` `TR-N003` `TR-N004` `TR-N005`

## What Changed

- Add package-level `doc.go` comments for:
  - `internal/app`
  - `internal/domain`
  - `internal/webserver`
- Keep scope comments-only (no runtime logic changes).
- Verify ST1000 package-comment coverage on these modules.

## Acceptance Criteria Covered

- [x] The change only covers the mapped `TR-F` scope
- [ ] Protocol behavior updates include RFC clause references in code/tests/PR description
- [ ] Protocol or E2E behavior changes include CI-runnable acceptance tests under `test/integration/`

## Verification

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`
- [ ] `cd web && npm run build` (required only when frontend files changed)

> Note: lint was executed with a fresh `GOLANGCI_LINT_CACHE` directory to avoid stale cache entries pointing to removed historical worktree paths.

## Risks and Rollback

- Risk level: `low`
- Main risk: Minimal; comments-only changes to package docs.
- Rollback plan: Revert this PR to remove the three new `doc.go` files.

## Reviewer Notes

- Suggested review order (files/modules):
  1. `internal/app/doc.go`
  2. `internal/domain/doc.go`
  3. `internal/webserver/doc.go`
- Open questions / assumptions: None.
