### PR TITLE
docs(roadmap): mark M2.7 delivered (CoA reply Message-Authenticator)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -27,7 +27,7 @@
 | 里程碑 | 主题 | 关联编号 | 优先级 | 状态 |
 | --- | --- | --- | --- | --- |
 | M1 | EAP-TLS 认证支持 | TR-F004 | P1 | 已交付 |
-| M2 | CoA 动态授权支持 | TR-F010 / TR-F012 / TR-F013 | P1 | 已交付（含可选跟进 M2.7） |
+| M2 | CoA 动态授权支持 | TR-F010 / TR-F012 / TR-F013 | P1 | 已交付 |
 | M3 | IPv6 能力增强闭环 | TR-F007 / TR-F011 / TR-F015 | P1 | 已完成 |
 | M4 | Agent 开发体系与质量门禁 | TR-F022 | P2 | 进行中 |
 | M5 | 厂商 VSA 覆盖扩展 | TR-F005 | P2 | 进行中 |
@@ -101,7 +101,7 @@
 - [x] M2.5 单元/集成测试覆盖成功、超时、NAS 拒绝场景
 - [x] M2.6 在 `test/integration/` 增加 CoA/Disconnect 端到端验收用例（CI 自动执行）
 - [x] M2.6a（M2.1 后置加固，PR #440）出站 CoA-Request / Disconnect-Request 按 RFC 5176 §3.4 携带 Message-Authenticator（HMAC-MD5，RFC 3579 §3.2），复用 `internal/radiusd/message_authenticator.go` 的 `computeMessageAuthenticator`；严格 NAS（FreeRADIUS 风格）会静默丢弃未签名请求，故签名对互通性必需。单元用例验证两类请求均携带可校验的 MA，集成用例以「严格 NAS 丢弃未签名请求」背书。
-- [ ] M2.7（可选增强，不阻塞 M2 交付）校验 CoA / Disconnect **应答**（ACK/NAK）携带的 Message-Authenticator：RFC 5176 §3.4 规定应答侧该属性为 OPTIONAL（0-1），收到且校验失败的应答 MUST 静默丢弃、未携带则接受。来源：#440 落地出站请求签名时按最小闭环裁剪掉了应答侧校验（并移除手写 raw-MD5 重建以消除 CodeQL `go/weak-sensitive-data-hashing` 告警）。实现需复用 `message_authenticator.go` 的 HMAC-MD5 helper（应答摘要以请求的 Request Authenticator 替换应答 Authenticator 字段、MA 值清零计算），并补单元 + `test/integration/` 用例（含损坏 MA 被丢弃、未签名应答被接受两种向量）。关联 `TR-F010`。
+- [x] M2.7（可选增强，不阻塞 M2 交付）校验 CoA / Disconnect **应答**（ACK/NAK）携带的 Message-Authenticator：RFC 5176 §3.4 规定应答侧该属性为 OPTIONAL（0-1），收到且校验失败的应答 MUST 静默丢弃、未携带则接受。来源：#440 落地出站请求签名时按最小闭环裁剪掉了应答侧校验（并移除手写 raw-MD5 重建以消除 CodeQL `go/weak-sensitive-data-hashing` 告警）。实现需复用 `message_authenticator.go` 的 HMAC-MD5 helper（应答摘要以请求的 Request Authenticator 替换应答 Authenticator 字段、MA 值清零计算），并补单元 + `test/integration/` 用例（含损坏 MA 被丢弃、未签名应答被接受两种向量）。关联 `TR-F010`。**已交付（PR #447）**：新增 `verifyResponseMessageAuthenticator`（应答摘要以对应请求的 Request Authenticator 计算、MA 值清零，复用 `computeMessageAuthenticator`；属性缺失则接受、存在但校验失败则丢弃、无密钥可校验时失败关闭）；`CoAService.send` 对校验失败的应答按「未应答」处理并以相同 Identifier 重传，预算耗尽经 `errResponseDiscarded` 经 `CoAResult.Err` 暴露且不计为超时（`TimedOut=false`）；补纯函数向量 + fakeNAS 单元用例与 `test/integration/` 端到端用例（未签名应答被接受、伪造 MA 被丢弃）。RFC 5176 §3.4 / RFC 3579 §3.2。
 
 验收口径：可对在线用户安全发起动态授权；每次触发有可查询的结果记录；**验收由 `test/integration/` 的 CI 用例背书**。
 


### PR DESCRIPTION
# Summary

Roadmap grooming follow-up for **M2.7** — verify the OPTIONAL `Message-Authenticator` on CoA/Disconnect replies (RFC 5176 §3.4), which merged to `main` via **#447**. Docs-only.

## Roadmap Mapping (Required for agent tasks)

- Milestone subtask: `M2.7`
- Feature ID(s): `TR-F010`
- Out-of-scope non-goals checked: `TR-N001` `TR-N002` `TR-N003` `TR-N004` `TR-N005`

## What Changed

- `docs/roadmap.md`:
  - Check off `M2.7` (`- [ ]` → `- [x]`) and append a delivery note (impl summary + tests + RFC 5176 §3.4 / RFC 3579 §3.2, PR #447).
  - Update the M2 overview status from `已交付（含可选跟进 M2.7）` to `已交付` now that the optional follow-up is delivered.

No code, scope, or feature-checklist change: `TR-F010` is already **已交付 / Delivered (M2)** in both the CN and EN checklists, and M2.7 was an optional reply-side hardening under that already-delivered milestone — so the roadmap ↔ feature-checklist statuses remain consistent.

## Acceptance Criteria Covered

- [x] The change only covers the mapped `TR-F` scope (plan-doc grooming for `TR-F010` / M2.7)
- [x] Protocol behavior updates include RFC clause references (the delivery note cites RFC 5176 §3.4 / RFC 3579 §3.2; the protocol code + tests landed in #447)
- [x] N/A — no protocol/E2E code change here (acceptance tests landed in #447)

## Verification

- [x] N/A `go build ./...` (docs-only)
- [x] N/A `go test ./...` (docs-only)
- [x] N/A `golangci-lint run` (docs-only)
- [x] N/A `cd web && npm run build` (no frontend files changed)

## Risks and Rollback

- Risk level: `low`
- Main risk: none beyond a stale doc; the change is a checkbox + status text.
- Rollback plan: revert this commit.

## Reviewer Notes

- Suggested review order: `docs/roadmap.md` (overview table row M2; subtask M2.7).
- Assumptions: delivery is defined as "merged to `main` + CI green", satisfied by #447.
