### PR TITLE
[codex] avoid EAP report branch collisions

### DIFF
--- a/.github/workflows/eap-acceptance-weekly.yml
+++ b/.github/workflows/eap-acceptance-weekly.yml
@@ -123,7 +123,7 @@ jobs:
             exit 0
           fi
 
-          branch="automation/eap-acceptance-report-${GITHUB_RUN_ID}"
+          branch="automation/eap-acceptance-report-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git switch -c "$branch"


### PR DESCRIPTION
Fixes EAP report PR publishing reruns by including GITHUB_RUN_ATTEMPT in the generated automation branch name.

Root cause: re-running a failed workflow keeps the same GITHUB_RUN_ID, so the workflow reused an existing remote branch and git push --force-with-lease rejected it with stale info.

Validation: parsed the workflow YAML with Ruby and ran git diff --check.
