### PR TITLE
feat(radius): add Radback request parser for M5.2 batch 1

### DIFF
--- a/internal/radiusd/plugins/vendorparsers/parsers/init.go
+++ b/internal/radiusd/plugins/vendorparsers/parsers/init.go
@@ -41,4 +41,11 @@ func init() {
 		Description: "ZTE RADIUS attributes",
 		Parser:      &ZTEParser{},
 	})
+
+	_ = vendors.Register(&vendors.VendorInfo{ //nolint:errcheck
+		Code:        vendors.CodeRadback,
+		Name:        "Radback",
+		Description: "Radback RADIUS attributes",
+		Parser:      &RadbackParser{},
+	})
 }

--- a/internal/radiusd/plugins/vendorparsers/parsers/radback_parser.go
+++ b/internal/radiusd/plugins/vendorparsers/parsers/radback_parser.go
@@ -1,0 +1,64 @@
+package parsers
+
+import (
+	"strings"
+
+	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/vendorparsers"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/vendors"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/vendors/radback"
+	"layeh.com/radius"
+	"layeh.com/radius/rfc2865"
+	"layeh.com/radius/rfc2869"
+)
+
+// RadbackParser handles Radback vendor attributes.
+//
+// Note: dictionary support is not parse support. Radback VSAs only affect
+// VendorRequest when this parser is registered and selected by NAS vendor code.
+type RadbackParser struct{}
+
+func (p *RadbackParser) VendorCode() string {
+	return vendors.CodeRadback
+}
+
+func (p *RadbackParser) VendorName() string {
+	return "Radback"
+}
+
+func (p *RadbackParser) Parse(r *radius.Request) (*vendorparsers.VendorRequest, error) {
+	vr := &vendorparsers.VendorRequest{}
+
+	// Radback request-side MAC is carried in VSA Mac-Addr (type 145). If absent,
+	// keep compatibility with the default parser and read Calling-Station-Id.
+	mac := strings.TrimSpace(radback.MacAddr_GetString(r.Packet))
+	if mac == "" {
+		mac = strings.TrimSpace(rfc2865.CallingStationID_GetString(r.Packet))
+	}
+	vr.MacAddr = normalizeMACAddress(mac)
+
+	// Bind-Dot1q-Vlan-Tag-Id (type 54) is the Radback request-side VLAN source.
+	// Fallback to shared NAS-Port-Id parsing when the VSA is not present.
+	vr.Vlanid1 = int64(radback.BindDot1qVlanTagID_Get(r.Packet))
+	if vr.Vlanid1 == 0 {
+		nasPortID := rfc2869.NASPortID_GetString(r.Packet)
+		vr.Vlanid1, vr.Vlanid2 = vendorparsers.ParseVlanIDs(nasPortID)
+	}
+
+	return vr, nil
+}
+
+func normalizeMACAddress(raw string) string {
+	mac := strings.ReplaceAll(raw, "-", ":")
+	if strings.Contains(mac, ":") || len(mac) != 12 {
+		return mac
+	}
+
+	return strings.Join([]string{
+		mac[0:2],
+		mac[2:4],
+		mac[4:6],
+		mac[6:8],
+		mac[8:10],
+		mac[10:12],
+	}, ":")
+}

--- a/internal/radiusd/plugins/vendorparsers/parsers/radback_parser_test.go
+++ b/internal/radiusd/plugins/vendorparsers/parsers/radback_parser_test.go
@@ -1,0 +1,118 @@
+package parsers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/vendors"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/vendors/radback"
+	"layeh.com/radius"
+	"layeh.com/radius/rfc2865"
+	"layeh.com/radius/rfc2869"
+)
+
+func TestRadbackParser_VendorCode(t *testing.T) {
+	parser := &RadbackParser{}
+	assert.Equal(t, vendors.CodeRadback, parser.VendorCode())
+}
+
+func TestRadbackParser_VendorName(t *testing.T) {
+	parser := &RadbackParser{}
+	assert.Equal(t, "Radback", parser.VendorName())
+}
+
+func TestRadbackParser_Parse(t *testing.T) {
+	parser := &RadbackParser{}
+
+	tests := []struct {
+		name           string
+		radbackMAC     string
+		callingStation string
+		vlanID         uint32
+		nasPortID      string
+		expectedMAC    string
+		expectedVlan1  int64
+		expectedVlan2  int64
+	}{
+		{
+			name:          "use radback mac and vlan",
+			radbackMAC:    "001122334455",
+			vlanID:        777,
+			expectedMAC:   "00:11:22:33:44:55",
+			expectedVlan1: 777,
+			expectedVlan2: 0,
+		},
+		{
+			name:           "fallback to calling station id",
+			callingStation: "aa-bb-cc-dd-ee-ff",
+			expectedMAC:    "aa:bb:cc:dd:ee:ff",
+			expectedVlan1:  0,
+			expectedVlan2:  0,
+		},
+		{
+			name:          "fallback vlan parse from nas-port-id",
+			radbackMAC:    "00-11-22-33-44-55",
+			nasPortID:     "3/0/1:2814.727",
+			expectedMAC:   "00:11:22:33:44:55",
+			expectedVlan1: 2814,
+			expectedVlan2: 727,
+		},
+		{
+			name:          "no attributes",
+			expectedMAC:   "",
+			expectedVlan1: 0,
+			expectedVlan2: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			packet := radius.New(radius.CodeAccessRequest, []byte("secret"))
+			if tt.radbackMAC != "" {
+				err := radback.MacAddr_SetString(packet, tt.radbackMAC)
+				require.NoError(t, err)
+			}
+			if tt.callingStation != "" {
+				err := rfc2865.CallingStationID_SetString(packet, tt.callingStation)
+				require.NoError(t, err)
+			}
+			if tt.vlanID > 0 {
+				err := radback.BindDot1qVlanTagID_Set(packet, radback.BindDot1qVlanTagID(tt.vlanID))
+				require.NoError(t, err)
+			}
+			if tt.nasPortID != "" {
+				err := rfc2869.NASPortID_SetString(packet, tt.nasPortID)
+				require.NoError(t, err)
+			}
+
+			req := &radius.Request{Packet: packet}
+			vr, err := parser.Parse(req)
+			require.NoError(t, err)
+			require.NotNil(t, vr)
+			assert.Equal(t, tt.expectedMAC, vr.MacAddr)
+			assert.Equal(t, tt.expectedVlan1, vr.Vlanid1)
+			assert.Equal(t, tt.expectedVlan2, vr.Vlanid2)
+		})
+	}
+}
+
+func TestNormalizeMACAddress(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		out  string
+	}{
+		{name: "empty", in: "", out: ""},
+		{name: "with dashes", in: "AA-BB-CC-DD-EE-FF", out: "AA:BB:CC:DD:EE:FF"},
+		{name: "with colons", in: "AA:BB:CC:DD:EE:FF", out: "AA:BB:CC:DD:EE:FF"},
+		{name: "twelve hex chars", in: "aabbccddeeff", out: "aa:bb:cc:dd:ee:ff"},
+		{name: "other format", in: "abc", out: "abc"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.out, normalizeMACAddress(tt.in))
+		})
+	}
+}


### PR DESCRIPTION
# Summary

## Roadmap Mapping (Required for agent tasks)

- Milestone subtask: `M5.2` (batch 1)
- Feature ID(s): `TR-F005`
- Out-of-scope non-goals checked: `TR-N001` `TR-N002` `TR-N003` `TR-N004` `TR-N005`

## What Changed

- Added `RadbackParser` to extract request-side MAC/VLAN for vendor code `2352`:
  - MAC source priority: `radback.MacAddr` VSA (type 145) -> fallback `Calling-Station-Id`.
  - VLAN source priority: `radback.BindDot1qVlanTagID` VSA (type 54) -> fallback shared `NAS-Port-Id` parsing.
- Registered the parser in `vendorparsers/parsers/init.go` so `vendors.GetParser(vendors.CodeRadback)` resolves to the new parser.
- Added parser sample tests covering Radback VSA extraction, fallback paths, and MAC normalization edge cases.

## Acceptance Criteria Covered

- [x] The change only covers the mapped `TR-F` scope
- [x] Protocol behavior updates include RFC clause references in code/tests/PR description (N/A: no protocol semantics changed)
- [x] Protocol or E2E behavior changes include CI-runnable acceptance tests under `test/integration/` (N/A: parser-only change with unit tests)

## Verification

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`
- [ ] `cd web && npm run build` (required only when frontend files changed)

## Risks and Rollback

- Risk level: `low`
- Main risk: Radback parser could override fallback parsing unexpectedly for NASes with malformed vendor MAC strings.
- Rollback plan: revert this PR to restore default-parser behavior for vendor `2352`.

## Reviewer Notes

- Suggested review order (files/modules):
  1. `internal/radiusd/plugins/vendorparsers/parsers/radback_parser.go`
  2. `internal/radiusd/plugins/vendorparsers/parsers/radback_parser_test.go`
  3. `internal/radiusd/plugins/vendorparsers/parsers/init.go`
- Open questions / assumptions:
  - This batch intentionally focuses on request-side parsing in M5.2; Radback response-side enhancer attributes will be handled in later batch if deployment requirements require vendor-specific Access-Accept VSAs.
