### PR TITLE
ci: harden performance benchmark workflow

### DIFF
--- a/.github/workflows/performance-benchmark-weekly.yml
+++ b/.github/workflows/performance-benchmark-weekly.yml
@@ -87,8 +87,16 @@ jobs:
           fi
 
           if [ -z "${PERFORMANCE_REPORT_SIGNING_KEY:-}" ] || [ -z "${PERFORMANCE_REPORT_SIGNING_EMAIL:-}" ]; then
-            echo "::error::PERFORMANCE_REPORT_SIGNING_KEY secret and PERFORMANCE_REPORT_SIGNING_EMAIL variable are required because main requires signed commits. EAP_REPORT_SIGNING_KEY/EAP_REPORT_SIGNING_EMAIL may be reused as a fallback."
-            exit 1
+            {
+              echo "## Performance benchmark report PR skipped"
+              echo
+              echo "Benchmark report files changed, but signed-commit credentials are not configured."
+              echo "Configure PERFORMANCE_REPORT_SIGNING_KEY and PERFORMANCE_REPORT_SIGNING_EMAIL, or reuse EAP_REPORT_SIGNING_KEY and EAP_REPORT_SIGNING_EMAIL."
+              echo
+              echo "The generated report remains available in the workflow artifact for this run."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning::Performance benchmark report PR skipped because signed-commit credentials are not configured."
+            exit 0
           fi
 
           install -m 700 -d "$HOME/.ssh"

--- a/internal/radiusd/radius_auth_bench_test.go
+++ b/internal/radiusd/radius_auth_bench_test.go
@@ -1,0 +1,175 @@
+package radiusd
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/glebarez/sqlite"
+	"github.com/talkincode/toughradius/v9/config"
+	"github.com/talkincode/toughradius/v9/internal/app"
+	"github.com/talkincode/toughradius/v9/internal/domain"
+	cachepkg "github.com/talkincode/toughradius/v9/internal/radiusd/cache"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/auth"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/registry"
+	"github.com/talkincode/toughradius/v9/pkg/common"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+	"layeh.com/radius"
+	"layeh.com/radius/rfc2865"
+)
+
+type benchmarkAuthAppContext struct {
+	metricsTestAppContext
+
+	configMgr    *app.ConfigManager
+	profileCache *app.ProfileCache
+}
+
+func (m *benchmarkAuthAppContext) ConfigMgr() *app.ConfigManager { return m.configMgr }
+func (m *benchmarkAuthAppContext) ProfileCache() *app.ProfileCache {
+	return m.profileCache
+}
+
+type benchmarkUserRepository struct {
+	user *domain.RadiusUser
+}
+
+func (r *benchmarkUserRepository) GetByUsername(context.Context, string) (*domain.RadiusUser, error) {
+	return r.user, nil
+}
+func (r *benchmarkUserRepository) GetByMacAddr(context.Context, string) (*domain.RadiusUser, error) {
+	return r.user, nil
+}
+func (r *benchmarkUserRepository) UpdateMacAddr(context.Context, string, string) error {
+	return nil
+}
+func (r *benchmarkUserRepository) UpdateVlanId(context.Context, string, int, int) error {
+	return nil
+}
+func (r *benchmarkUserRepository) UpdateLastOnline(context.Context, string) error {
+	return nil
+}
+func (r *benchmarkUserRepository) UpdateField(context.Context, string, string, interface{}) error {
+	return nil
+}
+
+type benchmarkNasRepository struct {
+	nas *domain.NetNas
+}
+
+func (r *benchmarkNasRepository) GetByIP(context.Context, string) (*domain.NetNas, error) {
+	return r.nas, nil
+}
+func (r *benchmarkNasRepository) GetByIdentifier(context.Context, string) (*domain.NetNas, error) {
+	return r.nas, nil
+}
+func (r *benchmarkNasRepository) GetByIPOrIdentifier(context.Context, string, string) (*domain.NetNas, error) {
+	return r.nas, nil
+}
+
+type benchmarkPasswordValidator struct{}
+
+func (benchmarkPasswordValidator) Name() string { return "benchmark-password-validator" }
+func (benchmarkPasswordValidator) CanHandle(*auth.AuthContext) bool {
+	return true
+}
+func (benchmarkPasswordValidator) Validate(context.Context, *auth.AuthContext, string) error {
+	return nil
+}
+
+func newBenchmarkAuthAppContext(b *testing.B) *benchmarkAuthAppContext {
+	b.Helper()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		b.Fatalf("open benchmark config database: %v", err)
+	}
+	if err := db.AutoMigrate(&domain.SysConfig{}); err != nil {
+		b.Fatalf("migrate benchmark config database: %v", err)
+	}
+
+	application := app.NewApplication(&config.AppConfig{})
+	application.OverrideDB(db)
+	profileCache := app.NewProfileCache(nil, time.Minute)
+	b.Cleanup(profileCache.Stop)
+
+	return &benchmarkAuthAppContext{
+		configMgr:    app.NewConfigManager(application),
+		profileCache: profileCache,
+	}
+}
+
+func newBenchmarkAuthService(b *testing.B) *AuthService {
+	b.Helper()
+
+	user := &domain.RadiusUser{
+		Username:   "bench-user",
+		Password:   "bench-pass",
+		Status:     common.ENABLED,
+		ExpireTime: time.Now().Add(time.Hour),
+	}
+	nas := &domain.NetNas{
+		Identifier: "bench-nas",
+		Ipaddr:     "127.0.0.1",
+		Secret:     "testing123",
+		VendorCode: "0",
+		Status:     common.ENABLED,
+	}
+	radiusService := &RadiusService{
+		appCtx:    newBenchmarkAuthAppContext(b),
+		authRate:  newAuthRateLimiter(defaultAuthRateShards),
+		nasCache:  cachepkg.NewTTLCache[*domain.NetNas](time.Minute, 16),
+		userCache: cachepkg.NewTTLCache[*domain.RadiusUser](time.Minute, 16),
+		UserRepo:  &benchmarkUserRepository{user: user},
+		NasRepo:   &benchmarkNasRepository{nas: nas},
+	}
+
+	return NewAuthService(radiusService)
+}
+
+func newBenchmarkAuthRequest(b *testing.B) *radius.Request {
+	b.Helper()
+
+	packet := radius.New(radius.CodeAccessRequest, []byte("testing123"))
+	if err := rfc2865.UserName_SetString(packet, "bench-user"); err != nil {
+		b.Fatalf("set User-Name: %v", err)
+	}
+	if err := rfc2865.NASIdentifier_SetString(packet, "bench-nas"); err != nil {
+		b.Fatalf("set NAS-Identifier: %v", err)
+	}
+
+	return &radius.Request{
+		Packet:     packet,
+		RemoteAddr: &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1812},
+	}
+}
+
+// BenchmarkServeRADIUSAccessAccept measures the real authentication hot path
+// from Access-Request ingress through NAS lookup, user lookup, plugin password
+// validation, response signing, Access-Accept write, bind update, metrics, and
+// last-online update. Repositories and plugins are in-memory/no-op so the
+// benchmark isolates RADIUS pipeline overhead rather than database latency.
+func BenchmarkServeRADIUSAccessAccept(b *testing.B) {
+	undoLogger := zap.ReplaceGlobals(zap.NewNop())
+	b.Cleanup(undoLogger)
+	registry.ResetForTest()
+	b.Cleanup(registry.ResetForTest)
+	registry.RegisterPasswordValidator(benchmarkPasswordValidator{})
+
+	svc := newBenchmarkAuthService(b)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		w := &captureResponseWriter{}
+		svc.ServeRADIUS(w, newBenchmarkAuthRequest(b))
+		if w.last == nil {
+			b.Fatal("ServeRADIUS did not write a response")
+		}
+		if w.last.Code != radius.CodeAccessAccept {
+			b.Fatalf("ServeRADIUS response code = %v, want %v", w.last.Code, radius.CodeAccessAccept)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #485. This keeps the weekly performance benchmark run useful when signed-report PR credentials are not configured yet, and adds a RADIUS authentication benchmark so the report includes the Access-Accept hot path.

## Changes

- Change the performance report PR step to write a warning and step summary, then skip auto-PR creation when signed-commit credentials are missing. Benchmark artifacts still upload and the job can stay green when benchmarks pass.
- Add `BenchmarkServeRADIUSAccessAccept`, which runs `AuthService.ServeRADIUS` through NAS lookup, user lookup, plugin password validation, response signing, Access-Accept write, bind update, metrics, and last-online update using in-memory/no-op dependencies.

## Validation

- `env GOCACHE=/tmp/go-build GOTELEMETRY=off go test -run '^$' -bench BenchmarkServeRADIUSAccessAccept -benchmem ./internal/radiusd`\n- `env GOCACHE=/tmp/go-build GOTELEMETRY=off go test -run '^(TestAuthenticateUserWithPluginsRunsValidatorAndPolicies|TestSendAcceptResponse_CountsAccept|TestMapEAPDispatchError)$' ./internal/radiusd`\n- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/performance-benchmark-weekly.yml"); puts "workflow yaml ok"'`\n- `bash -n /tmp/performance-open-report-pr.sh`\n- `git diff --check`\n\nNote: the full `go test ./internal/radiusd` run was stopped after more than three minutes with no output; the focused benchmark and related unit tests above passed.