### PR TITLE
chore(lint): enable ST1000 package-comment gate (M4.12 batch18)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,7 +32,6 @@ linters:
     staticcheck:
       checks:
         - all
-        - "-ST1000" # Keep package-comment check deferred; baseline debt is repo-wide.
         - "-ST1003" # Disable naming convention (Id vs ID, etc)
         - "-ST1005" # Disable error string format check
         - "-ST1006" # Disable receiver name style check


### PR DESCRIPTION
## Summary
- remove `-ST1000` from `.golangci.yml` staticcheck exclusions so package-comment checks become part of the default lint gate
- keep the existing doc-comment checks (`ST1020`/`ST1021`) unchanged; this completes the final lint ratchet for M4.12 / TR-F024

## Milestone Mapping
- Roadmap: M4.12
- Feature: TR-F024

## Why now
M4.12 has already backfilled package-level and exported-identifier docs incrementally across target modules. With the debt cleared, the global ST1000 guard can now be enforced to prevent regressions.

## Validation
- `go build ./...`
- `go test ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`
