### PR TITLE
ci: add workflow actionlint gate (#512)

### DIFF
--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -50,4 +50,4 @@ jobs:
           echo "$GOBIN" >> "$GITHUB_PATH"
 
       - name: Lint GitHub Actions workflows
-        run: actionlint -color
+        run: actionlint -color -shellcheck=

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,0 +1,40 @@
+name: Workflow Lint
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
+      - '.github/actionlint.yml'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
+      - '.github/actionlint.yml'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: workflow-lint-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Install actionlint
+        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2
+        with:
+          tool: actionlint
+
+      - name: Lint GitHub Actions workflows
+        run: actionlint -color

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -22,6 +22,9 @@ concurrency:
   group: workflow-lint-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  GO_VERSION: '1.25'
+
 jobs:
   actionlint:
     name: actionlint
@@ -31,10 +34,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - name: Install actionlint
-        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          tool: actionlint
+          go-version: ${{ env.GO_VERSION }}
+          check-latest: true
+          cache: false
+
+      - name: Install actionlint
+        env:
+          GOBIN: ${{ runner.temp }}/bin
+        run: |
+          mkdir -p "$GOBIN"
+          go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+          echo "$GOBIN" >> "$GITHUB_PATH"
 
       - name: Lint GitHub Actions workflows
         run: actionlint -color


### PR DESCRIPTION
## 关联 issue

- Closes #512

## 改动范围

- 新增 `Workflow Lint` GitHub Actions workflow，在 PR 或 main push 修改 `.github/workflows/**` / actionlint 配置时运行。
- 使用已钉死 SHA 的 `actions/checkout` 与 `actions/setup-go`，通过 `go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12` 安装 `actionlint`，只做静态 workflow lint，并显式关闭 ShellCheck 集成以避免把既有 shell 风格告警混入本 issue；不执行发布、Pages 部署或读取发布 secrets。

## 验证

- [x] `/tmp/codex-bin/actionlint -color -shellcheck=`
- [x] `ruby -e 'require "psych"; Dir[".github/workflows/*.yml"].sort.each { |f| Psych.load_file(f); puts "yaml ok #{f}" }'`
- [x] `git diff --check`
- [x] commit hook: `go test ./...`, `go vet ./...`, formatting check, `go build ./...`, module dependency check, `golangci-lint`
- [x] push hook: `go test ./...`, `go vet ./...`, formatting check, `go build ./...`, module dependency check, `golangci-lint`

## 风险

- 新增 PR check 只在 workflow/lint 配置路径变更时运行，可能暴露既有 workflow lint 问题；未发现新增运行时发布或 secret 暴露风险。

## 回滚

- Revert this PR to remove `.github/workflows/workflow-lint.yml` and restore the previous CI surface.

## 审批

已标记 `human-approval`，等待成员批准后再合并。
