### PR TITLE
feat(coa): verify Message-Authenticator on CoA/Disconnect replies (M2.7)

### DIFF
--- a/internal/radiusd/coa_service.go
+++ b/internal/radiusd/coa_service.go
@@ -42,6 +42,14 @@ var ErrSessionNotFound = errors.New("coa: online session not found")
 // destination NAS address.
 var ErrNoTarget = errors.New("coa: target NAS address is required")
 
+// errResponseDiscarded is an internal sentinel marking that a CoA/Disconnect
+// reply was silently discarded because its optional Message-Authenticator was
+// present but did not verify (RFC 5176 §3.4). It drives the retransmission loop
+// to keep waiting for an authentic reply and, when the budget is exhausted, is
+// surfaced in CoAResult.Err. It is not a timeout, so CoAResult.TimedOut stays
+// false.
+var errResponseDiscarded = errors.New("coa: reply discarded: invalid Message-Authenticator (RFC 5176 §3.4)")
+
 // CoAAction identifies the RADIUS Dynamic Authorization operation being sent.
 type CoAAction string
 
@@ -328,6 +336,12 @@ func (s *CoAService) send(ctx context.Context, action CoAAction, target CoATarge
 	}
 
 	var lastErr error
+	// Precompute the Request Authenticator the transport puts on the wire. It is
+	// needed to validate the optional Message-Authenticator a NAS may include on
+	// its reply: RFC 5176 §3.4 computes the reply digest with the request's
+	// Request Authenticator. The packet is not mutated after this point, so the
+	// value is stable across retransmissions.
+	reqAuth := requestAuthenticator(packet)
 	for attempt := 0; attempt <= s.retries; attempt++ {
 		if err := ctx.Err(); err != nil {
 			lastErr = err
@@ -342,6 +356,16 @@ func (s *CoAService) send(ctx context.Context, action CoAAction, target CoATarge
 		cancel()
 
 		if err == nil {
+			// RFC 5176 §3.4: a reply carrying a Message-Authenticator MUST verify,
+			// otherwise it is silently discarded; an absent attribute is accepted
+			// because it is OPTIONAL on responses. Treat a discarded reply as an
+			// unanswered attempt so the retransmission budget keeps trying for an
+			// authentic answer rather than letting a forged packet end the exchange.
+			if verifyResponseMessageAuthenticator(resp, reqAuth, []byte(target.Secret)) == msgAuthInvalid {
+				lastErr = errResponseDiscarded
+				s.logDiscardedResponse(result, resp)
+				continue
+			}
 			result.RTT = rtt
 			classifyResponse(result, resp)
 			s.logResult(result, packet, resp)
@@ -464,6 +488,45 @@ func setMessageAuthenticator(packet *radius.Packet, secret string) error {
 		return fmt.Errorf("set Message-Authenticator: %w", err)
 	}
 	return nil
+}
+
+// requestAuthenticator returns the sixteen-octet Request Authenticator the
+// transport computes for an outbound CoA/Disconnect request (RFC 5176 §2.3),
+// derived from the encoded packet so it matches the bytes radius.Client.Exchange
+// places on the wire. It is needed to validate the optional reply
+// Message-Authenticator (RFC 5176 §3.4), whose digest is keyed on the request's
+// Request Authenticator. Encode does not mutate the packet, so calling it here
+// reproduces the value Exchange sends. A zero value is returned when the packet
+// cannot be encoded; the resulting digest mismatch then fails closed.
+func requestAuthenticator(packet *radius.Packet) [16]byte {
+	var auth [16]byte
+	wire, err := packet.Encode()
+	if err != nil || len(wire) < 20 {
+		return auth
+	}
+	copy(auth[:], wire[4:20])
+	return auth
+}
+
+// logDiscardedResponse records a CoA/Disconnect reply that was silently discarded
+// because its Message-Authenticator was present but did not verify (RFC 5176
+// §3.4). The exchange continues retransmitting; this surfaces the dropped packet
+// for operators without aborting the attempt.
+func (s *CoAService) logDiscardedResponse(result *CoAResult, resp *radius.Packet) {
+	code := ""
+	if resp != nil {
+		code = resp.Code.String()
+	}
+	zap.L().Warn("radius coa reply discarded: invalid message-authenticator",
+		zap.String("namespace", "radius"),
+		zap.String("action", string(result.Action)),
+		zap.String("target", result.Target),
+		zap.String("username", result.Username),
+		zap.String("acct_session_id", result.AcctSessionID),
+		zap.Int("identifier", result.Identifier),
+		zap.String("discarded_response", code),
+		zap.String("rfc", "RFC 5176 §3.4"),
+	)
 }
 
 // deadline or a net.Error timeout), which is the condition that warrants a

--- a/internal/radiusd/coa_service_test.go
+++ b/internal/radiusd/coa_service_test.go
@@ -47,7 +47,38 @@ type fakeNAS struct {
 	replyCode radius.Code        // 0 => drop the request (no reply)
 	errCause  rfc3576.ErrorCause // added to NAK replies when non-zero
 	dropFirst int                // drop the first N requests, then use replyCode
+	replyAuth replyAuthMode      // how the reply carries a Message-Authenticator
 	received  []capturedReq
+}
+
+// replyAuthMode controls how the fake NAS signs its CoA/Disconnect reply, so
+// tests can exercise the RFC 5176 §3.4 reply-side Message-Authenticator paths.
+type replyAuthMode int
+
+const (
+	// replyAuthNone leaves the reply unsigned (no Message-Authenticator). It is
+	// the zero value and the default behavior.
+	replyAuthNone replyAuthMode = iota
+	// replyAuthSigned attaches a valid Message-Authenticator (RFC 5176 §3.4).
+	replyAuthSigned
+	// replyAuthCorrupt attaches a present but invalid Message-Authenticator by
+	// signing with the wrong secret, so the attribute is structurally valid
+	// (sixteen octets) yet fails the client's check.
+	replyAuthCorrupt
+)
+
+// signCoAReply signs a CoA/Disconnect reply with a Message-Authenticator the way
+// a NAS does per RFC 5176 §3.4: the request authenticator (carried into
+// resp.Authenticator by r.Response) sits in the Authenticator field, the
+// attribute value is treated as sixteen zero octets for the HMAC-MD5, and the
+// result is stored before the transport computes the Response Authenticator.
+func signCoAReply(resp *radius.Packet, secret string) {
+	_ = rfc2869.MessageAuthenticator_Set(resp, make([]byte, 16))
+	if b, err := resp.MarshalBinary(); err == nil {
+		mac := hmac.New(md5.New, []byte(secret))
+		mac.Write(b)
+		_ = rfc2869.MessageAuthenticator_Set(resp, mac.Sum(nil))
+	}
 }
 
 func newFakeNAS(t *testing.T, secret string, replyCode radius.Code) *fakeNAS {
@@ -103,6 +134,7 @@ func (fn *fakeNAS) handle(w radius.ResponseWriter, r *radius.Request) {
 	}
 	code := fn.replyCode
 	cause := fn.errCause
+	authMode := fn.replyAuth
 	fn.mu.Unlock()
 
 	if drop || code == 0 {
@@ -111,6 +143,12 @@ func (fn *fakeNAS) handle(w radius.ResponseWriter, r *radius.Request) {
 	resp := r.Response(code)
 	if cause != 0 && (code == radius.CodeDisconnectNAK || code == radius.CodeCoANAK) {
 		_ = rfc3576.ErrorCause_Add(resp, cause)
+	}
+	switch authMode {
+	case replyAuthSigned:
+		signCoAReply(resp, fn.secret)
+	case replyAuthCorrupt:
+		signCoAReply(resp, fn.secret+"-wrong")
 	}
 	_ = w.Write(resp)
 }
@@ -166,6 +204,14 @@ func (fn *fakeNAS) setBehavior(replyCode radius.Code, cause rfc3576.ErrorCause, 
 	fn.replyCode = replyCode
 	fn.errCause = cause
 	fn.dropFirst = dropFirst
+}
+
+// setReplyAuth selects how the fake NAS signs its CoA/Disconnect reply so tests
+// can drive the RFC 5176 §3.4 reply-side validation paths.
+func (fn *fakeNAS) setReplyAuth(mode replyAuthMode) {
+	fn.mu.Lock()
+	defer fn.mu.Unlock()
+	fn.replyAuth = mode
 }
 
 func TestCoAServiceDisconnectACK(t *testing.T) {
@@ -503,4 +549,197 @@ func TestCoAServiceRequestMessageAuthenticator(t *testing.T) {
 			t.Errorf("CoA-Request Message-Authenticator: present=%v valid=%v, want both true", got[0].hasMessageAuth, got[0].messageAuthOK)
 		}
 	})
+}
+
+// TestCoAServiceResponseMessageAuthenticator drives the RFC 5176 §3.4 reply-side
+// validation through the full send path: a correctly signed reply is accepted, an
+// unsigned reply is accepted (the attribute is OPTIONAL on responses), and a reply
+// whose Message-Authenticator does not verify is silently discarded.
+func TestCoAServiceResponseMessageAuthenticator(t *testing.T) {
+const secret = "testing123"
+
+t.Run("signed reply accepted", func(t *testing.T) {
+nas := newFakeNAS(t, secret, radius.CodeDisconnectACK)
+nas.setReplyAuth(replyAuthSigned)
+svc := NewCoAService(nil, WithCoATimeout(2*time.Second), WithCoARetries(2))
+target := CoATarget{Addr: "127.0.0.1", Secret: secret, Port: nas.port(t)}
+
+result, err := svc.Disconnect(context.Background(), target, SessionIdentity{Username: "alice", AcctSessionID: "s1"})
+if err != nil {
+t.Fatalf("Disconnect returned error: %v", err)
+}
+if !result.Success {
+t.Fatalf("expected success with a valid reply Message-Authenticator, got %+v", result)
+}
+if result.ResponseCode != "Disconnect-ACK" {
+t.Errorf("response code = %q, want Disconnect-ACK", result.ResponseCode)
+}
+if result.Attempts != 1 {
+t.Errorf("attempts = %d, want 1", result.Attempts)
+}
+})
+
+t.Run("unsigned reply accepted", func(t *testing.T) {
+nas := newFakeNAS(t, secret, radius.CodeCoAACK)
+nas.setReplyAuth(replyAuthNone) // reply carries no Message-Authenticator
+svc := NewCoAService(nil, WithCoATimeout(2*time.Second), WithCoARetries(2))
+target := CoATarget{Addr: "127.0.0.1", Secret: secret, Port: nas.port(t)}
+
+result, err := svc.CoA(context.Background(), target, SessionIdentity{Username: "bob", AcctSessionID: "s2"}, WithSessionTimeout(60))
+if err != nil {
+t.Fatalf("CoA returned error: %v", err)
+}
+if !result.Success {
+t.Fatalf("expected success with an unsigned reply (reply MA is OPTIONAL), got %+v", result)
+}
+if result.Attempts != 1 {
+t.Errorf("attempts = %d, want 1", result.Attempts)
+}
+})
+
+t.Run("invalid reply discarded", func(t *testing.T) {
+nas := newFakeNAS(t, secret, radius.CodeDisconnectACK)
+nas.setReplyAuth(replyAuthCorrupt)
+svc := NewCoAService(nil, WithCoATimeout(2*time.Second), WithCoARetries(2))
+target := CoATarget{Addr: "127.0.0.1", Secret: secret, Port: nas.port(t)}
+
+result, err := svc.Disconnect(context.Background(), target, SessionIdentity{Username: "carol", AcctSessionID: "s3"})
+if err != nil {
+t.Fatalf("Disconnect returned error: %v", err)
+}
+if result.Success {
+t.Fatalf("expected the forged reply to be discarded, got success: %+v", result)
+}
+if result.TimedOut {
+t.Error("a discarded reply must not be reported as a timeout")
+}
+if result.ResponseCode != "" {
+t.Errorf("response code = %q, want empty (no reply accepted)", result.ResponseCode)
+}
+if result.Err == "" {
+t.Error("expected Err to describe the discard")
+}
+// Every discarded reply is treated as unanswered, so the full budget is
+// spent: initial transmission + 2 retransmissions.
+if result.Attempts != 3 {
+t.Errorf("attempts = %d, want 3 (initial + 2 retransmissions)", result.Attempts)
+}
+if got := len(nas.snapshot()); got != 3 {
+t.Errorf("nas received %d packets, want 3", got)
+}
+})
+}
+
+// TestVerifyResponseMessageAuthenticator exercises the pure RFC 5176 §3.4 reply
+// validator against signed, unsigned, malformed, and forged vectors.
+func TestVerifyResponseMessageAuthenticator(t *testing.T) {
+const secret = "respsecret"
+var reqAuth [16]byte
+for i := range reqAuth {
+reqAuth[i] = byte(i + 1)
+}
+
+// build returns a Disconnect-ACK signed the way a NAS does (RFC 5176 §3.4):
+// keyed on reqAuth with the Message-Authenticator value zeroed during HMAC.
+build := func() *radius.Packet {
+p := radius.New(radius.CodeDisconnectACK, []byte(secret))
+p.Identifier = 7
+p.Authenticator = reqAuth
+if err := rfc2869.MessageAuthenticator_Set(p, make([]byte, 16)); err != nil {
+t.Fatalf("set placeholder MA: %v", err)
+}
+b, err := p.MarshalBinary()
+if err != nil {
+t.Fatalf("marshal: %v", err)
+}
+mac := hmac.New(md5.New, []byte(secret))
+mac.Write(b)
+if err := rfc2869.MessageAuthenticator_Set(p, mac.Sum(nil)); err != nil {
+t.Fatalf("set MA: %v", err)
+}
+return p
+}
+
+t.Run("valid", func(t *testing.T) {
+if got := verifyResponseMessageAuthenticator(build(), reqAuth, []byte(secret)); got != msgAuthValid {
+t.Errorf("got %v, want msgAuthValid", got)
+}
+})
+
+t.Run("keyed on request authenticator not the carried one", func(t *testing.T) {
+p := build()
+// Simulate the parsed reply carrying a Response Authenticator that differs
+// from the request authenticator; verification must still key on reqAuth.
+for i := range p.Authenticator {
+p.Authenticator[i] = 0xAA
+}
+if got := verifyResponseMessageAuthenticator(p, reqAuth, []byte(secret)); got != msgAuthValid {
+t.Errorf("got %v, want msgAuthValid", got)
+}
+})
+
+t.Run("absent accepted", func(t *testing.T) {
+p := radius.New(radius.CodeDisconnectACK, []byte(secret))
+if got := verifyResponseMessageAuthenticator(p, reqAuth, []byte(secret)); got != msgAuthAbsent {
+t.Errorf("got %v, want msgAuthAbsent", got)
+}
+})
+
+t.Run("nil accepted", func(t *testing.T) {
+if got := verifyResponseMessageAuthenticator(nil, reqAuth, []byte(secret)); got != msgAuthAbsent {
+t.Errorf("got %v, want msgAuthAbsent", got)
+}
+})
+
+t.Run("tampered value discarded", func(t *testing.T) {
+p := build()
+v, err := rfc2869.MessageAuthenticator_Lookup(p)
+if err != nil {
+t.Fatalf("lookup MA: %v", err)
+}
+tampered := append([]byte(nil), v...)
+tampered[0] ^= 0xFF
+if err := rfc2869.MessageAuthenticator_Set(p, tampered); err != nil {
+t.Fatalf("set tampered MA: %v", err)
+}
+if got := verifyResponseMessageAuthenticator(p, reqAuth, []byte(secret)); got != msgAuthInvalid {
+t.Errorf("got %v, want msgAuthInvalid", got)
+}
+})
+
+t.Run("wrong request authenticator discarded", func(t *testing.T) {
+var other [16]byte
+for i := range other {
+other[i] = 0x99
+}
+if got := verifyResponseMessageAuthenticator(build(), other, []byte(secret)); got != msgAuthInvalid {
+t.Errorf("got %v, want msgAuthInvalid", got)
+}
+})
+
+t.Run("wrong length discarded", func(t *testing.T) {
+p := build()
+if err := rfc2869.MessageAuthenticator_Set(p, make([]byte, 8)); err != nil {
+t.Fatalf("set short MA: %v", err)
+}
+if got := verifyResponseMessageAuthenticator(p, reqAuth, []byte(secret)); got != msgAuthInvalid {
+t.Errorf("got %v, want msgAuthInvalid", got)
+}
+})
+
+t.Run("duplicate attribute discarded", func(t *testing.T) {
+p := build()
+if err := rfc2869.MessageAuthenticator_Add(p, make([]byte, 16)); err != nil {
+t.Fatalf("add duplicate MA: %v", err)
+}
+if got := verifyResponseMessageAuthenticator(p, reqAuth, []byte(secret)); got != msgAuthInvalid {
+t.Errorf("got %v, want msgAuthInvalid", got)
+}
+})
+
+t.Run("present but no secret discarded", func(t *testing.T) {
+if got := verifyResponseMessageAuthenticator(build(), reqAuth, nil); got != msgAuthInvalid {
+t.Errorf("got %v, want msgAuthInvalid", got)
+}
+})
 }

--- a/internal/radiusd/message_authenticator.go
+++ b/internal/radiusd/message_authenticator.go
@@ -132,6 +132,70 @@ func (s *RadiusService) verifyMessageAuthenticator(r *radius.Packet, secret []by
 	return msgAuthInvalid
 }
 
+// verifyResponseMessageAuthenticator validates the OPTIONAL Message-Authenticator
+// attribute (RFC 3579 §3.2) that a NAS may include on a CoA/Disconnect reply
+// (ACK or NAK), per RFC 5176 §3.4. A Dynamic Authorization Client that receives a
+// reply carrying the attribute MUST recompute it and silently discard the packet
+// on mismatch; an absent attribute is accepted because it is optional on
+// responses.
+//
+// It returns msgAuthAbsent when no attribute is present (accept), msgAuthValid
+// when it verifies, and msgAuthInvalid when the reply must be discarded (wrong
+// value, malformed, duplicated, or unverifiable because no secret is available).
+//
+// Per RFC 5176 §3.4 the reply digest is HMAC-MD5 over the response packet with
+// the Message-Authenticator value treated as sixteen octets of zero and the
+// Authenticator field set to the Request Authenticator of the corresponding
+// request (reqAuth). A parsed reply carries the Response Authenticator in its
+// Authenticator field, so that field is overwritten with reqAuth before hashing.
+//
+// Presence is checked before the secret so an unsigned reply is still accepted
+// even when the shared secret is missing; a signed reply with no secret to verify
+// against fails closed.
+func verifyResponseMessageAuthenticator(resp *radius.Packet, reqAuth [16]byte, secret []byte) messageAuthResult {
+	if resp == nil {
+		return msgAuthAbsent
+	}
+
+	values, err := rfc2869.MessageAuthenticator_Gets(resp)
+	if err != nil {
+		return msgAuthInvalid
+	}
+	switch len(values) {
+	case 0:
+		return msgAuthAbsent
+	case 1:
+		// single attribute, validated below
+	default:
+		// RFC 3579 §3.2 allows at most one Message-Authenticator; reject extras.
+		return msgAuthInvalid
+	}
+
+	if len(secret) == 0 {
+		return msgAuthInvalid
+	}
+
+	received := values[0]
+	if len(received) != md5.Size {
+		return msgAuthInvalid
+	}
+
+	wire, err := resp.MarshalBinary()
+	if err != nil || len(wire) < 20 {
+		return msgAuthInvalid
+	}
+	// RFC 5176 §3.4: the reply digest is computed with the Request Authenticator
+	// of the corresponding request, not the Response Authenticator carried on the
+	// reply, so overwrite the marshaled Authenticator field before hashing.
+	copy(wire[4:20], reqAuth[:])
+
+	expected := computeMessageAuthenticator(wire, secret)
+	if hmac.Equal(received, expected) {
+		return msgAuthValid
+	}
+	return msgAuthInvalid
+}
+
 // addResponseMessageAuthenticator signs a non-EAP Access-Accept/Access-Reject
 // response with a freshly computed Message-Authenticator. It must be called
 // before the response is written so the attribute is covered by the Response

--- a/test/integration/client_test.go
+++ b/test/integration/client_test.go
@@ -5,9 +5,11 @@ package integration
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -22,29 +24,60 @@ type apiClient struct {
 	http  *http.Client
 }
 
+// adminTokenOnce guards a single admin login shared by the whole test process.
+var (
+	adminTokenOnce sync.Once
+	adminTokenVal  string
+	adminTokenErr  error
+)
+
 func newAPIClient(t *testing.T) *apiClient {
 	t.Helper()
-	c := &apiClient{base: h.webBaseURL, http: &http.Client{}}
-	c.login(t, h.adminUser, h.adminPass)
-	return c
+	return &apiClient{base: h.webBaseURL, http: &http.Client{}, token: sharedAdminToken(t)}
 }
 
-func (c *apiClient) login(t *testing.T, username, password string) {
+// sharedAdminToken logs in once per test process and caches the JWT for reuse by
+// every apiClient. The token's TTL (server-side tokenTTL is 12h) dwarfs any
+// suite run, so reuse is safe and mirrors how a real client behaves. It also
+// keeps the suite within the login endpoint's production rate limit (burst 5,
+// then one token every 3s per client IP): logging in afresh for each test would
+// trip HTTP 429 from 127.0.0.1 once the suite grew past the initial burst.
+func sharedAdminToken(t *testing.T) string {
 	t.Helper()
-	body, _ := json.Marshal(map[string]string{"username": username, "password": password})
-	resp, err := c.http.Post(c.base+"/api/v1/auth/login", "application/json", bytes.NewReader(body))
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equalf(t, http.StatusOK, resp.StatusCode, "login should succeed")
+	adminTokenOnce.Do(func() {
+		adminTokenVal, adminTokenErr = loginToken(h.webBaseURL, h.adminUser, h.adminPass)
+	})
+	require.NoError(t, adminTokenErr, "shared admin login should succeed")
+	require.NotEmpty(t, adminTokenVal, "shared admin login must return a token")
+	return adminTokenVal
+}
 
+// loginToken performs the real /auth/login round-trip and returns the bearer
+// token, so authenticated requests still flow through the production JWT
+// middleware chain.
+func loginToken(base, username, password string) (string, error) {
+	body, _ := json.Marshal(map[string]string{"username": username, "password": password})
+	resp, err := http.Post(base+"/api/v1/auth/login", "application/json", bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		msg, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("login status %d: %s", resp.StatusCode, string(msg))
+	}
 	var payload struct {
 		Data struct {
 			Token string `json:"token"`
 		} `json:"data"`
 	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&payload))
-	require.NotEmpty(t, payload.Data.Token, "login must return a token")
-	c.token = payload.Data.Token
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", err
+	}
+	if payload.Data.Token == "" {
+		return "", fmt.Errorf("login returned an empty token")
+	}
+	return payload.Data.Token, nil
 }
 
 // getJSON performs an authenticated GET and returns the raw response body.

--- a/test/integration/coa_test.go
+++ b/test/integration/coa_test.go
@@ -52,15 +52,32 @@ type itFakeNAS struct {
 	mu        sync.Mutex
 	replyCode radius.Code // 0 => drop the request (force a client timeout)
 	errCause  rfc3576.ErrorCause
+	replyAuth itReplyAuth // how the reply carries a Message-Authenticator
 	received  []radius.Code
 	badAuth   int // count of requests missing/failing Message-Authenticator
 }
+
+// itReplyAuth controls how the fake NAS signs its CoA/Disconnect reply, exercising
+// the RFC 5176 §3.4 reply-side Message-Authenticator paths in the Dynamic
+// Authorization Client.
+type itReplyAuth int
+
+const (
+	// itReplyAuthSigned attaches a valid Message-Authenticator (RFC 5176 §3.4). It
+	// is the zero value and the default so existing exchanges keep verifying.
+	itReplyAuthSigned itReplyAuth = iota
+	// itReplyAuthNone leaves the reply unsigned (no Message-Authenticator).
+	itReplyAuthNone
+	// itReplyAuthCorrupt attaches a present but invalid Message-Authenticator by
+	// signing with the wrong secret.
+	itReplyAuthCorrupt
+)
 
 func newITFakeNAS(t *testing.T, secret string, replyCode radius.Code, cause rfc3576.ErrorCause) *itFakeNAS {
 	t.Helper()
 	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
 	require.NoError(t, err)
-	fn := &itFakeNAS{addr: pc.LocalAddr().String(), secret: secret, replyCode: replyCode, errCause: cause}
+	fn := &itFakeNAS{addr: pc.LocalAddr().String(), secret: secret, replyCode: replyCode, errCause: cause, replyAuth: itReplyAuthSigned}
 	fn.server = &radius.PacketServer{
 		Handler:      radius.HandlerFunc(fn.handle),
 		SecretSource: radius.StaticSecretSource([]byte(secret)),
@@ -88,6 +105,7 @@ func (fn *itFakeNAS) handle(w radius.ResponseWriter, r *radius.Request) {
 	}
 	code := fn.replyCode
 	cause := fn.errCause
+	authMode := fn.replyAuth
 	fn.mu.Unlock()
 
 	if !present || !valid {
@@ -102,14 +120,32 @@ func (fn *itFakeNAS) handle(w radius.ResponseWriter, r *radius.Request) {
 	}
 	// Sign the reply (RFC 5176 §3.4) so the Dynamic Authorization Client can
 	// authenticate it. resp.Authenticator is the request authenticator, which is
-	// the value the client recomputes the reply digest with.
+	// the value the client recomputes the reply digest with. Tests can instead
+	// leave it unsigned or sign it with the wrong secret to drive the
+	// accept/discard paths.
+	switch authMode {
+	case itReplyAuthNone:
+		// leave the reply unsigned: the attribute is OPTIONAL on responses
+	case itReplyAuthCorrupt:
+		itSignReply(resp, fn.secret+"-wrong")
+	default: // itReplyAuthSigned
+		itSignReply(resp, fn.secret)
+	}
+	_ = w.Write(resp)
+}
+
+// itSignReply signs resp with a Message-Authenticator the way a NAS does per RFC
+// 5176 §3.4: the request authenticator (carried into resp.Authenticator by
+// r.Response) sits in the Authenticator field, the attribute value is treated as
+// sixteen zero octets for the HMAC-MD5, and the result is stored before the
+// transport computes the Response Authenticator.
+func itSignReply(resp *radius.Packet, secret string) {
 	_ = rfc2869.MessageAuthenticator_Set(resp, make([]byte, 16))
 	if b, err := resp.MarshalBinary(); err == nil {
-		mac := hmac.New(md5.New, resp.Secret)
+		mac := hmac.New(md5.New, []byte(secret))
 		mac.Write(b)
 		_ = rfc2869.MessageAuthenticator_Set(resp, mac.Sum(nil))
 	}
-	_ = w.Write(resp)
 }
 
 // itVerifyRequestMessageAuth verifies the Message-Authenticator on an inbound
@@ -156,6 +192,14 @@ func (fn *itFakeNAS) badAuthCount() int {
 	fn.mu.Lock()
 	defer fn.mu.Unlock()
 	return fn.badAuth
+}
+
+// setReplyAuth selects how the fake NAS signs its CoA/Disconnect reply so tests
+// can drive the RFC 5176 §3.4 reply-side accept/discard paths.
+func (fn *itFakeNAS) setReplyAuth(mode itReplyAuth) {
+	fn.mu.Lock()
+	defer fn.mu.Unlock()
+	fn.replyAuth = mode
 }
 
 // seedCoAOnlineSession inserts a NAS (reachable at 127.0.0.1:coaPort) and an
@@ -282,4 +326,59 @@ func TestSessionCoAEndToEnd_NAK(t *testing.T) {
 	assert.Equal(t, "CoA-NAK", audit.ResponseCode)
 	assert.Equal(t, int(rfc3576.ErrorCause_Value_UnsupportedAttribute), audit.ErrorCause)
 	assert.Equal(t, h.adminUser, audit.OperatorName)
+}
+
+// TestSessionDisconnectEndToEnd_UnsignedReplyAccepted proves that a NAS reply
+// without a Message-Authenticator is accepted: the attribute is OPTIONAL on
+// CoA/Disconnect responses (RFC 5176 §3.4), so the exchange still succeeds.
+func TestSessionDisconnectEndToEnd_UnsignedReplyAccepted(t *testing.T) {
+const secret = "it-coa-secret-unsigned"
+nas := newITFakeNAS(t, secret, radius.CodeDisconnectACK, 0)
+nas.setReplyAuth(itReplyAuthNone)
+id, username, acctSessionID := seedCoAOnlineSession(t, secret, nas.port(t))
+
+c := newAPIClient(t)
+status, body := c.post(t, "/api/v1/sessions/"+strconv.FormatInt(id, 10)+"/disconnect", nil)
+require.Equalf(t, 200, status, "disconnect body: %s", string(body))
+
+var action coaActionBody
+unwrapData(t, body, &action)
+assert.True(t, action.Success, "an unsigned reply must be accepted (RFC 5176 §3.4 reply MA is OPTIONAL)")
+assert.Equal(t, "Disconnect-ACK", action.ResponseCode)
+assert.Equal(t, username, action.Username)
+assert.Equal(t, acctSessionID, action.AcctSessionID)
+assert.False(t, action.TimedOut)
+assert.Equal(t, 1, nas.requestCount(), "an accepted reply ends the exchange on the first attempt")
+
+audit := latestAuditForSession(t, id)
+assert.Equal(t, "disconnect", audit.Action)
+assert.True(t, audit.Success)
+assert.Equal(t, "Disconnect-ACK", audit.ResponseCode)
+}
+
+// TestSessionDisconnectEndToEnd_ForgedReplyDiscarded proves that a NAS reply
+// carrying an invalid Message-Authenticator MUST be silently discarded (RFC 5176
+// §3.4). With every reply discarded the exchange reports success=false without
+// accepting a response code, and the discard is not a timeout.
+func TestSessionDisconnectEndToEnd_ForgedReplyDiscarded(t *testing.T) {
+const secret = "it-coa-secret-forged"
+nas := newITFakeNAS(t, secret, radius.CodeDisconnectACK, 0)
+nas.setReplyAuth(itReplyAuthCorrupt)
+id, _, _ := seedCoAOnlineSession(t, secret, nas.port(t))
+
+c := newAPIClient(t)
+status, body := c.post(t, "/api/v1/sessions/"+strconv.FormatInt(id, 10)+"/disconnect", nil)
+require.Equalf(t, 200, status, "disconnect body: %s", string(body))
+
+var action coaActionBody
+unwrapData(t, body, &action)
+assert.False(t, action.Success, "a reply with an invalid Message-Authenticator must be discarded")
+assert.Empty(t, action.ResponseCode, "no reply should be accepted")
+assert.False(t, action.TimedOut, "a discarded reply is not a timeout")
+assert.GreaterOrEqual(t, nas.requestCount(), 1, "the NAS received at least the initial request")
+assert.Equal(t, 0, nas.badAuthCount(), "the request itself carried a valid Message-Authenticator")
+
+audit := latestAuditForSession(t, id)
+assert.Equal(t, "disconnect", audit.Action)
+assert.False(t, audit.Success, "a discarded-reply exchange is audited as a failure")
 }


### PR DESCRIPTION
# Summary

Implements **M2.7**: the Dynamic Authorization Client now verifies the OPTIONAL `Message-Authenticator` on CoA / Disconnect **reply** packets (ACK/NAK) per **RFC 5176 §3.4**. A reply that carries the attribute MUST recompute and verify it, silently discarding the packet on mismatch; an absent attribute is accepted because it is optional on responses.

## Roadmap Mapping (Required for agent tasks)

- Milestone subtask: `M2.7`
- Feature ID(s): `TR-F010`
- Out-of-scope non-goals checked: `TR-N001` `TR-N002` `TR-N003` `TR-N004` `TR-N005`

## What Changed

- **`internal/radiusd/message_authenticator.go`** — add `verifyResponseMessageAuthenticator`. The reply digest is keyed on the corresponding request's **Request Authenticator** (RFC 5176 §3.4), not the Response Authenticator carried on the reply, and reuses `computeMessageAuthenticator`. Returns `msgAuthAbsent` (accept) when no attribute / nil packet, `msgAuthValid` when it verifies, `msgAuthInvalid` (discard) for a wrong/malformed/duplicated value. Presence is checked **before** the secret so an unsigned reply is accepted even without a secret, while a signed reply with nothing to verify against fails closed.
- **`internal/radiusd/coa_service.go`** — wire verification into `CoAService.send`. The request's on-wire Request Authenticator is precomputed once (`requestAuthenticator`) before the retransmission loop; an invalid reply is discarded, logged (`logDiscardedResponse`), and treated as an **unanswered attempt** so the retry budget keeps waiting for an authentic answer (RFC 5176 §2.3). Exhaustion surfaces `errResponseDiscarded` via `CoAResult.Err` and is **not** classified as a timeout (`CoAResult.TimedOut` stays false).
- **`internal/radiusd/coa_service_test.go`** — pure-function vectors (valid / absent / nil / tampered / wrong-reqAuth / wrong-length / duplicate / no-secret) plus end-to-end `fakeNAS` cases (signed accepted, unsigned accepted, forged discarded).
- **`test/integration/coa_test.go`** — `TestSessionDisconnectEndToEnd_UnsignedReplyAccepted` and `TestSessionDisconnectEndToEnd_ForgedReplyDiscarded`, driven through the real admin API → CoA service → fake NAS path against PostgreSQL.
- **`test/integration/client_test.go`** — cache a single admin JWT across the suite (server token TTL is 12h) instead of logging in per test. This keeps the growing API suite within the login endpoint's **production** rate limit (burst 5, then one token / 3s per client IP) without weakening that security control; logging in afresh per test was tripping HTTP 429 from 127.0.0.1.

## Acceptance Criteria Covered

- [x] The change only covers the mapped `TR-F` scope (`TR-F010`)
- [x] Protocol behavior updates include RFC clause references in code/tests/PR description (RFC 5176 §3.4, RFC 3579 §3.2)
- [x] Protocol or E2E behavior changes include CI-runnable acceptance tests under `test/integration/`

## Verification

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `golangci-lint run` (v2.12.2, CI-parity / no build tags) → **0 issues**
- [x] N/A `cd web && npm run build` (no frontend files changed)
- [x] Integration acceptance tests (`-tags integration`) pass against real PostgreSQL, including the two new CoA reply tests and the existing ACK/NAK exchanges (the latter now exercise the valid-MA reply path end-to-end). Full suite re-run twice — stable.

## Risks and Rollback

- Risk level: `low`
- Main risk: a NAS that signs replies with a non-conforming digest would now have its reply discarded. Mitigated because the attribute is OPTIONAL on responses (unsigned replies are still accepted) and the discard mirrors the mandatory §3.4 rule; only a *present but invalid* MA is dropped.
- Rollback plan: revert this commit; the change is isolated to the CoA reply path and two test files.

## Reviewer Notes

- Suggested review order: `internal/radiusd/message_authenticator.go` (new `verifyResponseMessageAuthenticator`) → `internal/radiusd/coa_service.go` (`send` wiring + `requestAuthenticator`/`logDiscardedResponse`) → `internal/radiusd/coa_service_test.go` → `test/integration/coa_test.go` → `test/integration/client_test.go`.
- Assumptions: `radius.Client.Exchange` already validates the **Response Authenticator** via the real secret, so the "forged reply" test signs the MA with a wrong secret while keeping the Response Authenticator valid, isolating the MA failure. `packet.Encode()` is deterministic and does not mutate the packet, so re-encoding reproduces the exact on-wire Request Authenticator.