### PR TITLE
feat(radius): add aruba access-accept enhancer (M5.3)

### DIFF
--- a/internal/radiusd/plugins/auth/enhancers/aruba_enhancer.go
+++ b/internal/radiusd/plugins/auth/enhancers/aruba_enhancer.go
@@ -1,0 +1,79 @@
+package enhancers
+
+import (
+	"context"
+
+	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/auth"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/vendors"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/vendors/aruba"
+	"github.com/talkincode/toughradius/v9/pkg/common"
+)
+
+// arubaMaxVLANID is the largest assignable IEEE 802.1Q VLAN ID. VLAN 0 and 4095
+// are reserved, so a valid subscriber VLAN is 1..4094. Bounding Vlanid1 to this
+// range both enforces a valid 802.1Q tag and keeps the int->uint32 conversion in
+// Enhance safe from overflow.
+const arubaMaxVLANID = 4094
+
+// ArubaAcceptEnhancer adds Aruba's canonical Access-Accept policy attributes for
+// sessions terminating on an Aruba/HPE NAS (SMI Private Enterprise Code 14823).
+type ArubaAcceptEnhancer struct{}
+
+// NewArubaAcceptEnhancer returns an ArubaAcceptEnhancer ready for registration.
+func NewArubaAcceptEnhancer() *ArubaAcceptEnhancer {
+	return &ArubaAcceptEnhancer{}
+}
+
+// Name returns the response-enhancer registry key for the Aruba enhancer.
+func (e *ArubaAcceptEnhancer) Name() string {
+	return "accept-aruba"
+}
+
+// Enhance appends Aruba's primary policy attributes to the Access-Accept:
+//
+//   - Aruba-User-Vlan (type 2, integer): the subscriber's assigned VLAN, taken
+//     from the user's configured Vlanid1. Aruba controllers honor this attribute
+//     to place the client into a RADIUS-assigned VLAN. Only a valid 802.1Q ID
+//     (1..4094) is emitted; Vlanid2 (typically the QinQ outer tag) has no
+//     Aruba-User-Vlan equivalent and is intentionally not sent.
+//   - Aruba-User-Role (type 1, string): the subscriber's firewall/user role,
+//     sourced from the generic Domain vendor-policy field via GetDomain (so it
+//     honors profile inheritance). This mirrors the Huawei enhancer, which maps
+//     the same Domain field to Huawei-Domain-Name: in both cases Domain carries
+//     the NAS-specific primary policy selector.
+//
+// Enhance is a no-op for a nil context/response/user, for non-Aruba NAS devices,
+// and when the source fields are unset, so it never mutates an Access-Accept it
+// does not own.
+func (e *ArubaAcceptEnhancer) Enhance(ctx context.Context, authCtx *auth.AuthContext) error {
+	if authCtx == nil || authCtx.Response == nil || authCtx.User == nil {
+		return nil
+	}
+	if !matchVendor(authCtx, vendors.CodeAruba) {
+		return nil
+	}
+
+	user := authCtx.User
+	resp := authCtx.Response
+
+	// Get profile cache from metadata
+	var profileCache interface{}
+	if authCtx.Metadata != nil {
+		profileCache = authCtx.Metadata["profile_cache"]
+	}
+
+	// Aruba-User-Vlan: assign the subscriber VLAN when a valid 802.1Q ID is
+	// configured. The 1..4094 bound also keeps the int->uint32 conversion safe.
+	if vlan := user.Vlanid1; vlan >= 1 && vlan <= arubaMaxVLANID {
+		_ = aruba.ArubaUserVlan_Set(resp, aruba.ArubaUserVlan(vlan)) //nolint:errcheck,gosec // G115: vlan is bounded to 1..4094 above
+	}
+
+	// Aruba-User-Role: reuse the generic Domain vendor-policy field as the Aruba
+	// user role, mirroring the Huawei enhancer's Domain->Huawei-Domain-Name map.
+	role := user.GetDomain(profileCache)
+	if common.IsNotEmptyAndNA(role) {
+		_ = aruba.ArubaUserRole_SetString(resp, role) //nolint:errcheck
+	}
+
+	return nil
+}

--- a/internal/radiusd/plugins/auth/enhancers/aruba_enhancer_test.go
+++ b/internal/radiusd/plugins/auth/enhancers/aruba_enhancer_test.go
@@ -114,14 +114,15 @@ func TestArubaAcceptEnhancer_Enhance_UserVlan(t *testing.T) {
 	tests := []struct {
 		name         string
 		vlanid1      int
-		expectedVlan uint32 // 0 means the attribute must be absent
+		expectVlan   uint32
+		expectAbsent bool // attribute must not be present at all
 	}{
-		{name: "valid access vlan", vlanid1: 200, expectedVlan: 200},
-		{name: "lowest valid vlan", vlanid1: 1, expectedVlan: 1},
-		{name: "highest valid vlan", vlanid1: arubaMaxVLANID, expectedVlan: arubaMaxVLANID},
-		{name: "zero vlan skipped", vlanid1: 0, expectedVlan: 0},
-		{name: "reserved 4095 skipped", vlanid1: 4095, expectedVlan: 0},
-		{name: "negative vlan skipped", vlanid1: -1, expectedVlan: 0},
+		{name: "valid access vlan", vlanid1: 200, expectVlan: 200},
+		{name: "lowest valid vlan", vlanid1: 1, expectVlan: 1},
+		{name: "highest valid vlan", vlanid1: arubaMaxVLANID, expectVlan: arubaMaxVLANID},
+		{name: "zero vlan skipped", vlanid1: 0, expectAbsent: true},
+		{name: "reserved 4095 skipped", vlanid1: 4095, expectAbsent: true},
+		{name: "negative vlan skipped", vlanid1: -1, expectAbsent: true},
 	}
 
 	for _, tt := range tests {
@@ -142,7 +143,15 @@ func TestArubaAcceptEnhancer_Enhance_UserVlan(t *testing.T) {
 			err := enhancer.Enhance(ctx, authCtx)
 			require.NoError(t, err)
 
-			assert.Equal(t, tt.expectedVlan, uint32(aruba.ArubaUserVlan_Get(response)))
+			// Use Lookup so a skipped VLAN asserts true absence, not the zero
+			// value that Get cannot distinguish from a present "0".
+			vlan, lookupErr := aruba.ArubaUserVlan_Lookup(response)
+			if tt.expectAbsent {
+				assert.ErrorIs(t, lookupErr, radius.ErrNoAttribute)
+			} else {
+				require.NoError(t, lookupErr)
+				assert.Equal(t, tt.expectVlan, uint32(vlan))
+			}
 		})
 	}
 }

--- a/internal/radiusd/plugins/auth/enhancers/aruba_enhancer_test.go
+++ b/internal/radiusd/plugins/auth/enhancers/aruba_enhancer_test.go
@@ -1,0 +1,185 @@
+package enhancers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/talkincode/toughradius/v9/internal/domain"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/auth"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/vendors"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/vendors/aruba"
+	"layeh.com/radius"
+)
+
+func TestArubaAcceptEnhancer_Name(t *testing.T) {
+	enhancer := NewArubaAcceptEnhancer()
+	assert.Equal(t, "accept-aruba", enhancer.Name())
+}
+
+func TestArubaAcceptEnhancer_Enhance_NilSafety(t *testing.T) {
+	enhancer := NewArubaAcceptEnhancer()
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		authCtx *auth.AuthContext
+	}{
+		{
+			name:    "nil context",
+			authCtx: nil,
+		},
+		{
+			name: "nil response",
+			authCtx: &auth.AuthContext{
+				User: &domain.RadiusUser{},
+			},
+		},
+		{
+			name: "nil user",
+			authCtx: &auth.AuthContext{
+				Response: radius.New(radius.CodeAccessAccept, []byte("secret")),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := enhancer.Enhance(ctx, tt.authCtx)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestArubaAcceptEnhancer_Enhance_VendorMatch(t *testing.T) {
+	enhancer := NewArubaAcceptEnhancer()
+	ctx := context.Background()
+
+	tests := []struct {
+		name          string
+		vendorCode    string
+		shouldEnhance bool
+	}{
+		{
+			name:          "aruba vendor",
+			vendorCode:    vendors.CodeAruba,
+			shouldEnhance: true,
+		},
+		{
+			name:          "other vendor",
+			vendorCode:    vendors.CodeHuawei,
+			shouldEnhance: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response := radius.New(radius.CodeAccessAccept, []byte("secret"))
+			user := &domain.RadiusUser{
+				Username: "testuser",
+				Vlanid1:  120,
+				Domain:   "guest-role",
+			}
+			nas := &domain.NetNas{
+				VendorCode: tt.vendorCode,
+			}
+
+			authCtx := &auth.AuthContext{
+				Response: response,
+				User:     user,
+				Nas:      nas,
+			}
+
+			err := enhancer.Enhance(ctx, authCtx)
+			require.NoError(t, err)
+
+			vlan := aruba.ArubaUserVlan_Get(response)
+			role := aruba.ArubaUserRole_GetString(response)
+			if tt.shouldEnhance {
+				assert.Equal(t, uint32(120), uint32(vlan))
+				assert.Equal(t, "guest-role", role)
+			} else {
+				assert.Equal(t, uint32(0), uint32(vlan))
+				assert.Equal(t, "", role)
+			}
+		})
+	}
+}
+
+func TestArubaAcceptEnhancer_Enhance_UserVlan(t *testing.T) {
+	enhancer := NewArubaAcceptEnhancer()
+	ctx := context.Background()
+
+	tests := []struct {
+		name         string
+		vlanid1      int
+		expectedVlan uint32 // 0 means the attribute must be absent
+	}{
+		{name: "valid access vlan", vlanid1: 200, expectedVlan: 200},
+		{name: "lowest valid vlan", vlanid1: 1, expectedVlan: 1},
+		{name: "highest valid vlan", vlanid1: arubaMaxVLANID, expectedVlan: arubaMaxVLANID},
+		{name: "zero vlan skipped", vlanid1: 0, expectedVlan: 0},
+		{name: "reserved 4095 skipped", vlanid1: 4095, expectedVlan: 0},
+		{name: "negative vlan skipped", vlanid1: -1, expectedVlan: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response := radius.New(radius.CodeAccessAccept, []byte("secret"))
+			user := &domain.RadiusUser{
+				Username: "testuser",
+				Vlanid1:  tt.vlanid1,
+			}
+			nas := &domain.NetNas{VendorCode: vendors.CodeAruba}
+
+			authCtx := &auth.AuthContext{
+				Response: response,
+				User:     user,
+				Nas:      nas,
+			}
+
+			err := enhancer.Enhance(ctx, authCtx)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expectedVlan, uint32(aruba.ArubaUserVlan_Get(response)))
+		})
+	}
+}
+
+func TestArubaAcceptEnhancer_Enhance_UserRole(t *testing.T) {
+	enhancer := NewArubaAcceptEnhancer()
+	ctx := context.Background()
+
+	tests := []struct {
+		name         string
+		domain       string
+		expectedRole string // "" means the attribute must be absent
+	}{
+		{name: "role from domain", domain: "employee", expectedRole: "employee"},
+		{name: "empty domain skipped", domain: "", expectedRole: ""},
+		{name: "NA domain skipped", domain: "N/A", expectedRole: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response := radius.New(radius.CodeAccessAccept, []byte("secret"))
+			user := &domain.RadiusUser{
+				Username: "testuser",
+				Domain:   tt.domain,
+			}
+			nas := &domain.NetNas{VendorCode: vendors.CodeAruba}
+
+			authCtx := &auth.AuthContext{
+				Response: response,
+				User:     user,
+				Nas:      nas,
+			}
+
+			err := enhancer.Enhance(ctx, authCtx)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expectedRole, aruba.ArubaUserRole_GetString(response))
+		})
+	}
+}

--- a/internal/radiusd/plugins/init.go
+++ b/internal/radiusd/plugins/init.go
@@ -40,6 +40,7 @@ func InitPlugins(appCtx app.ConfigManagerProvider, sessionRepo repository.Sessio
 	registry.RegisterResponseEnhancer(enhancers.NewZTEAcceptEnhancer())
 	registry.RegisterResponseEnhancer(enhancers.NewMikrotikAcceptEnhancer())
 	registry.RegisterResponseEnhancer(enhancers.NewIkuaiAcceptEnhancer())
+	registry.RegisterResponseEnhancer(enhancers.NewArubaAcceptEnhancer())
 
 	// Register authentication guards
 	var cfgGetter interface{ GetInt64(string, string) int64 }


### PR DESCRIPTION
# Summary

## Roadmap Mapping (Required for agent tasks)

- Milestone subtask: `M5.3` (厂商样例包覆盖解析与响应属性)
- Feature ID(s): `TR-F005`
- Out-of-scope non-goals checked: `TR-N001` `TR-N002` `TR-N003` `TR-N004` `TR-N005`

## What Changed

M5.2 delivered Aruba's **request-side** parser; this round adds the matching **response-side** enhancer so an Aruba/HPE NAS (SMI Private Enterprise Code `14823`) receives its canonical Access-Accept policy VSAs.

- Added `ArubaAcceptEnhancer` at `internal/radiusd/plugins/auth/enhancers/aruba_enhancer.go`:
  - **`Aruba-User-Vlan`** (type 2, integer) ← the user's configured `Vlanid1`. Emitted only for a valid 802.1Q ID (`1..4094`); `Vlanid2` (typically the QinQ outer tag) has no `Aruba-User-Vlan` equivalent and is intentionally not sent. The `1..4094` bound also keeps the `int`→`uint32` conversion overflow-safe (no unchecked G115).
  - **`Aruba-User-Role`** (type 1, string) ← the generic `Domain` vendor-policy field via `GetDomain` (honoring profile inheritance). This mirrors the existing **Huawei** enhancer, which maps the same `Domain` field to `Huawei-Domain-Name` — in both cases `Domain` carries the NAS-specific primary policy selector.
  - No-op for nil context/response/user, for non-Aruba NAS devices, and when the source fields are unset, so it never mutates an Access-Accept it does not own.
- Registered the enhancer in `internal/radiusd/plugins/init.go` (alongside the existing default/huawei/h3c/zte/mikrotik/ikuai enhancers).
- Added sample-based tests in `aruba_enhancer_test.go` covering name, nil-safety, vendor match/no-match, VLAN bounds (valid / lowest / highest / zero / reserved `4095` / negative), and role sourcing (value / empty / `N/A`).

## Acceptance Criteria Covered

- [x] The change only covers the mapped `TR-F` scope
- [x] Protocol behavior updates include RFC clause references in code/tests/PR description (Aruba VSAs are vendor-proprietary under the RFC 2865 §5.26 Vendor-Specific framework; the enhancer doc notes the SMI Private Enterprise Code 14823)
- [x] Protocol or E2E behavior changes include CI-runnable acceptance tests under `test/integration/` (N/A: vendor response-VSA enhancer, unit-tested like the existing 5 enhancers per `add-radius-vendor` SOP)

## Verification

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run` (0 issues)
- [x] `cd web && npm run build` (N/A: no frontend changes)

## Risks and Rollback

- Risk level: `low`
- Main risk: emitting `Aruba-User-Vlan`/`Aruba-User-Role` only when the user has those fields configured; behavior is purely additive to the Access-Accept and gated on the NAS vendor code, so non-Aruba sessions are unaffected.
- Rollback plan: revert this commit to remove the enhancer registration and file.

## Reviewer Notes

- Suggested review order: `internal/radiusd/plugins/auth/enhancers/aruba_enhancer.go` → `internal/radiusd/plugins/init.go` → `aruba_enhancer_test.go`.
- Open questions / assumptions: `Domain`→`Aruba-User-Role` reuses the same generic vendor-policy field the Huawei enhancer already maps to `Huawei-Domain-Name`; VLAN assignment sources the user's primary `Vlanid1`.