### PR TITLE
feat(radius): add alcatel request parser (M5.2)

### DIFF
--- a/internal/radiusd/plugins/vendorparsers/parsers/alcatel_parser.go
+++ b/internal/radiusd/plugins/vendorparsers/parsers/alcatel_parser.go
@@ -1,0 +1,44 @@
+package parsers
+
+import (
+	"strings"
+
+	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/vendorparsers"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/vendors"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/vendors/alcatel"
+	"layeh.com/radius"
+	"layeh.com/radius/rfc2865"
+	"layeh.com/radius/rfc2869"
+)
+
+// AlcatelParser parses Alcatel request attributes.
+//
+// Note: dictionary support is not parse support. Alcatel VSAs only affect
+// VendorRequest when this parser is registered and selected by NAS vendor code.
+type AlcatelParser struct{}
+
+func (p *AlcatelParser) VendorCode() string {
+	return vendors.CodeAlcatel
+}
+
+func (p *AlcatelParser) VendorName() string {
+	return "Alcatel"
+}
+
+func (p *AlcatelParser) Parse(r *radius.Request) (*vendorparsers.VendorRequest, error) {
+	vr := &vendorparsers.VendorRequest{}
+
+	// Alcatel request-side MAC is carried in AAT-User-MAC-Address (type 132). If
+	// absent, keep compatibility with the default parser behavior.
+	mac := strings.TrimSpace(alcatel.AATUserMACAddress_GetString(r.Packet))
+	if mac == "" {
+		mac = strings.TrimSpace(rfc2865.CallingStationID_GetString(r.Packet))
+	}
+	vr.MacAddr = normalizeMACAddress(mac)
+
+	// Alcatel request-side VLAN falls back to the shared NAS-Port-Id parser.
+	nasPortID := rfc2869.NASPortID_GetString(r.Packet)
+	vr.Vlanid1, vr.Vlanid2 = vendorparsers.ParseVlanIDs(nasPortID)
+
+	return vr, nil
+}

--- a/internal/radiusd/plugins/vendorparsers/parsers/alcatel_parser_test.go
+++ b/internal/radiusd/plugins/vendorparsers/parsers/alcatel_parser_test.go
@@ -1,0 +1,93 @@
+package parsers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/vendors"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/vendors/alcatel"
+	"layeh.com/radius"
+	"layeh.com/radius/rfc2865"
+	"layeh.com/radius/rfc2869"
+)
+
+func TestAlcatelParser_VendorCode(t *testing.T) {
+	parser := &AlcatelParser{}
+	assert.Equal(t, vendors.CodeAlcatel, parser.VendorCode())
+}
+
+func TestAlcatelParser_VendorName(t *testing.T) {
+	parser := &AlcatelParser{}
+	assert.Equal(t, "Alcatel", parser.VendorName())
+}
+
+func TestAlcatelParser_Parse(t *testing.T) {
+	parser := &AlcatelParser{}
+
+	tests := []struct {
+		name           string
+		alcatelMAC     string
+		callingStation string
+		nasPortID      string
+		expectedMAC    string
+		expectedVlan1  int64
+		expectedVlan2  int64
+	}{
+		{
+			name:          "use alcatel mac and parse vlan from nas-port-id",
+			alcatelMAC:    "001122334455",
+			nasPortID:     "3/0/1:2814.727",
+			expectedMAC:   "00:11:22:33:44:55",
+			expectedVlan1: 2814,
+			expectedVlan2: 727,
+		},
+		{
+			name:           "fallback to calling-station-id",
+			callingStation: "aa-bb-cc-dd-ee-ff",
+			expectedMAC:    "aa:bb:cc:dd:ee:ff",
+			expectedVlan1:  0,
+			expectedVlan2:  0,
+		},
+		{
+			name:           "prefer alcatel mac over calling-station-id",
+			alcatelMAC:     "11-22-33-44-55-66",
+			callingStation: "00-00-00-00-00-00",
+			expectedMAC:    "11:22:33:44:55:66",
+			expectedVlan1:  0,
+			expectedVlan2:  0,
+		},
+		{
+			name:          "no attributes",
+			expectedMAC:   "",
+			expectedVlan1: 0,
+			expectedVlan2: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			packet := radius.New(radius.CodeAccessRequest, []byte("secret"))
+			if tt.alcatelMAC != "" {
+				err := alcatel.AATUserMACAddress_SetString(packet, tt.alcatelMAC)
+				require.NoError(t, err)
+			}
+			if tt.callingStation != "" {
+				err := rfc2865.CallingStationID_SetString(packet, tt.callingStation)
+				require.NoError(t, err)
+			}
+			if tt.nasPortID != "" {
+				err := rfc2869.NASPortID_SetString(packet, tt.nasPortID)
+				require.NoError(t, err)
+			}
+
+			req := &radius.Request{Packet: packet}
+			vr, err := parser.Parse(req)
+			require.NoError(t, err)
+			require.NotNil(t, vr)
+			assert.Equal(t, tt.expectedMAC, vr.MacAddr)
+			assert.Equal(t, tt.expectedVlan1, vr.Vlanid1)
+			assert.Equal(t, tt.expectedVlan2, vr.Vlanid2)
+		})
+	}
+}

--- a/internal/radiusd/plugins/vendorparsers/parsers/init.go
+++ b/internal/radiusd/plugins/vendorparsers/parsers/init.go
@@ -48,4 +48,11 @@ func init() {
 		Description: "Radback RADIUS attributes",
 		Parser:      &RadbackParser{},
 	})
+
+	_ = vendors.Register(&vendors.VendorInfo{ //nolint:errcheck
+		Code:        vendors.CodeAlcatel,
+		Name:        "Alcatel",
+		Description: "Alcatel RADIUS attributes",
+		Parser:      &AlcatelParser{},
+	})
 }

--- a/internal/radiusd/vendors/codes.go
+++ b/internal/radiusd/vendors/codes.go
@@ -3,6 +3,7 @@ package vendors
 // Standard RADIUS Vendor Codes
 const (
 	CodeStandard  = "0"
+	CodeAlcatel   = "3041"
 	CodeCisco     = "9"
 	CodeMicrosoft = "311"
 	CodeHuawei    = "2011"


### PR DESCRIPTION
# Summary

## Roadmap Mapping (Required for agent tasks)

- Milestone subtask: `M5.2`
- Feature ID(s): `TR-F005`
- Out-of-scope non-goals checked: `TR-N001` `TR-N002` `TR-N003` `TR-N004` `TR-N005`

## What Changed

- Added `CodeAlcatel` vendor constant (`3041`) in `internal/radiusd/vendors/codes.go`.
- Added `AlcatelParser` at `internal/radiusd/plugins/vendorparsers/parsers/alcatel_parser.go`.
- Parser behavior:
  - Prefer request-side Alcatel VSA `AAT-User-MAC-Address`.
  - Fallback to standard `Calling-Station-Id` when vendor VSA is absent.
  - Parse VLAN IDs from `NAS-Port-Id` via shared `ParseVlanIDs` helper.
- Registered Alcatel parser in `internal/radiusd/plugins/vendorparsers/parsers/init.go`.
- Added sample-based parser tests in `alcatel_parser_test.go` covering vendor/fallback/no-attribute paths.

## Acceptance Criteria Covered

- [x] The change only covers the mapped `TR-F` scope
- [x] Protocol behavior updates include RFC clause references in code/tests/PR description (N/A: no protocol behavior change)
- [x] Protocol or E2E behavior changes include CI-runnable acceptance tests under `test/integration/` (N/A: parser-only change)

## Verification

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`
- [x] `cd web && npm run build` (required only when frontend files changed) (N/A: no frontend changes)

## Risks and Rollback

- Risk level: `low`
- Main risk: vendor selection by NAS code could bypass default parsing for misconfigured Alcatel NAS entries.
- Rollback plan: revert this PR commit to remove Alcatel parser registration and code constant.

## Reviewer Notes

- Suggested review order (files/modules):
  1. `internal/radiusd/plugins/vendorparsers/parsers/alcatel_parser.go`
  2. `internal/radiusd/plugins/vendorparsers/parsers/alcatel_parser_test.go`
  3. `internal/radiusd/plugins/vendorparsers/parsers/init.go`
  4. `internal/radiusd/vendors/codes.go`
- Open questions / assumptions:
  - This round focuses on request-side parsing only; response-side Alcatel enhancer is intentionally out of scope for this minimal M5.2 increment.
