### PR TITLE
fix: guard insecure default admin secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,8 @@ TOUGHRADIUS_SYSTEM_DEBUG=true
 TOUGHRADIUS_WEB_HOST=0.0.0.0
 TOUGHRADIUS_WEB_PORT=1816
 TOUGHRADIUS_WEB_TLS_PORT=1817
-TOUGHRADIUS_WEB_SECRET=9b6de5cc-0731-1203-xxtt-0f568ac9da37
+# 必须在生产环境改为每个实例唯一的长随机值；该值用于签发管理后台 JWT。
+TOUGHRADIUS_WEB_SECRET=change-me-to-a-long-random-string
 
 # ============================================
 # 数据库配置

--- a/README.md
+++ b/README.md
@@ -155,7 +155,10 @@ Access Web Management Interface: <http://localhost:1816>
 Default Admin Account:
 
 - Username: admin
-- Password: Please check the initialization log output
+- Password: toughradius
+
+Change the default admin password immediately after first login. For any deployment exposed beyond a local development host, also set `web.secret` / `TOUGHRADIUS_WEB_SECRET` to a long random value before starting the service; it signs management API JWTs.
+Production mode (`system.debug=false` or `logger.mode=production`) refuses to start when the built-in placeholder or an empty JWT secret is still configured.
 
 ## 📖 Documentation
 

--- a/config/config.go
+++ b/config/config.go
@@ -28,6 +28,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// DefaultWebSecret is the development placeholder used when web.secret is not
+// overridden by a config file or TOUGHRADIUS_WEB_SECRET.
+const DefaultWebSecret = "9b6de5cc-0731-1203-xxtt-0f568ac9da37" //nolint:gosec // Development placeholder; production must override it.
+
 // DBConfig holds database connection settings for ToughRADIUS.
 //
 // Supports two database backends:
@@ -441,7 +445,7 @@ var DefaultAppConfig = &AppConfig{
 		Host:    "0.0.0.0",
 		Port:    1816,
 		TlsPort: 1817,
-		Secret:  "9b6de5cc-0731-1203-xxtt-0f568ac9da37",
+		Secret:  DefaultWebSecret,
 	},
 	Database: DBConfig{
 		Type:     "sqlite",    // Default to SQLite for development and testing

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -40,6 +40,10 @@ func TestDefaultAppConfig(t *testing.T) {
 		t.Errorf("Expected Web.TlsPort 1817, got %d", cfg.Web.TlsPort)
 	}
 
+	if cfg.Web.Secret != DefaultWebSecret {
+		t.Errorf("Expected Web.Secret to use DefaultWebSecret, got '%s'", cfg.Web.Secret)
+	}
+
 	// TestDatabase configuration
 	if cfg.Database.Type != "sqlite" {
 		t.Errorf("Expected Database.Type 'sqlite', got '%s'", cfg.Database.Type)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -114,6 +114,8 @@ func (a *Application) Init(cfg *config.AppConfig) {
 
 	zap.ReplaceGlobals(logger)
 
+	warnInsecureRuntimeDefaults(cfg)
+
 	// Initialize metrics with workdir convention
 	err = metrics.InitMetrics(cfg.System.Workdir)
 	if err != nil {
@@ -147,6 +149,40 @@ func (a *Application) Init(cfg *config.AppConfig) {
 	a.profileCache = NewProfileCache(a.gormDB, DefaultProfileCacheTTL)
 
 	a.initJob()
+}
+
+func warnInsecureRuntimeDefaults(cfg *config.AppConfig) {
+	if cfg == nil {
+		return
+	}
+
+	secret := strings.TrimSpace(cfg.Web.Secret)
+	fields := []zap.Field{
+		zap.String("config", "web.secret"),
+		zap.String("env", "TOUGHRADIUS_WEB_SECRET"),
+		zap.String("action", "set a long random secret before exposing the admin API"),
+	}
+	switch secret {
+	case "":
+		logInsecureRuntimeDefault(cfg, "web jwt signing secret is empty", fields...)
+	case config.DefaultWebSecret:
+		logInsecureRuntimeDefault(cfg, "web jwt signing secret uses the built-in development placeholder", fields...)
+	}
+}
+
+func logInsecureRuntimeDefault(cfg *config.AppConfig, msg string, fields ...zap.Field) {
+	if isProductionRuntime(cfg) {
+		zap.L().Fatal(msg, fields...)
+		return
+	}
+	zap.L().Warn(msg, fields...)
+}
+
+func isProductionRuntime(cfg *config.AppConfig) bool {
+	if cfg == nil {
+		return false
+	}
+	return !cfg.System.Debug || strings.EqualFold(cfg.Logger.Mode, "production")
 }
 
 func (a *Application) MigrateDB(track bool) (err error) {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -4,6 +4,9 @@ import (
 	"testing"
 
 	"github.com/talkincode/toughradius/v9/config"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestNewApplication(t *testing.T) {
@@ -44,5 +47,88 @@ func TestApplication_Config(t *testing.T) {
 func TestAutoRegisterPopNodeIdConstant(t *testing.T) {
 	if AutoRegisterPopNodeId != 999999999 {
 		t.Errorf("Expected AutoRegisterPopNodeId to be 999999999, got %d", AutoRegisterPopNodeId)
+	}
+}
+
+func TestWarnInsecureRuntimeDefaults(t *testing.T) {
+	tests := []struct {
+		name      string
+		secret    string
+		wantWarns int
+	}{
+		{
+			name:      "empty secret warns",
+			secret:    "",
+			wantWarns: 1,
+		},
+		{
+			name:      "default placeholder warns",
+			secret:    config.DefaultWebSecret,
+			wantWarns: 1,
+		},
+		{
+			name:      "custom secret is quiet",
+			secret:    "local-test-random-secret",
+			wantWarns: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			core, logs := observer.New(zapcore.WarnLevel)
+			undo := zap.ReplaceGlobals(zap.New(core))
+			defer undo()
+
+			warnInsecureRuntimeDefaults(&config.AppConfig{
+				System: config.SysConfig{Debug: true},
+				Logger: config.LogConfig{Mode: "development"},
+				Web:    config.WebConfig{Secret: tt.secret},
+			})
+
+			if logs.Len() != tt.wantWarns {
+				t.Fatalf("expected %d warnings, got %d: %+v", tt.wantWarns, logs.Len(), logs.All())
+			}
+		})
+	}
+}
+
+func TestIsProductionRuntime(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *config.AppConfig
+		want bool
+	}{
+		{
+			name: "development",
+			cfg: &config.AppConfig{
+				System: config.SysConfig{Debug: true},
+				Logger: config.LogConfig{Mode: "development"},
+			},
+			want: false,
+		},
+		{
+			name: "debug disabled",
+			cfg: &config.AppConfig{
+				System: config.SysConfig{Debug: false},
+				Logger: config.LogConfig{Mode: "development"},
+			},
+			want: true,
+		},
+		{
+			name: "production logger",
+			cfg: &config.AppConfig{
+				System: config.SysConfig{Debug: true},
+				Logger: config.LogConfig{Mode: "production"},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isProductionRuntime(tt.cfg); got != tt.want {
+				t.Fatalf("expected %v, got %v", tt.want, got)
+			}
+		})
 	}
 }

--- a/internal/app/initdb.go
+++ b/internal/app/initdb.go
@@ -12,18 +12,20 @@ import (
 	"gorm.io/gorm"
 )
 
-func (a *Application) checkSuper() {
-	const superUsername = "admin"
-	const defaultPassword = "toughradius"
+const (
+	defaultSuperUsername = "admin"
+	defaultSuperPassword = "toughradius"
+)
 
-	hashedPassword, err := common.HashPassword(defaultPassword)
+func (a *Application) checkSuper() {
+	hashedPassword, err := common.HashPassword(defaultSuperPassword)
 	if err != nil {
 		zap.L().Error("failed to hash default super admin password", zap.Error(err))
 		return
 	}
 
 	var operator domain.SysOpr
-	err = a.gormDB.Where("username = ?", superUsername).First(&operator).Error
+	err = a.gormDB.Where("username = ?", defaultSuperUsername).First(&operator).Error
 	switch {
 	case errors.Is(err, gorm.ErrRecordNotFound):
 		if err := a.gormDB.Create(&domain.SysOpr{
@@ -31,7 +33,7 @@ func (a *Application) checkSuper() {
 			Realname:  "administrator",
 			Mobile:    "0000",
 			Email:     "N/A",
-			Username:  superUsername,
+			Username:  defaultSuperUsername,
 			Password:  hashedPassword,
 			Level:     "super",
 			Status:    common.ENABLED,
@@ -40,7 +42,8 @@ func (a *Application) checkSuper() {
 		}).Error; err != nil {
 			zap.L().Error("failed to create default super admin", zap.Error(err))
 		} else {
-			zap.L().Info("initialized default super admin account", zap.String("username", superUsername))
+			zap.L().Info("initialized default super admin account", zap.String("username", defaultSuperUsername))
+			warnDefaultSuperPassword("created")
 		}
 		return
 	case err != nil:
@@ -53,6 +56,9 @@ func (a *Application) checkSuper() {
 	resetStatus := !strings.EqualFold(operator.Status, common.ENABLED)
 
 	if !resetPassword && !resetLevel && !resetStatus {
+		if common.VerifyPassword(defaultSuperPassword, operator.Password) {
+			warnDefaultSuperPassword("existing")
+		}
 		return
 	}
 
@@ -75,10 +81,20 @@ func (a *Application) checkSuper() {
 	}
 
 	zap.L().Warn("repaired default super admin account",
-		zap.String("username", superUsername),
+		zap.String("username", defaultSuperUsername),
 		zap.Bool("passwordReset", resetPassword),
 		zap.Bool("levelReset", resetLevel),
 		zap.Bool("statusEnabled", resetStatus))
+	if resetPassword {
+		warnDefaultSuperPassword("repaired")
+	}
+}
+
+func warnDefaultSuperPassword(source string) {
+	zap.L().Warn("default super admin account uses the built-in password",
+		zap.String("username", defaultSuperUsername),
+		zap.String("source", source),
+		zap.String("action", "change the admin password before exposing the admin API"))
 }
 
 func (a *Application) checkSettings() {

--- a/internal/app/initdb_test.go
+++ b/internal/app/initdb_test.go
@@ -8,6 +8,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/talkincode/toughradius/v9/internal/domain"
 	"github.com/talkincode/toughradius/v9/pkg/common"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 	"gorm.io/gorm"
 )
 
@@ -57,4 +60,35 @@ func TestCheckSuperRepairsExistingAdmin(t *testing.T) {
 	assert.Equal(t, "super", admin.Level)
 	assert.Equal(t, common.ENABLED, admin.Status)
 	assert.True(t, common.VerifyPassword("toughradius", admin.Password))
+}
+
+func TestCheckSuperWarnsWhenCreatingDefaultAdmin(t *testing.T) {
+	app := newTestApplication(t)
+	core, logs := observer.New(zapcore.WarnLevel)
+	undo := zap.ReplaceGlobals(zap.New(core))
+	defer undo()
+
+	app.checkSuper()
+
+	assert.Equal(t, 1, logs.FilterMessage("default super admin account uses the built-in password").Len())
+}
+
+func TestCheckSuperWarnsWhenExistingAdminUsesDefaultPassword(t *testing.T) {
+	app := newTestApplication(t)
+	password, err := common.HashPassword(defaultSuperPassword)
+	require.NoError(t, err)
+	require.NoError(t, app.gormDB.Create(&domain.SysOpr{
+		ID:       common.UUIDint64(),
+		Username: defaultSuperUsername,
+		Password: password,
+		Level:    "super",
+		Status:   common.ENABLED,
+	}).Error)
+	core, logs := observer.New(zapcore.WarnLevel)
+	undo := zap.ReplaceGlobals(zap.New(core))
+	defer undo()
+
+	app.checkSuper()
+
+	assert.Equal(t, 1, logs.FilterMessage("default super admin account uses the built-in password").Len())
 }


### PR DESCRIPTION
## Summary
- refuse production startup when the Web JWT signing secret is empty or still uses the built-in placeholder; development mode emits a warning instead
- warn when the built-in admin account is created, repaired, or still using the built-in password
- align README and .env.example so operators see the real default password and required JWT secret override

## Validation
- env GOCACHE=/tmp/go-build GOTELEMETRY=off go test ./config ./internal/app
- env GOCACHE=/tmp/go-build GOTELEMETRY=off go test -short ./...
- env GOCACHE=/tmp/go-build GOTELEMETRY=off go vet ./...
- git diff --check

Addresses #460