### PR TITLE
docs(godoc): M4.12 batch16 accounting handler contracts

### DIFF
--- a/internal/radiusd/plugins/accounting/handlers/nas_state_handler.go
+++ b/internal/radiusd/plugins/accounting/handlers/nas_state_handler.go
@@ -9,26 +9,36 @@ import (
 	"layeh.com/radius/rfc2866"
 )
 
-// NasStateHandler Handle Accounting-On/Off event
+// NasStateHandler handles Accounting-On and Accounting-Off events by clearing
+// online sessions for the NAS that restarted or went offline.
 type NasStateHandler struct {
 	sessionRepo repository.SessionRepository
 }
 
+// NewNasStateHandler constructs a NasStateHandler with the session repository
+// used for NAS-scoped bulk cleanup.
 func NewNasStateHandler(sessionRepo repository.SessionRepository) *NasStateHandler {
 	return &NasStateHandler{
 		sessionRepo: sessionRepo,
 	}
 }
 
+// Name returns the stable plugin name used by the accounting dispatcher.
 func (h *NasStateHandler) Name() string {
 	return "NasStateHandler"
 }
 
+// CanHandle reports whether the context represents Accounting-On or
+// Accounting-Off.
 func (h *NasStateHandler) CanHandle(ctx *accounting.AccountingContext) bool {
 	return ctx.StatusType == int(rfc2866.AcctStatusType_Value_AccountingOn) ||
 		ctx.StatusType == int(rfc2866.AcctStatusType_Value_AccountingOff)
 }
 
+// Handle removes all online sessions bound to the NAS in the event context.
+//
+// Handle returns an error when repository access is unavailable or when NAS
+// identity data is missing, because both are required to scope the cleanup.
 func (h *NasStateHandler) Handle(ctx *accounting.AccountingContext) error {
 	if h.sessionRepo == nil {
 		return fmt.Errorf("session repository is not available")

--- a/internal/radiusd/plugins/accounting/handlers/start_handler.go
+++ b/internal/radiusd/plugins/accounting/handlers/start_handler.go
@@ -18,12 +18,19 @@ import (
 	"layeh.com/radius/rfc4818"
 	"layeh.com/radius/rfc6911"
 ) // StartHandler Accounting Start handler
+// StartHandler handles Accounting-Start packets and persists both online-session
+// and accounting rows for newly created sessions.
+//
+// The handler treats repeated Accounting-Start packets for the same
+// Acct-Session-Id as retransmissions and avoids double-billing by skipping
+// duplicate accounting inserts.
 type StartHandler struct {
 	sessionRepo    repository.SessionRepository
 	accountingRepo repository.AccountingRepository
 }
 
-// NewStartHandler CreateAccounting Start handler
+// NewStartHandler constructs a StartHandler with repositories used to persist
+// online-session and accounting state.
 func NewStartHandler(
 	sessionRepo repository.SessionRepository,
 	accountingRepo repository.AccountingRepository,
@@ -34,14 +41,22 @@ func NewStartHandler(
 	}
 }
 
+// Name returns the stable plugin name used by the accounting dispatcher.
 func (h *StartHandler) Name() string {
 	return "StartHandler"
 }
 
+// CanHandle reports whether the context represents an Accounting-Start packet.
 func (h *StartHandler) CanHandle(ctx *accounting.AccountingContext) bool {
 	return ctx.StatusType == int(rfc2866.AcctStatusType_Value_Start)
 }
 
+// Handle writes a new online-session row and a matching accounting row.
+//
+// Handle is idempotent on Acct-Session-Id: retransmitted starts do not create
+// duplicate records. If accounting-row creation fails after the online row was
+// created, Handle best-effort rolls back the online row so a later
+// retransmission can recreate both rows consistently.
 func (h *StartHandler) Handle(acctCtx *accounting.AccountingContext) error {
 	vendorReq := acctCtx.VendorReq
 	if vendorReq == nil {

--- a/internal/radiusd/plugins/accounting/handlers/stop_handler.go
+++ b/internal/radiusd/plugins/accounting/handlers/stop_handler.go
@@ -9,13 +9,15 @@ import (
 	"layeh.com/radius/rfc2866"
 )
 
-// StopHandler Accounting Stop handler
+// StopHandler handles Accounting-Stop packets and finalizes session
+// accounting.
 type StopHandler struct {
 	sessionRepo    repository.SessionRepository
 	accountingRepo repository.AccountingRepository
 }
 
-// NewStopHandler CreateAccounting Stop handler
+// NewStopHandler constructs a StopHandler with repositories used to update the
+// final accounting counters and clear online-session state.
 func NewStopHandler(
 	sessionRepo repository.SessionRepository,
 	accountingRepo repository.AccountingRepository,
@@ -26,14 +28,22 @@ func NewStopHandler(
 	}
 }
 
+// Name returns the stable plugin name used by the accounting dispatcher.
 func (h *StopHandler) Name() string {
 	return "StopHandler"
 }
 
+// CanHandle reports whether the context represents an Accounting-Stop packet.
 func (h *StopHandler) CanHandle(ctx *accounting.AccountingContext) bool {
 	return ctx.StatusType == int(rfc2866.AcctStatusType_Value_Stop)
 }
 
+// Handle updates the session's stop-time counters and removes the matching
+// online-session row.
+//
+// When updating the accounting row fails, Handle logs the error and still tries
+// to remove the online-session record so stale sessions do not remain online
+// forever.
 func (h *StopHandler) Handle(acctCtx *accounting.AccountingContext) error {
 	vendorReq := acctCtx.VendorReq
 	if vendorReq == nil {

--- a/internal/radiusd/plugins/accounting/handlers/update_handler.go
+++ b/internal/radiusd/plugins/accounting/handlers/update_handler.go
@@ -12,24 +12,31 @@ import (
 	"layeh.com/radius/rfc2869"
 )
 
-// UpdateHandler Accounting Update handler
+// UpdateHandler handles Accounting-Interim-Update packets and refreshes
+// counters on the active online-session row.
 type UpdateHandler struct {
 	sessionRepo repository.SessionRepository
 }
 
-// NewUpdateHandler CreateAccounting Update handler
+// NewUpdateHandler constructs an UpdateHandler with the session repository used
+// for interim counter updates.
 func NewUpdateHandler(sessionRepo repository.SessionRepository) *UpdateHandler {
 	return &UpdateHandler{sessionRepo: sessionRepo}
 }
 
+// Name returns the stable plugin name used by the accounting dispatcher.
 func (h *UpdateHandler) Name() string {
 	return "UpdateHandler"
 }
 
+// CanHandle reports whether the context represents an Accounting-Interim-Update
+// packet.
 func (h *UpdateHandler) CanHandle(ctx *accounting.AccountingContext) bool {
 	return ctx.StatusType == int(rfc2866.AcctStatusType_Value_InterimUpdate)
 }
 
+// Handle updates the online-session row with the latest traffic and session
+// counters carried in the interim packet.
 func (h *UpdateHandler) Handle(acctCtx *accounting.AccountingContext) error {
 	vendorReq := acctCtx.VendorReq
 	if vendorReq == nil {


### PR DESCRIPTION
## Summary
- continue `M4.12` (`TR-F024`) with a comments-only increment
- backfill standard-library style contracts for exported accounting handler APIs in `internal/radiusd/plugins/accounting/handlers`
- document idempotency/rollback behavior for Start, stop-record + cleanup behavior for Stop, interim-update semantics, and NAS on/off cleanup boundaries

## Scope
- `internal/radiusd/plugins/accounting/handlers/start_handler.go`
- `internal/radiusd/plugins/accounting/handlers/stop_handler.go`
- `internal/radiusd/plugins/accounting/handlers/update_handler.go`
- `internal/radiusd/plugins/accounting/handlers/nas_state_handler.go`

## Verification
- `go build ./...`
- `go test ./...`
- `tmp_cache=$(mktemp -d) && GOLANGCI_LINT_CACHE="$tmp_cache" go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run && rm -rf "$tmp_cache"`
