### PR TITLE
docs(roadmap): close M5.1 (delivered via #433) and recalibrate M5.2 parser priority (TR-F005)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -30,7 +30,7 @@
 | M2 | CoA 动态授权支持 | TR-F010 / TR-F012 / TR-F013 | P1 | 已交付 |
 | M3 | IPv6 能力增强闭环 | TR-F007 / TR-F011 / TR-F015 | P1 | 已完成 |
 | M4 | Agent 开发体系与质量门禁 | TR-F022 | P2 | 进行中 |
-| M5 | 厂商 VSA 覆盖扩展 | TR-F005 | P2 | 计划中 |
+| M5 | 厂商 VSA 覆盖扩展 | TR-F005 | P2 | 进行中 |
 | M6 | 可观测性与运维增强 | TR-F015 | P3 | 计划中 |
 | M7 | 上游 RADIUS 库跟踪与协议合规 | TR-F021 / TR-F022 | P2 | 进行中 |
 | M8 | PEAPv0 / EAP-MSCHAPv2 认证支持 | TR-F004 | P1 | 已完成 |
@@ -154,10 +154,11 @@
 - **关联编号**：`TR-F005`
 - **目标**：按 parser / enhancer / registry 模式扩展更多厂商 VSA 覆盖，补齐样例包测试。
 - **技能**：`.agents/skills/add-radius-vendor/SKILL.md`
+- **状态**：进行中（M5.1 已交付，M5.2 待按校准后的优先级逐厂商推进）
 
 子任务：
-- [ ] M5.1 梳理待补厂商清单与字典差异
-- [ ] M5.2 逐厂商按现有模式接入 parser / enhancer
+- [x] M5.1 梳理待补厂商清单与字典差异<br/>**已交付**（PR #433）：基线快照 [`docs/vendor-vsa-gap-baseline.md`](vendor-vsa-gap-baseline.md) 记录覆盖矩阵——15 个生成厂商字典；已注册 parser 为 `default + huawei + h3c + zte`，已注册 enhancer 为 `default + huawei + h3c + zte + mikrotik + ikuai`；`alcatel(3041)` / `aruba(14823)` / `unix(4)` 三个字典缺 `vendors.Code*` 常量。核心结论「字典 ≠ parser」：未注册 parser 的厂商一律回落到只解析标准属性的 `DefaultParser`。
+- [ ] M5.2 逐厂商按现有模式接入 parser / enhancer<br/>**优先级校准（基于 M5.1 字典证据，groom 修订）**：`vendorparsers.VendorRequest` 仅承载 `MacAddr` + 双 `Vlanid`，故 **parser 仅对「在请求侧以厂商私有 VSA 编码 MAC/VLAN」的厂商有增量价值**。证据：`mikrotik` / `ikuai` 请求侧用标准 `Calling-Station-Id`（其 VLAN VSA 如 `Mikrotik-Wireless-VLANID` 属 Access-Accept 响应侧），单独加 parser 会与 `DefaultParser` 行为重复、仅补「对称」而无行为差异，故**不再优先**（原基线把它们列为 batch 1 系误判）。优先接入存在请求侧厂商私有 MAC/VLAN 的厂商：`radback`（`Mac-Addr` / `Bind-Dot1q-Vlan-Tag-Id`）、`alcatel`（`AAT-User-MAC-Address`）、`aruba`（`Aruba-User-Vlan`）、`juniper`（`Juniper-VoIP-Vlan`）——具体请求/响应侧语义按各厂商字典与规范逐一核实。enhancer（响应速率 / VLAN）的价值与 parser 解耦，按部署需求独立推进。每厂商按 `add-radius-vendor` SOP 交付：parser + 注册（缺 `Code*` 常量先补）+ enhancer（若需响应 VSA）+ 样例测试，过 `go test ./internal/radiusd/...` 与 golangci-lint 门禁。
 - [ ] M5.3 厂商样例包覆盖解析与响应属性
 
 ## M6 — 可观测性与运维增强

--- a/docs/vendor-vsa-gap-baseline.md
+++ b/docs/vendor-vsa-gap-baseline.md
@@ -54,13 +54,35 @@ rg '^\$INCLUDE\s+dictionary\.' share/dictionary
 
 ## Prioritized Backlog for M5.2
 
-1. Complete parser symmetry for already-enhanced vendors:
-   - `mikrotik`, `ikuai`
-2. Fill high-demand enterprise paths already documented for deployment:
-   - `cisco` first, then `juniper` / `microsoft`
-3. Close full missing coverage on remaining generated vendors:
-   - `f5`, `hillstone`, `pfSense`, `alcatel`, `aruba`, `unix`, `radback`
-4. For each vendor in M5.2, follow the same acceptance set:
+> Prioritization corrected during M5.1 → M5.2 grooming, anchored to the gap
+> matrix above and to the `vendorparsers.VendorRequest` model (it carries only
+> `MacAddr` + two `Vlanid` fields). A vendor **parser** therefore adds value only
+> when the vendor encodes MAC/VLAN with a vendor-specific VSA **on the request
+> side**; otherwise it merely duplicates `DefaultParser` (which already reads the
+> standard `Calling-Station-Id`). The response **enhancer** (rate/VLAN reply
+> attributes) is a separate, demand-driven track and does not depend on a parser.
+
+1. Parsers with genuine request-side value — vendors whose dictionary exposes a
+   vendor-specific MAC/VLAN request attribute (verify request/response semantics
+   per vendor dictionary + spec before implementing):
+   - `radback` (`Mac-Addr` / `Bind-Dot1q-Vlan-Tag-Id`)
+   - `alcatel` (`AAT-User-MAC-Address`)
+   - `aruba` (`Aruba-User-Vlan`)
+   - `juniper` (`Juniper-VoIP-Vlan`)
+2. Enhancers (response attributes) — drive by deployment demand, independently of
+   parser work; `cisco` (`cisco-avpair`), `juniper`, `microsoft` are common asks.
+3. De-prioritized "symmetry-only" parsers — `mikrotik`, `ikuai` use the standard
+   `Calling-Station-Id` on the request side (their VLAN VSAs such as
+   `Mikrotik-Wireless-VLANID` are Access-Accept reply attributes), so a dedicated
+   parser would be behaviorally identical to `DefaultParser`. Add one only if a
+   concrete deployment proves a vendor-specific request encoding. (The original
+   baseline listed these as batch 1 — that was a misjudgment, now corrected.)
+4. Remaining generated vendors with no current request-side parser value:
+   `cisco`, `f5`, `hillstone`, `pfSense`, `unix`, `microsoft` — close as
+   enhancer/registry work or when a deployment surfaces a real attribute need.
+   Note: `alcatel`, `aruba`, `unix` still lack a `vendors.Code*` constant; add it
+   before registering a parser/enhancer.
+5. For each vendor in M5.2, follow the same acceptance set:
    - parser + registration + enhancer (if response VSA required)
    - sample-based parser/enhancer tests
    - `go test ./internal/radiusd/...` and `golangci-lint` green


### PR DESCRIPTION
# Summary

Groom round: the M5.1 deliverable was merged but the roadmap was never updated, and the M5.2 backlog priority needs an evidence-based correction.

## Roadmap Mapping (Required for agent tasks)

- Milestone subtask: `M5.1` (close as delivered) + `M5.2` (priority recalibration)
- Feature ID(s): `TR-F005`
- Out-of-scope non-goals checked: `TR-N001` `TR-N002` `TR-N003` `TR-N004` `TR-N005` — none touched

## What Changed

- **`docs/roadmap.md`**: M5.1 → `[x]` with a delivery note (baseline doc, merged via #433). M5 overview-table status `计划中` → `进行中`; added a matching `状态` line to the M5 section. Rewrote the M5.2 note with an evidence-based parser-priority recalibration.
- **`docs/vendor-vsa-gap-baseline.md`**: replaced the "Prioritized Backlog for M5.2" section so it reflects real parser value instead of cosmetic symmetry.

### Why the recalibration
`vendorparsers.VendorRequest` carries only `MacAddr` + two `Vlanid` fields, so a vendor **parser** only adds value when the vendor encodes MAC/VLAN with a **request-side** VSA. The M5.1 dictionary survey shows `mikrotik`/`ikuai` use the standard `Calling-Station-Id` on the request side (their VLAN VSAs such as `Mikrotik-Wireless-VLANID` are Access-Accept reply attributes), so a dedicated parser for them would be behaviorally identical to `DefaultParser`. The original baseline listed them as batch 1 — a misjudgment. Reprioritized toward vendors with genuine request-side vendor-specific MAC/VLAN (`radback`, `alcatel`, `aruba`, `juniper`); enhancer (response) work stays a separate demand-driven track.

## Acceptance Criteria Covered

- [x] The change only covers the mapped `TR-F` scope (TR-F005 plan docs)
- [x] Protocol behavior updates include RFC clause references — N/A, no protocol/code behavior change (docs-only)
- [x] Protocol or E2E behavior changes include CI-runnable acceptance tests — N/A, docs-only

## Verification

- [x] `go build ./...` (green; no Go files changed)
- [x] `go test ./...` — unaffected (diff is `.md`-only)
- [x] `golangci-lint run` — unaffected (diff is `.md`-only)
- [ ] `cd web && npm run build` — N/A (no frontend changes)

Diff is two markdown files only (`git diff --name-only origin/main` → `.md` only). Neither file is part of the `docs-site/` mdbook (no `SUMMARY.md` entry), so the docs link-check gate does not apply.

## Risks and Rollback

- Risk level: `low`
- Main risk: none beyond plan-doc wording; no runtime behavior touched.
- Rollback plan: revert this commit; roadmap/baseline return to prior text.

## Reviewer Notes

- Suggested review order: `docs/roadmap.md` (M5 section + overview row), then `docs/vendor-vsa-gap-baseline.md` (backlog section).
- Assumptions: M5.1 is delivered because `docs/vendor-vsa-gap-baseline.md` is on `main` via merged PR #433; the prior round simply skipped the groom step (`groom-roadmap`).