### PR TITLE
docs: fix README documentation links (#457)

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,10 +162,10 @@ Default Admin Account:
 - 📚 **[Bilingual Handbook (mdbook)](https://www.toughradius.net/)** - CN/EN documentation site (source in [`docs-site/`](docs-site/)) consolidating the overview, security policy, RFC reference, and more; built, link-checked, and deployed to GitHub Pages by CI
 - [Roadmap](docs/roadmap.md) - Milestones and the EAP suite delivery plan (EAP-TLS / PEAP / TTLS, with TLS 1.3, TEAP, EAP-PWD tracked)
 - [Feature Checklist](docs/feature-checklist.md) / [English](docs/feature-checklist.en.md) - Product scope baseline for aligning future development with feature IDs and avoiding uncontrolled direction changes
-- [Architecture](docs/v9-architecture.md) - v9 version architecture design
-- [React Admin Refactor](docs/react-admin-refactor.md) - Frontend management interface explanation
-- [SQLite Support](docs/sqlite-support.md) - SQLite database configuration
-- [Environment Variables](docs/environment-variables.md) - Environment variable configuration guide
+- [Overview](docs-site/src/en/overview.md) / [Concepts & Terminology](docs-site/src/en/concepts.md) - Current architecture, service model, and AAA concepts
+- [Admin UI Manual](docs-site/src/en/admin-manual.md) - React Admin management interface, pages, roles, and workflows
+- [Operations Guide](docs-site/src/en/ops-guide.md) - Production configuration, environment variables, SQLite/PostgreSQL storage, backup, and runtime operations
+- [Documentation Map](docs-site/src/en/documentation-map.md) / [中文](docs-site/src/zh/documentation-map.md) - Canonical map for handbook chapters and repository documents
 
 ## 🏗️ Project Structure
 


### PR DESCRIPTION
## 关联 issue

- Closes #457

## 改动范围

- Replaced README Documentation links that pointed to removed `docs/*.md` files.
- Pointed Architecture/Admin UI/SQLite/env-var entries to existing mdBook source chapters and the bilingual documentation map.

## 验证

- [x] `ruby -ne '$_.scan(/\[[^\]]+\]\(([^)]+)\)/){|m| u=m[0]; next if u =~ /^(https?:|mailto:|#)/; path=u.split("#",2)[0]; path="." if path.empty?; unless File.exist?(path); warn "missing #{u}\n"; exit 1; end}; END{puts "README local markdown links resolve" if $!.nil?}' README.md` → passed
- [x] Repository quality hook during first commit attempt ran `go test ./...` and `go vet ./...` → passed
- [ ] `mdbook build docs-site` → not run: `mdbook` is not installed in this environment
- [ ] Repository formatting hook → blocked by pre-existing unrelated Go formatting drift in `internal/adminapi/settings_test.go`, `internal/adminapi/system_backup_test.go`, `internal/radiusd/coa_service_test.go`, `internal/radiusd/plugins/eap/handlers/md5_handler.go`, `internal/radiusd/plugins/eap/handlers/ttls_avp_test.go`, `internal/radiusd/plugins/eap/statemanager/memory_state_manager.go`, `internal/radiusd/plugins/eap/statemanager/memory_state_manager_test.go`, and `test/integration/coa_test.go`

## 风险

- 未发现新增运行时风险；变更仅影响 README 链接。
- 残余风险：本地缺少 `mdbook`，未能执行 mdBook 构建；仓库既有 Go 格式漂移会继续阻塞本地质量钩子。

## 回滚

- Revert this PR to restore the previous README Documentation link list.

## 审批

已标记 `human-approval`，等待成员批准后再合并。