### PR TITLE
[codex] add web TLS management toggle

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -93,18 +93,24 @@ type SysConfig struct {
 // Secret is used for JWT token signing and session management. It should
 // be a cryptographically secure random string in production environments.
 //
-// TlsPort enables HTTPS access when configured with valid certificates.
+// TlsEnabled controls whether the built-in HTTPS listener is started. A nil
+// value preserves the legacy default and enables the listener.
+//
+// TlsPort is the built-in HTTPS listener port when TlsEnabled is true and valid
+// certificates are present.
 //
 // Environment variable overrides:
 //   - TOUGHRADIUS_WEB_HOST
 //   - TOUGHRADIUS_WEB_PORT
+//   - TOUGHRADIUS_WEB_TLS_ENABLED
 //   - TOUGHRADIUS_WEB_TLS_PORT
 //   - TOUGHRADIUS_WEB_SECRET
 type WebConfig struct {
-	Host    string `yaml:"host"`
-	Port    int    `yaml:"port"`
-	TlsPort int    `yaml:"tls_port"`
-	Secret  string `yaml:"secret"`
+	Host       string `yaml:"host"`
+	Port       int    `yaml:"port"`
+	TlsEnabled *bool  `yaml:"tls_enabled"`
+	TlsPort    int    `yaml:"tls_port"`
+	Secret     string `yaml:"secret"`
 }
 
 // RadiusdConfig holds RADIUS protocol service settings.
@@ -355,8 +361,8 @@ func setEnvValue(name string, val *string) {
 
 // setEnvBoolValue sets a boolean configuration value from an environment variable.
 //
-// Recognizes the following truthy values (case-sensitive): "true", "1", "on"
-// All other values (including empty string) are treated as false.
+// Recognizes the following truthy values (case-sensitive): "true", "1", "on".
+// All other non-empty values are treated as false.
 //
 // Parameters:
 //   - name: Environment variable name (e.g., "TOUGHRADIUS_RADIUS_DEBUG")
@@ -369,6 +375,28 @@ func setEnvBoolValue(name string, val *bool) {
 	if evalue != "" {
 		*val = evalue == "true" || evalue == "1" || evalue == "on"
 	}
+}
+
+// setEnvOptionalBoolValue sets an optional boolean configuration value from an
+// environment variable.
+//
+// Recognizes the following truthy values (case-sensitive): "true", "1", "on".
+// All other non-empty values are treated as false.
+//
+// Parameters:
+//   - name: Environment variable name (e.g., "TOUGHRADIUS_WEB_TLS_ENABLED")
+//   - val: Pointer to an optional configuration field to update
+//
+// Side effects:
+//   - Modifies *val if environment variable is set and non-empty
+func setEnvOptionalBoolValue(name string, val **bool) {
+	var evalue = os.Getenv(name)
+	if evalue == "" {
+		return
+	}
+
+	parsed := evalue == "true" || evalue == "1" || evalue == "on"
+	*val = &parsed
 }
 
 // setEnvInt64Value sets an int64 configuration value from an environment variable.
@@ -442,10 +470,11 @@ var DefaultAppConfig = &AppConfig{
 		Debug:    true,
 	},
 	Web: WebConfig{ //nolint:gosec // Default secret is a placeholder for development/testing only
-		Host:    "0.0.0.0",
-		Port:    1816,
-		TlsPort: 1817,
-		Secret:  DefaultWebSecret,
+		Host:       "0.0.0.0",
+		Port:       1816,
+		TlsEnabled: boolPtr(true),
+		TlsPort:    1817,
+		Secret:     DefaultWebSecret,
 	},
 	Database: DBConfig{
 		Type:     "sqlite",    // Default to SQLite for development and testing
@@ -475,6 +504,10 @@ var DefaultAppConfig = &AppConfig{
 		FileEnable: true,
 		Filename:   "/var/toughradius/toughradius.log",
 	},
+}
+
+func boolPtr(v bool) *bool {
+	return &v
 }
 
 // LoadConfig loads application configuration from YAML file and environment variables.
@@ -539,6 +572,10 @@ func LoadConfig(cfile string) *AppConfig {
 	setEnvValue("TOUGHRADIUS_WEB_HOST", &cfg.Web.Host)
 	setEnvValue("TOUGHRADIUS_WEB_SECRET", &cfg.Web.Secret)
 	setEnvIntValue("TOUGHRADIUS_WEB_PORT", &cfg.Web.Port)
+	setEnvOptionalBoolValue("TOUGHRADIUS_WEB_TLS_ENABLED", &cfg.Web.TlsEnabled)
+	if cfg.Web.TlsEnabled == nil {
+		cfg.Web.TlsEnabled = boolPtr(true)
+	}
 	setEnvIntValue("TOUGHRADIUS_WEB_TLS_PORT", &cfg.Web.TlsPort)
 
 	// DB

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -36,6 +36,10 @@ func TestDefaultAppConfig(t *testing.T) {
 		t.Errorf("Expected Web.Port 1816, got %d", cfg.Web.Port)
 	}
 
+	if cfg.Web.TlsEnabled == nil || !*cfg.Web.TlsEnabled {
+		t.Error("Expected Web.TlsEnabled to default to true")
+	}
+
 	if cfg.Web.TlsPort != 1817 {
 		t.Errorf("Expected Web.TlsPort 1817, got %d", cfg.Web.TlsPort)
 	}
@@ -154,6 +158,8 @@ func TestAppConfigGetters(t *testing.T) {
 }
 
 func TestLoadConfigFromFile(t *testing.T) {
+	t.Setenv("TOUGHRADIUS_WEB_TLS_ENABLED", "")
+
 	tmpDir := t.TempDir()
 	configFile := filepath.Join(tmpDir, "test-config.yml")
 
@@ -168,6 +174,7 @@ system:
 web:
   host: 127.0.0.1
   port: 8080
+  tls_enabled: false
   tls_port: 8443
   secret: test-secret
 
@@ -227,6 +234,14 @@ logger:
 		t.Errorf("Expected Web.Port 8080, got %d", cfg.Web.Port)
 	}
 
+	if cfg.Web.TlsEnabled == nil || *cfg.Web.TlsEnabled {
+		t.Error("Expected Web.TlsEnabled false from config file")
+	}
+
+	if cfg.Web.TlsPort != 8443 {
+		t.Errorf("Expected Web.TlsPort 8443, got %d", cfg.Web.TlsPort)
+	}
+
 	if cfg.Web.Secret != "test-secret" {
 		t.Errorf("Expected Web.Secret 'test-secret', got '%s'", cfg.Web.Secret)
 	}
@@ -276,6 +291,8 @@ logger:
 }
 
 func TestLoadConfigNonExistent(t *testing.T) {
+	t.Setenv("TOUGHRADIUS_WEB_TLS_ENABLED", "")
+
 	// Loading a nonexistent config file should return the default configuration
 	cfg := LoadConfig("/nonexistent/path/config.yml")
 
@@ -286,6 +303,38 @@ func TestLoadConfigNonExistent(t *testing.T) {
 
 	if cfg.Web.Port != DefaultAppConfig.Web.Port {
 		t.Errorf("Expected default Web.Port %d, got %d", DefaultAppConfig.Web.Port, cfg.Web.Port)
+	}
+
+	if cfg.Web.TlsEnabled == nil || !*cfg.Web.TlsEnabled {
+		t.Error("Expected default Web.TlsEnabled to be true")
+	}
+}
+
+func TestLoadConfigDefaultsWebTLSEnabledWhenOmitted(t *testing.T) {
+	t.Setenv("TOUGHRADIUS_WEB_TLS_ENABLED", "")
+
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "web-tls-compat.yml")
+
+	configContent := `
+system:
+  workdir: ` + tmpDir + `
+
+web:
+  host: 127.0.0.1
+  port: 8080
+  tls_port: 8443
+  secret: test-secret
+`
+
+	err := os.WriteFile(configFile, []byte(configContent), 0600) //nolint:gosec // G306: test file permissions
+	if err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	cfg := LoadConfig(configFile)
+	if cfg.Web.TlsEnabled == nil || !*cfg.Web.TlsEnabled {
+		t.Error("Expected omitted web.tls_enabled to preserve the legacy enabled default")
 	}
 }
 
@@ -336,6 +385,7 @@ logger:
 		"TOUGHRADIUS_SYSTEM_DEBUG":         "true",
 		"TOUGHRADIUS_WEB_HOST":             "192.168.1.1",
 		"TOUGHRADIUS_WEB_PORT":             "9090",
+		"TOUGHRADIUS_WEB_TLS_ENABLED":      "false",
 		"TOUGHRADIUS_WEB_SECRET":           "env-secret",
 		"TOUGHRADIUS_DB_TYPE":              "postgres",
 		"TOUGHRADIUS_DB_HOST":              "db.server.com",
@@ -387,6 +437,10 @@ logger:
 
 	if cfg.Web.Port != 9090 {
 		t.Errorf("Expected Web.Port 9090 (from env), got %d", cfg.Web.Port)
+	}
+
+	if cfg.Web.TlsEnabled == nil || *cfg.Web.TlsEnabled {
+		t.Error("Expected Web.TlsEnabled false (from env)")
 	}
 
 	if cfg.Web.Secret != "env-secret" {

--- a/docs-site/src/en/faq.md
+++ b/docs-site/src/en/faq.md
@@ -36,7 +36,8 @@ Yes — every port is configurable (`radiusd.auth_port`, `radiusd.acct_port`,
 The web TLS listener needs `{workdir}/private/toughradius.tls.crt` and `.key`.
 If they are missing or invalid the failure is logged and **only** the HTTPS
 listener stops — plain HTTP on 1816 keeps serving. Generate certificates with
-`cmd/certgen` or provide your own.
+`cmd/certgen` or provide your own. If you do not need the built-in HTTPS
+listener, set `web.tls_enabled: false` or `TOUGHRADIUS_WEB_TLS_ENABLED=false`.
 
 ### Is `-initdb` safe to run again?
 

--- a/docs-site/src/en/ops-guide.md
+++ b/docs-site/src/en/ops-guide.md
@@ -33,7 +33,7 @@ WantedBy=multi-user.target
 | Port | Protocol | Service | Config key |
 | ---- | -------- | ------- | ---------- |
 | 1816 | TCP HTTP | Admin UI + REST API | `web.port` |
-| 1817 | TCP HTTPS | Admin UI over TLS (optional; start failure is non-fatal) | `web.tls_port` |
+| 1817 | TCP HTTPS | Admin UI over TLS (optional; start failure is non-fatal) | `web.tls_enabled` / `web.tls_port` |
 | 1812 | UDP | RADIUS authentication | `radiusd.auth_port` |
 | 1813 | UDP | RADIUS accounting | `radiusd.acct_port` |
 | 2083 | TCP TLS | RadSec (RFC 6614) | `radiusd.radsec_port` |
@@ -53,6 +53,7 @@ system:
 web:
   host: 0.0.0.0
   port: 1816
+  tls_enabled: true              # Enabled by default for compatibility; set false to disable the built-in HTTPS listener
   tls_port: 1817
   secret: <random-string>        # JWT signing secret — change it
 database:
@@ -103,7 +104,7 @@ Environment variables override the YAML file:
 | -------- | --------- |
 | `TOUGHRADIUS_SYSTEM_WORKER_DIR` | `system.workdir` |
 | `TOUGHRADIUS_SYSTEM_DEBUG` | `system.debug` |
-| `TOUGHRADIUS_WEB_HOST` / `_WEB_PORT` / `_WEB_TLS_PORT` / `_WEB_SECRET` | `web.*` |
+| `TOUGHRADIUS_WEB_HOST` / `_WEB_PORT` / `_WEB_TLS_ENABLED` / `_WEB_TLS_PORT` / `_WEB_SECRET` | `web.*` |
 | `TOUGHRADIUS_DB_TYPE` / `_DB_HOST` / `_DB_PORT` / `_DB_NAME` / `_DB_USER` / `_DB_PWD` / `_DB_DEBUG` | `database.*` |
 | `TOUGHRADIUS_RADIUS_ENABLED` / `_RADIUS_HOST` / `_RADIUS_AUTHPORT` / `_RADIUS_ACCTPORT` / `_RADIUS_DEBUG` | `radiusd.*` |
 | `TOUGHRADIUS_RADIUS_RADSEC_PORT` / `_RADIUS_RADSEC_WORKER` / `_RADIUS_RADSEC_CA_CERT` / `_RADIUS_RADSEC_CERT` / `_RADIUS_RADSEC_KEY` | RadSec settings |
@@ -151,7 +152,7 @@ Three independent certificate consumers:
 | Consumer | Files | Notes |
 | -------- | ----- | ----- |
 | **RadSec** | `radiusd.radsec_ca_cert` / `radsec_cert` / `radsec_key` | TLS 1.2+; client certificates are verified **if presented** (`VerifyClientCertIfGiven`) |
-| **Web HTTPS** | `{workdir}/private/toughradius.tls.crt` + `.key` (fixed paths) | Listens on `web.tls_port`; failure to load is logged, HTTP keeps running |
+| **Web HTTPS** | `{workdir}/private/toughradius.tls.crt` + `.key` (fixed paths) | Listens on `web.tls_port` when `web.tls_enabled` is true; failure to load is logged, HTTP keeps running |
 | **EAP (TLS/PEAP/TTLS)** | System Config → `EapTlsCertFile`, `EapTlsKeyFile`, `EapTlsCaFile`, `EapTlsMinVersion` | Empty cert/key disables TLS-based EAP methods |
 
 Generate a complete CA/server/client set with the bundled tool:

--- a/docs-site/src/zh/faq.md
+++ b/docs-site/src/zh/faq.md
@@ -32,7 +32,8 @@ SQLite（默认）零依赖——纯 Go 驱动、单文件存于 `{workdir}/data
 
 Web TLS 监听需要 `{workdir}/private/toughradius.tls.crt` 与 `.key`。文件缺失
 或无效时只记录日志并**仅**停掉 HTTPS 监听——1816 上的 HTTP 继续服务。可用
-`cmd/certgen` 生成证书或提供自己的证书。
+`cmd/certgen` 生成证书或提供自己的证书。若不需要内置 HTTPS 监听，设置
+`web.tls_enabled: false` 或 `TOUGHRADIUS_WEB_TLS_ENABLED=false`。
 
 ### `-initdb` 可以再跑一次吗？
 

--- a/docs-site/src/zh/ops-guide.md
+++ b/docs-site/src/zh/ops-guide.md
@@ -31,7 +31,7 @@ WantedBy=multi-user.target
 | 端口 | 协议 | 服务 | 配置键 |
 | ---- | ---- | ---- | ------ |
 | 1816 | TCP HTTP | 管理界面 + REST API | `web.port` |
-| 1817 | TCP HTTPS | 管理界面 TLS（可选；启动失败不影响整体） | `web.tls_port` |
+| 1817 | TCP HTTPS | 管理界面 TLS（可选；启动失败不影响整体） | `web.tls_enabled` / `web.tls_port` |
 | 1812 | UDP | RADIUS 认证 | `radiusd.auth_port` |
 | 1813 | UDP | RADIUS 计费 | `radiusd.acct_port` |
 | 2083 | TCP TLS | RadSec（RFC 6614） | `radiusd.radsec_port` |
@@ -51,6 +51,7 @@ system:
 web:
   host: 0.0.0.0
   port: 1816
+  tls_enabled: true              # 兼容旧版本默认启用；设为 false 可关闭内置 HTTPS 监听
   tls_port: 1817
   secret: <随机字符串>            # JWT 签名密钥——务必修改
 database:
@@ -101,7 +102,7 @@ logger:
 | ---- | ------ |
 | `TOUGHRADIUS_SYSTEM_WORKER_DIR` | `system.workdir` |
 | `TOUGHRADIUS_SYSTEM_DEBUG` | `system.debug` |
-| `TOUGHRADIUS_WEB_HOST` / `_WEB_PORT` / `_WEB_TLS_PORT` / `_WEB_SECRET` | `web.*` |
+| `TOUGHRADIUS_WEB_HOST` / `_WEB_PORT` / `_WEB_TLS_ENABLED` / `_WEB_TLS_PORT` / `_WEB_SECRET` | `web.*` |
 | `TOUGHRADIUS_DB_TYPE` / `_DB_HOST` / `_DB_PORT` / `_DB_NAME` / `_DB_USER` / `_DB_PWD` / `_DB_DEBUG` | `database.*` |
 | `TOUGHRADIUS_RADIUS_ENABLED` / `_RADIUS_HOST` / `_RADIUS_AUTHPORT` / `_RADIUS_ACCTPORT` / `_RADIUS_DEBUG` | `radiusd.*` |
 | `TOUGHRADIUS_RADIUS_RADSEC_PORT` / `_RADIUS_RADSEC_WORKER` / `_RADIUS_RADSEC_CA_CERT` / `_RADIUS_RADSEC_CERT` / `_RADIUS_RADSEC_KEY` | RadSec 配置 |
@@ -146,7 +147,7 @@ RADIUS 运行时配置（EAP 方法、证书、间隔、拒绝延迟等）存储
 | 使用方 | 文件 | 说明 |
 | ------ | ---- | ---- |
 | **RadSec** | `radiusd.radsec_ca_cert` / `radsec_cert` / `radsec_key` | TLS 1.2+；客户端证书**提供则校验**（`VerifyClientCertIfGiven`） |
-| **Web HTTPS** | `{workdir}/private/toughradius.tls.crt` + `.key`（固定路径） | 监听 `web.tls_port`；加载失败仅记日志，HTTP 继续运行 |
+| **Web HTTPS** | `{workdir}/private/toughradius.tls.crt` + `.key`（固定路径） | `web.tls_enabled` 为 true 时监听 `web.tls_port`；加载失败仅记日志，HTTP 继续运行 |
 | **EAP（TLS/PEAP/TTLS）** | 系统配置 → `EapTlsCertFile`、`EapTlsKeyFile`、`EapTlsCaFile`、`EapTlsMinVersion` | 证书/私钥留空即禁用基于 TLS 的 EAP 方法 |
 
 用内置工具一次生成 CA/服务器/客户端全套证书：

--- a/internal/webserver/server.go
+++ b/internal/webserver/server.go
@@ -319,20 +319,28 @@ func chromeDevtoolsManifest(c echo.Context) error {
 // Start Admin Server
 func (s *AdminServer) Start() error {
 	appconfig := s.appCtx.Config()
-	go func() {
-		zap.S().Infof("Prepare to start the TLS management port %s:%d", appconfig.Web.Host, appconfig.Web.TlsPort)
-		err := s.root.StartTLS(fmt.Sprintf("%s:%d", appconfig.Web.Host, appconfig.Web.TlsPort),
-			path.Join(appconfig.GetPrivateDir(), "toughradius.tls.crt"), path.Join(appconfig.GetPrivateDir(), "toughradius.tls.key"))
-		if err != nil {
-			zap.S().Errorf("Error starting TLS management port %s", err.Error())
-		}
-	}()
+	if shouldStartTLSManagementPort(appconfig.Web.TlsEnabled) {
+		go func() {
+			zap.S().Infof("Prepare to start the TLS management port %s:%d", appconfig.Web.Host, appconfig.Web.TlsPort)
+			err := s.root.StartTLS(fmt.Sprintf("%s:%d", appconfig.Web.Host, appconfig.Web.TlsPort),
+				path.Join(appconfig.GetPrivateDir(), "toughradius.tls.crt"), path.Join(appconfig.GetPrivateDir(), "toughradius.tls.key"))
+			if err != nil {
+				zap.S().Errorf("Error starting TLS management port %s", err.Error())
+			}
+		}()
+	} else {
+		zap.S().Info("TLS management port disabled by configuration")
+	}
 	zap.S().Infof("Start the management server %s:%d", appconfig.Web.Host, appconfig.Web.Port)
 	err := s.root.Start(fmt.Sprintf("%s:%d", appconfig.Web.Host, appconfig.Web.Port))
 	if err != nil {
 		zap.S().Errorf("Error starting management server %s", err.Error())
 	}
 	return err
+}
+
+func shouldStartTLSManagementPort(enabled *bool) bool {
+	return enabled == nil || *enabled
 }
 
 // ParseJwtToken Parse Jwt Token

--- a/internal/webserver/server_test.go
+++ b/internal/webserver/server_test.go
@@ -35,3 +35,12 @@ func TestJwtSkipFuncDoesNotBypassWithDevmode(t *testing.T) {
 	t.Setenv("TOUGHRADIUS_DEVMODE", "true")
 	assert.False(t, skip(newCtx(apiBasePath+"/users")))
 }
+
+func TestShouldStartTLSManagementPort(t *testing.T) {
+	enabled := true
+	disabled := false
+
+	assert.True(t, shouldStartTLSManagementPort(nil), "nil preserves legacy enabled behavior")
+	assert.True(t, shouldStartTLSManagementPort(&enabled))
+	assert.False(t, shouldStartTLSManagementPort(&disabled))
+}

--- a/scripts/init-db.sh
+++ b/scripts/init-db.sh
@@ -85,6 +85,7 @@ system:
 web:
   host: 0.0.0.0
   port: 1816
+  tls_enabled: true
   tls_port: 1817
   secret: 9b6de5cc-0731-1203-xxtt-0f568ac9da37
 
@@ -191,6 +192,7 @@ system:
 web:
   host: 0.0.0.0
   port: 1816
+  tls_enabled: true
   tls_port: 1817
   secret: 9b6de5cc-0731-1203-xxtt-0f568ac9da37
 


### PR DESCRIPTION
## Summary

- Add `web.tls_enabled` and `TOUGHRADIUS_WEB_TLS_ENABLED` to explicitly control the built-in HTTPS admin listener.
- Preserve legacy compatibility by defaulting omitted `web.tls_enabled` to enabled.
- Skip the TLS management port when the new switch is false, while keeping HTTP management service behavior unchanged.
- Update bilingual docs, FAQ, init-db samples, and targeted tests.

## Validation

- `go test ./config ./internal/webserver`
- `git diff --check`

## Notes

- `go test -short ./...` was also attempted, but existing `internal/radiusd` test `TestServeRADIUSCountsDropOnPanicRecover` timed out after 10 minutes in `internal/radiusd/radius_acct.go:57`; this is outside the Web TLS toggle change.
