### PR TITLE
feat(radius): add aruba request parser (M5.2)

### DIFF
--- a/internal/radiusd/plugins/vendorparsers/parsers/aruba_parser.go
+++ b/internal/radiusd/plugins/vendorparsers/parsers/aruba_parser.go
@@ -1,0 +1,44 @@
+package parsers
+
+import (
+	"strings"
+
+	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/vendorparsers"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/vendors"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/vendors/aruba"
+	"layeh.com/radius"
+	"layeh.com/radius/rfc2865"
+	"layeh.com/radius/rfc2869"
+)
+
+// ArubaParser parses Aruba request attributes.
+//
+// Note: dictionary support is not parse support. Aruba VSAs only affect
+// VendorRequest when this parser is registered and selected by NAS vendor code.
+type ArubaParser struct{}
+
+func (p *ArubaParser) VendorCode() string {
+	return vendors.CodeAruba
+}
+
+func (p *ArubaParser) VendorName() string {
+	return "Aruba"
+}
+
+func (p *ArubaParser) Parse(r *radius.Request) (*vendorparsers.VendorRequest, error) {
+	vr := &vendorparsers.VendorRequest{}
+
+	// Aruba request-side MAC usually remains in standard Calling-Station-Id.
+	mac := strings.TrimSpace(rfc2865.CallingStationID_GetString(r.Packet))
+	vr.MacAddr = normalizeMACAddress(mac)
+
+	// Aruba request-side VLAN uses Aruba-User-Vlan (type 2). When absent, keep
+	// compatibility with shared NAS-Port-Id parsing.
+	vr.Vlanid1 = int64(aruba.ArubaUserVlan_Get(r.Packet))
+	if vr.Vlanid1 == 0 {
+		nasPortID := rfc2869.NASPortID_GetString(r.Packet)
+		vr.Vlanid1, vr.Vlanid2 = vendorparsers.ParseVlanIDs(nasPortID)
+	}
+
+	return vr, nil
+}

--- a/internal/radiusd/plugins/vendorparsers/parsers/aruba_parser_test.go
+++ b/internal/radiusd/plugins/vendorparsers/parsers/aruba_parser_test.go
@@ -1,0 +1,96 @@
+package parsers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/vendors"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/vendors/aruba"
+	"layeh.com/radius"
+	"layeh.com/radius/rfc2865"
+	"layeh.com/radius/rfc2869"
+)
+
+func TestArubaParser_VendorCode(t *testing.T) {
+	parser := &ArubaParser{}
+	assert.Equal(t, vendors.CodeAruba, parser.VendorCode())
+}
+
+func TestArubaParser_VendorName(t *testing.T) {
+	parser := &ArubaParser{}
+	assert.Equal(t, "Aruba", parser.VendorName())
+}
+
+func TestArubaParser_Parse(t *testing.T) {
+	parser := &ArubaParser{}
+
+	tests := []struct {
+		name           string
+		callingStation string
+		arubaVLAN      uint32
+		nasPortID      string
+		expectedMAC    string
+		expectedVlan1  int64
+		expectedVlan2  int64
+	}{
+		{
+			name:           "use aruba user vlan and normalize mac",
+			callingStation: "001122334455",
+			arubaVLAN:      120,
+			expectedMAC:    "00:11:22:33:44:55",
+			expectedVlan1:  120,
+			expectedVlan2:  0,
+		},
+		{
+			name:           "fallback vlan parse from nas-port-id",
+			callingStation: "aa-bb-cc-dd-ee-ff",
+			nasPortID:      "3/0/1:2814.727",
+			expectedMAC:    "aa:bb:cc:dd:ee:ff",
+			expectedVlan1:  2814,
+			expectedVlan2:  727,
+		},
+		{
+			name:           "prefer aruba user vlan over nas-port-id",
+			callingStation: "11-22-33-44-55-66",
+			arubaVLAN:      100,
+			nasPortID:      "3/0/1:2814.727",
+			expectedMAC:    "11:22:33:44:55:66",
+			expectedVlan1:  100,
+			expectedVlan2:  0,
+		},
+		{
+			name:          "no attributes",
+			expectedMAC:   "",
+			expectedVlan1: 0,
+			expectedVlan2: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			packet := radius.New(radius.CodeAccessRequest, []byte("secret"))
+
+			if tt.callingStation != "" {
+				err := rfc2865.CallingStationID_SetString(packet, tt.callingStation)
+				require.NoError(t, err)
+			}
+			if tt.arubaVLAN > 0 {
+				err := aruba.ArubaUserVlan_Set(packet, aruba.ArubaUserVlan(tt.arubaVLAN))
+				require.NoError(t, err)
+			}
+			if tt.nasPortID != "" {
+				err := rfc2869.NASPortID_SetString(packet, tt.nasPortID)
+				require.NoError(t, err)
+			}
+
+			req := &radius.Request{Packet: packet}
+			vr, err := parser.Parse(req)
+			require.NoError(t, err)
+			require.NotNil(t, vr)
+			assert.Equal(t, tt.expectedMAC, vr.MacAddr)
+			assert.Equal(t, tt.expectedVlan1, vr.Vlanid1)
+			assert.Equal(t, tt.expectedVlan2, vr.Vlanid2)
+		})
+	}
+}

--- a/internal/radiusd/plugins/vendorparsers/parsers/init.go
+++ b/internal/radiusd/plugins/vendorparsers/parsers/init.go
@@ -55,4 +55,11 @@ func init() {
 		Description: "Alcatel RADIUS attributes",
 		Parser:      &AlcatelParser{},
 	})
+
+	_ = vendors.Register(&vendors.VendorInfo{ //nolint:errcheck
+		Code:        vendors.CodeAruba,
+		Name:        "Aruba",
+		Description: "Aruba RADIUS attributes",
+		Parser:      &ArubaParser{},
+	})
 }

--- a/internal/radiusd/vendors/codes.go
+++ b/internal/radiusd/vendors/codes.go
@@ -4,6 +4,7 @@ package vendors
 const (
 	CodeStandard  = "0"
 	CodeAlcatel   = "3041"
+	CodeAruba     = "14823"
 	CodeCisco     = "9"
 	CodeMicrosoft = "311"
 	CodeHuawei    = "2011"


### PR DESCRIPTION
# Summary

## Roadmap Mapping (Required for agent tasks)

- Milestone subtask: `M5.2`
- Feature ID(s): `TR-F005`
- Out-of-scope non-goals checked: `TR-N001` `TR-N002` `TR-N003` `TR-N004` `TR-N005`

## What Changed

- Added `CodeAruba` vendor constant (`14823`) in `internal/radiusd/vendors/codes.go`.
- Added `ArubaParser` at `internal/radiusd/plugins/vendorparsers/parsers/aruba_parser.go`.
- Parser behavior:
  - Parse MAC from standard `Calling-Station-Id` (normalized with shared MAC helper).
  - Parse request VLAN from Aruba VSA `Aruba-User-Vlan`.
  - Fallback to shared `NAS-Port-Id` parsing when Aruba VSA is absent.
- Registered Aruba parser in `internal/radiusd/plugins/vendorparsers/parsers/init.go`.
- Added sample-based parser tests in `aruba_parser_test.go` covering Aruba-VLAN, fallback, precedence, and empty attributes.

## Acceptance Criteria Covered

- [x] The change only covers the mapped `TR-F` scope
- [x] Protocol behavior updates include RFC clause references in code/tests/PR description (N/A: parser-only change)
- [x] Protocol or E2E behavior changes include CI-runnable acceptance tests under `test/integration/` (N/A: parser-only change)

## Verification

- [x] `go build ./...`
- [x] `go test ./internal/radiusd/...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`
- [x] `cd web && npm run build` (required only when frontend files changed) (N/A: no frontend changes)

## Risks and Rollback

- Risk level: `low`
- Main risk: some Aruba deployments may still encode VLAN only in NAS-Port-Id; parser keeps fallback to preserve compatibility.
- Rollback plan: revert this PR commit to remove Aruba parser registration and vendor code constant.

## Reviewer Notes

- Suggested review order (files/modules):
  1. `internal/radiusd/plugins/vendorparsers/parsers/aruba_parser.go`
  2. `internal/radiusd/plugins/vendorparsers/parsers/aruba_parser_test.go`
  3. `internal/radiusd/plugins/vendorparsers/parsers/init.go`
  4. `internal/radiusd/vendors/codes.go`
- Open questions / assumptions:
  - This round focuses on request parser support only; Aruba Access-Accept enhancer remains out of scope for this minimal M5.2 increment.
