### PR TITLE
docs(roadmap): groom M2 — record #440 outbound MA signing; backfill optional M2.7 reply verification

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -27,7 +27,7 @@
 | 里程碑 | 主题 | 关联编号 | 优先级 | 状态 |
 | --- | --- | --- | --- | --- |
 | M1 | EAP-TLS 认证支持 | TR-F004 | P1 | 已交付 |
-| M2 | CoA 动态授权支持 | TR-F010 / TR-F012 / TR-F013 | P1 | 已交付 |
+| M2 | CoA 动态授权支持 | TR-F010 / TR-F012 / TR-F013 | P1 | 已交付（含可选跟进 M2.7） |
 | M3 | IPv6 能力增强闭环 | TR-F007 / TR-F011 / TR-F015 | P1 | 已完成 |
 | M4 | Agent 开发体系与质量门禁 | TR-F022 | P2 | 进行中 |
 | M5 | 厂商 VSA 覆盖扩展 | TR-F005 | P2 | 进行中 |
@@ -100,6 +100,8 @@
 - [x] M2.4 前端在线会话页暴露安全动作按钮 + 结果反馈
 - [x] M2.5 单元/集成测试覆盖成功、超时、NAS 拒绝场景
 - [x] M2.6 在 `test/integration/` 增加 CoA/Disconnect 端到端验收用例（CI 自动执行）
+- [x] M2.6a（M2.1 后置加固，PR #440）出站 CoA-Request / Disconnect-Request 按 RFC 5176 §3.4 携带 Message-Authenticator（HMAC-MD5，RFC 3579 §3.2），复用 `internal/radiusd/message_authenticator.go` 的 `computeMessageAuthenticator`；严格 NAS（FreeRADIUS 风格）会静默丢弃未签名请求，故签名对互通性必需。单元用例验证两类请求均携带可校验的 MA，集成用例以「严格 NAS 丢弃未签名请求」背书。
+- [ ] M2.7（可选增强，不阻塞 M2 交付）校验 CoA / Disconnect **应答**（ACK/NAK）携带的 Message-Authenticator：RFC 5176 §3.4 规定应答侧该属性为 OPTIONAL（0-1），收到且校验失败的应答 MUST 静默丢弃、未携带则接受。来源：#440 落地出站请求签名时按最小闭环裁剪掉了应答侧校验（并移除手写 raw-MD5 重建以消除 CodeQL `go/weak-sensitive-data-hashing` 告警）。实现需复用 `message_authenticator.go` 的 HMAC-MD5 helper（应答摘要以请求的 Request Authenticator 替换应答 Authenticator 字段、MA 值清零计算），并补单元 + `test/integration/` 用例（含损坏 MA 被丢弃、未签名应答被接受两种向量）。关联 `TR-F010`。
 
 验收口径：可对在线用户安全发起动态授权；每次触发有可查询的结果记录；**验收由 `test/integration/` 的 CI 用例背书**。
 


### PR DESCRIPTION
## Summary

Roadmap self-iteration (grooming) closing out this orchestration round's drain of the in-flight CoA Message-Authenticator PRs. **Plan-doc only — no product code.**

This round drained six in-flight `agent-roadmap` PRs to a clean state: **#439, #441, #442, #443, #414, #440** are all merged to `main`. #440 (CoA/Disconnect Message-Authenticator) was reworked during review — scoped down to outbound request signing, reusing the shared `computeMessageAuthenticator` helper from #439, which also cleared a CodeQL `go/weak-sensitive-data-hashing` alert.

## Changes to `docs/roadmap.md`

- **M2.6a** (checked, PR #440): records that outbound CoA-Request / Disconnect-Request now carry an RFC 5176 §3.4 Message-Authenticator (HMAC-MD5, RFC 3579 §3.2). Strict NASes silently drop unsigned requests, so this is interoperability-critical.
- **M2.7** (new, unchecked, optional): verify the Message-Authenticator on CoA/Disconnect **replies** — OPTIONAL per RFC 5176 §3.4. Deliberately scoped out of #440 to keep that PR a minimal closed loop; tracked here so the deferred work is not lost.
- **Overview table**: M2 status annotated `已交付（含可选跟进 M2.7）` so the milestone status stays consistent with the open optional subtask.

## Scope / guardrails

- No new `TR-F` required — M2.7 is within `TR-F010`'s existing (delivered) scope; `docs/feature-checklist.md` TR-F010 remains `已交付（M2）` and is untouched.
- No `TR-N001`–`TR-N005` non-goal touched.

## Roadmap Mapping

- Milestone: **M2** (CoA Dynamic Authorization)
- Feature: **TR-F010** (CoA / Disconnect-Message), **TR-F022** (roadmap/CI hygiene)

## Spec

- RFC 5176 §3.4 (Message-Authenticator in Dynamic Authorization), RFC 3579 §3.2 (HMAC-MD5)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>