### PR TITLE
feat(radius): add juniper request parser for voip vlan

### DIFF
--- a/internal/radiusd/plugins/vendorparsers/parsers/init.go
+++ b/internal/radiusd/plugins/vendorparsers/parsers/init.go
@@ -62,4 +62,11 @@ func init() {
 		Description: "Aruba RADIUS attributes",
 		Parser:      &ArubaParser{},
 	})
+
+	_ = vendors.Register(&vendors.VendorInfo{ //nolint:errcheck
+		Code:        vendors.CodeJuniper,
+		Name:        "Juniper",
+		Description: "Juniper RADIUS attributes",
+		Parser:      &JuniperParser{},
+	})
 }

--- a/internal/radiusd/plugins/vendorparsers/parsers/juniper_parser.go
+++ b/internal/radiusd/plugins/vendorparsers/parsers/juniper_parser.go
@@ -1,0 +1,50 @@
+package parsers
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/vendorparsers"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/vendors"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/vendors/juniper"
+	"layeh.com/radius"
+	"layeh.com/radius/rfc2865"
+	"layeh.com/radius/rfc2869"
+)
+
+// JuniperParser parses Juniper request attributes.
+//
+// Note: dictionary support is not parse support. Juniper VSAs only affect
+// VendorRequest when this parser is registered and selected by NAS vendor code.
+type JuniperParser struct{}
+
+func (p *JuniperParser) VendorCode() string {
+	return vendors.CodeJuniper
+}
+
+func (p *JuniperParser) VendorName() string {
+	return "Juniper"
+}
+
+func (p *JuniperParser) Parse(r *radius.Request) (*vendorparsers.VendorRequest, error) {
+	vr := &vendorparsers.VendorRequest{}
+
+	// Juniper request-side MAC typically remains in Calling-Station-Id.
+	mac := strings.TrimSpace(rfc2865.CallingStationID_GetString(r.Packet))
+	vr.MacAddr = normalizeMACAddress(mac)
+
+	// Juniper request-side VLAN can be carried in Juniper-VoIP-Vlan (type 49).
+	// If absent or malformed, keep compatibility with shared NAS-Port-Id parsing.
+	vlan := strings.TrimSpace(juniper.JuniperVoIPVlan_GetString(r.Packet))
+	if vlan != "" {
+		if id, err := strconv.ParseInt(vlan, 10, 64); err == nil && id > 0 {
+			vr.Vlanid1 = id
+			return vr, nil
+		}
+	}
+
+	nasPortID := rfc2869.NASPortID_GetString(r.Packet)
+	vr.Vlanid1, vr.Vlanid2 = vendorparsers.ParseVlanIDs(nasPortID)
+
+	return vr, nil
+}

--- a/internal/radiusd/plugins/vendorparsers/parsers/juniper_parser_test.go
+++ b/internal/radiusd/plugins/vendorparsers/parsers/juniper_parser_test.go
@@ -1,0 +1,105 @@
+package parsers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/vendors"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/vendors/juniper"
+	"layeh.com/radius"
+	"layeh.com/radius/rfc2865"
+	"layeh.com/radius/rfc2869"
+)
+
+func TestJuniperParser_VendorCode(t *testing.T) {
+	parser := &JuniperParser{}
+	assert.Equal(t, vendors.CodeJuniper, parser.VendorCode())
+}
+
+func TestJuniperParser_VendorName(t *testing.T) {
+	parser := &JuniperParser{}
+	assert.Equal(t, "Juniper", parser.VendorName())
+}
+
+func TestJuniperParser_Parse(t *testing.T) {
+	parser := &JuniperParser{}
+
+	tests := []struct {
+		name           string
+		callingStation string
+		voipVLAN       string
+		nasPortID      string
+		expectedMAC    string
+		expectedVlan1  int64
+		expectedVlan2  int64
+	}{
+		{
+			name:           "use juniper voip vlan and normalize mac",
+			callingStation: "001122334455",
+			voipVLAN:       "120",
+			expectedMAC:    "00:11:22:33:44:55",
+			expectedVlan1:  120,
+			expectedVlan2:  0,
+		},
+		{
+			name:           "fallback vlan parse from nas-port-id when voip vlan is missing",
+			callingStation: "aa-bb-cc-dd-ee-ff",
+			nasPortID:      "3/0/1:2814.727",
+			expectedMAC:    "aa:bb:cc:dd:ee:ff",
+			expectedVlan1:  2814,
+			expectedVlan2:  727,
+		},
+		{
+			name:           "fallback vlan parse from nas-port-id when voip vlan is malformed",
+			callingStation: "11-22-33-44-55-66",
+			voipVLAN:       "voice-200",
+			nasPortID:      "3/0/1:400.12",
+			expectedMAC:    "11:22:33:44:55:66",
+			expectedVlan1:  400,
+			expectedVlan2:  12,
+		},
+		{
+			name:           "prefer juniper voip vlan over nas-port-id",
+			callingStation: "11-22-33-44-55-66",
+			voipVLAN:       "100",
+			nasPortID:      "3/0/1:2814.727",
+			expectedMAC:    "11:22:33:44:55:66",
+			expectedVlan1:  100,
+			expectedVlan2:  0,
+		},
+		{
+			name:          "no attributes",
+			expectedMAC:   "",
+			expectedVlan1: 0,
+			expectedVlan2: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			packet := radius.New(radius.CodeAccessRequest, []byte("secret"))
+
+			if tt.callingStation != "" {
+				err := rfc2865.CallingStationID_SetString(packet, tt.callingStation)
+				require.NoError(t, err)
+			}
+			if tt.voipVLAN != "" {
+				err := juniper.JuniperVoIPVlan_SetString(packet, tt.voipVLAN)
+				require.NoError(t, err)
+			}
+			if tt.nasPortID != "" {
+				err := rfc2869.NASPortID_SetString(packet, tt.nasPortID)
+				require.NoError(t, err)
+			}
+
+			req := &radius.Request{Packet: packet}
+			vr, err := parser.Parse(req)
+			require.NoError(t, err)
+			require.NotNil(t, vr)
+			assert.Equal(t, tt.expectedMAC, vr.MacAddr)
+			assert.Equal(t, tt.expectedVlan1, vr.Vlanid1)
+			assert.Equal(t, tt.expectedVlan2, vr.Vlanid2)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add `JuniperParser` to extract request MAC and parse VLAN from `Juniper-VoIP-Vlan` (fallback to `NAS-Port-Id` on missing/malformed values)
- register Juniper parser in vendor parser registry init
- add sample-based parser tests covering VSA-first path, fallback path, malformed VSA fallback, and parser identity metadata

## Milestone / Feature
- Milestone: M5.2
- Feature: TR-F005

## Verification
- `go build ./...`
- `go test ./internal/radiusd/plugins/vendorparsers/parsers -run Juniper -count=1`
- `go test ./internal/radiusd/... -count=1`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`
