### PR TITLE
docs(config): add Web TLS env example (#520)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,8 @@ TOUGHRADIUS_SYSTEM_DEBUG=true
 # ============================================
 TOUGHRADIUS_WEB_HOST=0.0.0.0
 TOUGHRADIUS_WEB_PORT=1816
+# 设为 false 可关闭内置 HTTPS 管理监听
+TOUGHRADIUS_WEB_TLS_ENABLED=true
 TOUGHRADIUS_WEB_TLS_PORT=1817
 # 必须在生产环境改为每个实例唯一的长随机值；该值用于签发管理后台 JWT。
 TOUGHRADIUS_WEB_SECRET=change-me-to-a-long-random-string


### PR DESCRIPTION
## 关联 issue

- Closes #520

## 改动范围

- 在 `.env.example` 的 Web 服务配置段补充 `TOUGHRADIUS_WEB_TLS_ENABLED=true`。
- 添加注释说明设为 `false` 可关闭内置 HTTPS 管理监听。

## 验证

- [x] `rg -n "TOUGHRADIUS_WEB_TLS_ENABLED|web\.tls_enabled" .env.example docs-site/src/en/ops-guide.md docs-site/src/zh/ops-guide.md docs-site/src/en/faq.md docs-site/src/zh/faq.md config/config.go`
- [x] `go test ./config ./internal/webserver`
- [x] `git diff --check`
- [x] commit/push hooks: `go test ./...`, `go vet ./...`, formatting, build, and module dependency checks passed; `golangci-lint` reported existing non-blocking warnings from unrelated paths and the hook completed successfully.

## 风险

未发现新增运行时风险；本 PR 只更新环境变量样例，不改变配置解析、默认值或监听行为。

## 回滚

Revert 本 PR 即可恢复 `.env.example` 原样。

## 审批

已标记 `human-approval`，等待成员批准后再合并。
