### PR TITLE
docs(roadmap): refresh M5.1 vendor VSA inventory and reconcile M5 status (TR-F005)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -34,7 +34,7 @@ The Chinese roadmap keeps the detailed agent delivery log. This English roadmap 
 | M2 | CoA dynamic authorization | TR-F010 / TR-F012 / TR-F013 | P1 | Delivered |
 | M3 | IPv6 capability closure | TR-F007 / TR-F011 / TR-F015 | P1 | Delivered |
 | M4 | Agent development system and quality gates | TR-F022 / TR-F024 | P2 | Delivered |
-| M5 | Vendor VSA coverage expansion | TR-F005 | P2 | Planned |
+| M5 | Vendor VSA coverage expansion | TR-F005 | P2 | In progress |
 | M6 | Observability and operations improvements | TR-F015 | P3 | Planned |
 | M7 | Upstream RADIUS library tracking and protocol compliance | TR-F021 / TR-F022 | P2 | In progress |
 | M8 | PEAPv0 / EAP-MSCHAPv2 authentication | TR-F004 | P1 | Delivered |
@@ -53,11 +53,11 @@ The Chinese roadmap keeps the detailed agent delivery log. This English roadmap 
 
 ## Current Execution Queue
 
-The next executable milestone is **M5 vendor VSA expansion**. M14.6 now has CI-backed OpenLDAP acceptance coverage; M14.5 remains blocked until load evidence justifies connection pooling / reconnect work.
+The next executable milestone is **M5 vendor VSA expansion**: the M5.1 inventory and the M5.2/M5.3 parser + enhancer batch are delivered, and **M5.4** (Cisco `cisco-avpair` Access-Accept enhancer) is the next pickable subtask. M14.6 now has CI-backed OpenLDAP acceptance coverage; M14.5 remains blocked until load evidence justifies connection pooling / reconnect work.
 
 | Order | Task | Status | Acceptance focus |
 | --- | --- | --- | --- |
-| 1 | M5 vendor VSA expansion | Planned | Add parser/enhancer coverage with vendor packet samples |
+| 1 | M5 vendor VSA expansion | In progress | M5.1 inventory + M5.2/M5.3 parsers/enhancer delivered; M5.4 Cisco `cisco-avpair` enhancer next, with vendor packet samples |
 | 2 | M7 upstream and RFC compliance tracking | In progress | Evaluate upstream fixes and add RFC-backed regression tests when behavior changes |
 | 3 | M10 EAP-TLS 1.3 / RFC 9190 | Planned | Keep TLS 1.2 compatibility while adding TLS 1.3 key derivation and close-notify semantics |
 | 4 | M14.5 LDAP connection robustness | Blocked: waiting for load evidence | Revisit pooling/reconnect design only when connection cost or cancellation evidence justifies the complexity |
@@ -66,7 +66,10 @@ Agent-facing unchecked tasks:
 
 - [x] M14.6 LDAP integration acceptance tests: add CI-executable `test/integration/` coverage with a real OpenLDAP service container and seed LDIF. Delivered via `test/integration/ldap_test.go` plus CI / local compose OpenLDAP service wiring: plain PAP and `EAP-TTLS/PAP` authenticate through real LDAP bind while local `RadiusUser.Password` is deliberately wrong; wrong password rejects as `radus_reject_passwd_error`; directory unavailable and non-PAP CHAP reject as `radus_reject_ldap_error` with diagnostic reply text.
 - [ ] M14.5 (Blocked: waiting for load evidence) LDAP connection robustness: revisit pooling, reconnect, and request-context propagation only when load evidence shows connection setup cost or cancellation behavior justifies the added complexity.
-- [ ] M5.1 Inventory pending vendor VSA gaps and dictionary differences.
+- [x] M5.1 Inventory pending vendor VSA gaps and dictionary differences. Delivered: `docs/vendor-vsa-gap-baseline.md` refreshed to HEAD `9882f79e` — registered parsers `default + huawei + h3c + zte + radback + alcatel + aruba + juniper`, response enhancers `default + huawei + h3c + zte + mikrotik + ikuai + aruba`, a corrected gap matrix, a delta-since-#433 section, and the next-batch backlog. (The first baseline #433 was superseded once M5.2/M5.3 landed; `#470` had re-opened this checkbox.)
+- [x] M5.2 Add request-side vendor parsers for genuine MAC/VLAN request VSAs. Delivered: `radback` (#449), `alcatel` (#450), `aruba` (#451), and `juniper` (#453) request parsers, plus the `vendors.CodeAlcatel` / `CodeAruba` constants.
+- [x] M5.3 Add the first vendor Access-Accept response enhancer. Delivered: `aruba` response enhancer registered in `plugins/init.go` (#456) with sample-based tests.
+- [ ] M5.4 Add a Cisco `cisco-avpair` Access-Accept response enhancer (the most common vendor reply attribute; `cisco` already has its `Code*` constant and dictionary package, only the enhancer is missing). Follow the enhancer + `plugins/init.go` registration + sample-test pattern. Remaining enhancers (`alcatel` / `juniper` / `radback` / `microsoft` / `f5` / `hillstone` / `pfSense`) stay demand-driven.
 - [ ] M7.1 Manually evaluate important upstream `layeh.com/radius` fixes and decide whether to sync the `talkincode/radius` fork and update the `go.mod` replacement.
 - [ ] M10.1 Add TLS 1.3 handshake negotiation and TLS 1.2 fallback for EAP-TLS.
 

--- a/docs/roadmap.zh.md
+++ b/docs/roadmap.zh.md
@@ -34,7 +34,7 @@
 | M2 | CoA 动态授权支持 | TR-F010 / TR-F012 / TR-F013 | P1 | 已交付 |
 | M3 | IPv6 能力增强闭环 | TR-F007 / TR-F011 / TR-F015 | P1 | 已交付 |
 | M4 | Agent 开发体系与质量门禁 | TR-F022 | P2 | 已交付 |
-| M5 | 厂商 VSA 覆盖扩展 | TR-F005 | P2 | 计划中 |
+| M5 | 厂商 VSA 覆盖扩展 | TR-F005 | P2 | 进行中 |
 | M6 | 可观测性与运维增强 | TR-F015 | P3 | 计划中 |
 | M7 | 上游 RADIUS 库跟踪与协议合规 | TR-F021 / TR-F022 | P2 | 进行中 |
 | M8 | PEAPv0 / EAP-MSCHAPv2 认证支持 | TR-F004 | P1 | 已交付 |
@@ -160,9 +160,10 @@
 - **技能**：`.agents/skills/add-radius-vendor/SKILL.md`
 
 子任务：
-- [ ] M5.1 梳理待补厂商清单与字典差异
-- [ ] M5.2 逐厂商按现有模式接入 parser / enhancer
-- [ ] M5.3 厂商样例包覆盖解析与响应属性
+- [x] M5.1 梳理待补厂商清单与字典差异<br/>**已交付**：`docs/vendor-vsa-gap-baseline.md` 刷新至 HEAD `9882f79e` 的当前真实状态——已注册 parser `default + huawei + h3c + zte + radback + alcatel + aruba + juniper`、响应 enhancer `default + huawei + h3c + zte + mikrotik + ikuai + aruba`；修正差距矩阵、补「自 #433 首版以来的增量」小节与下一批 backlog。首版基线 #433 在 M5.2/M5.3 落地后已过时，且 `#470`（路线图英文优先化）一度把本勾选项重新打开，本轮据实重勾并刷新。仅文档、无运行逻辑变更。
+- [x] M5.2 逐厂商按现有模式接入 request parser（针对真正的厂商私有 MAC/VLAN 请求 VSA）<br/>**已交付**：`radback`（#449，MAC + VLAN）、`alcatel`（#450，MAC）、`aruba`（#451，VLAN）、`juniper`（#453，VoIP VLAN）request parser，并补 `vendors.CodeAlcatel` / `CodeAruba` 常量；各带样例解析测试。`mikrotik` / `ikuai` 请求侧用标准 `Calling-Station-Id`，其 VLAN VSA 属 Access-Accept 回执属性，dedicated parser 与 `DefaultParser` 行为一致，故不补。
+- [x] M5.3 首个厂商 Access-Accept 响应 enhancer<br/>**已交付**：`aruba` 响应 enhancer 注册进 `plugins/init.go`（#456），带样例响应属性测试。（原子任务标题「样例包覆盖解析与响应属性」已并入每厂商验收集——parser/enhancer 均随样例测试交付。）
+- [ ] M5.4 新增 Cisco `cisco-avpair` Access-Accept 响应 enhancer（最常见的厂商回执属性；`cisco` 已有 `Code*` 常量与字典包，仅缺 enhancer）。按 enhancer + `plugins/init.go` 注册 + 样例测试模式实现。其余 enhancer（`alcatel` / `juniper` / `radback` / `microsoft` / `f5` / `hillstone` / `pfSense`）按部署需求驱动。
 
 ## M6 — 可观测性与运维增强
 

--- a/docs/vendor-vsa-gap-baseline.md
+++ b/docs/vendor-vsa-gap-baseline.md
@@ -1,8 +1,12 @@
 # TR-F005 / M5.1 Vendor VSA Gap Baseline
 
-This document records the M5.1 baseline for "vendor backlog and dictionary gaps"
-under TR-F005. It is intentionally snapshot-style so M5.2 can execute by batch
-without re-discovering the same scope.
+This document is the M5.1 inventory for "vendor backlog and dictionary gaps"
+under TR-F005. It is intentionally snapshot-style so the next M5 batch can
+execute without re-discovering the same scope.
+
+> Refreshed after the M5.2 request-parser batch (#449–#454) and the M5.3 Aruba
+> response enhancer (#456) landed. The first baseline (#433) predated that work
+> and is superseded by the matrix below; see "Delta since the first baseline".
 
 ## Scope and Method
 
@@ -10,82 +14,108 @@ Inspection sources:
 
 - `internal/radiusd/vendors/*`
 - `internal/radiusd/vendors/codes.go`
-- `internal/radiusd/plugins/vendorparsers/parsers/*_parser.go`
-- `internal/radiusd/plugins/auth/enhancers/*_enhancer.go`
+- `internal/radiusd/plugins/vendorparsers/parsers/init.go` (parser registration —
+  the source of truth for what is actually active, not just the `*_parser.go`
+  files present)
+- `internal/radiusd/plugins/init.go` (`RegisterResponseEnhancer` registration)
 - `share/dictionary` and `share/dictionary.*`
 
 Snapshot commands (reproducible):
 
 ```bash
-git rev-parse --short HEAD
+git rev-parse --short HEAD                                  # 9882f79e
 ls internal/radiusd/vendors
-ls internal/radiusd/plugins/vendorparsers/parsers/*_parser.go
-ls internal/radiusd/plugins/auth/enhancers/*_enhancer.go
-rg '^\$INCLUDE\s+dictionary\.' share/dictionary
+grep -E 'Code[A-Z]' internal/radiusd/vendors/codes.go
+grep -E 'Code(Huawei|H3C|ZTE|Radback|Alcatel|Aruba|Juniper)' \
+  internal/radiusd/plugins/vendorparsers/parsers/init.go    # registered parsers
+grep RegisterResponseEnhancer internal/radiusd/plugins/init.go
+grep -c '^\$INCLUDE' share/dictionary                       # 213
 ```
 
-## Coverage Snapshot
+## Coverage Snapshot (HEAD 9882f79e)
 
 - Generated vendor dictionary packages: `15`
-- Registered vendor parsers: `default + huawei + h3c + zte`
-- Registered vendor enhancers: `default + huawei + h3c + zte + mikrotik + ikuai`
-- `share/dictionary` includes `213` dictionary entries; the repo currently ships
-  generated packages for `15` vendors.
+- Registered vendor parsers (`parsers/init.go`): `default + huawei + h3c + zte +
+  radback + alcatel + aruba + juniper` (7 vendors + default)
+- Registered response enhancers (`plugins/init.go`): `default + huawei + h3c +
+  zte + mikrotik + ikuai + aruba` (6 vendors + default)
+- `share/dictionary` includes `213` `$INCLUDE dictionary.*` entries; the repo
+  ships generated packages for `15` of those vendors.
 
-## M5.1 Gap Matrix
+## Why a parser is not always worth adding
 
-| Vendor Package | Vendor ID | `Code*` Constant | Parser | Enhancer | Dictionary Source Gap |
+`vendorparsers.VendorRequest` carries only `MacAddr`, `Vlanid1`, `Vlanid2`. A
+vendor **parser** therefore adds value only when the vendor encodes MAC/VLAN with
+a vendor-specific **request** VSA; otherwise it merely duplicates `DefaultParser`,
+which already reads the standard `Calling-Station-Id`. The response **enhancer**
+(rate / VLAN / `avpair` reply attributes) is a separate, demand-driven track and
+does not depend on a parser.
+
+## M5.1 Gap Matrix (current)
+
+| Vendor Package | Vendor ID | `Code*` Constant | Parser | Enhancer | Dictionary Source |
 | --- | ---: | --- | --- | --- | --- |
-| `alcatel` | 3041 | missing | missing | missing | `share/dictionary.alcatel` exists |
-| `aruba` | 14823 | missing | missing | missing | `share/dictionary.aruba` exists |
-| `cisco` | 9 | present | missing | missing | `share/dictionary.cisco` exists |
-| `f5` | 3375 | present | missing | missing | `share/dictionary.f5` exists |
-| `h3c` | 25506 | present | present | present | none |
-| `hillstone` | 28557 | present | missing | missing | `share/dictionary.hillstone` exists |
-| `huawei` | 2011 | present | present | present | none |
-| `ikuai` | 10055 | present | missing | present | no `share/dictionary.ikuai` file in tree |
-| `juniper` | 2636 | present | missing | missing | `share/dictionary.juniper` exists |
-| `microsoft` | 311 | present | missing | missing | `share/dictionary.microsoft` exists |
-| `mikrotik` | 14988 | present | missing | present | `share/dictionary.mikrotik` exists |
-| `pfSense` | 13644 | present | missing | missing | source file name is `dictionary.pfsense` (case mapping) |
-| `radback` | 2352 | present | missing | missing | no `share/dictionary.radback` or `dictionary.redback` file |
-| `unix` | 4 | missing | missing | missing | `share/dictionary.unix` exists |
-| `zte` | 3902 | present | present | present | none |
+| `alcatel` | 3041 | present | present | missing | `share/dictionary.alcatel` |
+| `aruba` | 14823 | present | present | present | `share/dictionary.aruba` |
+| `cisco` | 9 | present | missing | missing | `share/dictionary.cisco` |
+| `f5` | 3375 | present | missing | missing | `share/dictionary.f5` |
+| `h3c` | 25506 | present | present | present | `share/dictionary.h3c` |
+| `hillstone` | 28557 | present | missing | missing | `share/dictionary.hillstone` |
+| `huawei` | 2011 | present | present | present | `share/dictionary.huawei` |
+| `ikuai` | 10055 | present | missing | present | no `share/dictionary.ikuai` in tree |
+| `juniper` | 2636 | present | present | missing | `share/dictionary.juniper` |
+| `microsoft` | 311 | present | missing | missing | `share/dictionary.microsoft` |
+| `mikrotik` | 14988 | present | missing | present | `share/dictionary.mikrotik` |
+| `pfSense` | 13644 | present | missing | missing | `share/dictionary.pfsense` (case mapping) |
+| `radback` | 2352 | present | present | missing | no `share/dictionary.radback`/`.redback` in tree |
+| `unix` | 4 | missing (`CodeUnix`) | missing | missing | `share/dictionary.unix` |
+| `zte` | 3902 | present | present | present | `share/dictionary.zte` |
 
-## Prioritized Backlog for M5.2
+## Delta since the first baseline (#433)
 
-> Prioritization corrected during M5.1 → M5.2 grooming, anchored to the gap
-> matrix above and to the `vendorparsers.VendorRequest` model (it carries only
-> `MacAddr` + two `Vlanid` fields). A vendor **parser** therefore adds value only
-> when the vendor encodes MAC/VLAN with a vendor-specific VSA **on the request
-> side**; otherwise it merely duplicates `DefaultParser` (which already reads the
-> standard `Calling-Station-Id`). The response **enhancer** (rate/VLAN reply
-> attributes) is a separate, demand-driven track and does not depend on a parser.
+The M5.2 / M5.3 batches closed the high-value request-side parser gaps and the
+first response enhancer that the first baseline listed as pending:
 
-1. Parsers with genuine request-side value — vendors whose dictionary exposes a
-   vendor-specific MAC/VLAN request attribute (verify request/response semantics
-   per vendor dictionary + spec before implementing):
-   - `radback` (`Mac-Addr` / `Bind-Dot1q-Vlan-Tag-Id`)
-   - `alcatel` (`AAT-User-MAC-Address`)
-   - `aruba` (`Aruba-User-Vlan`)
-   - `juniper` (`Juniper-VoIP-Vlan`)
-2. Enhancers (response attributes) — drive by deployment demand, independently of
-   parser work; `cisco` (`cisco-avpair`), `juniper`, `microsoft` are common asks.
-3. De-prioritized "symmetry-only" parsers — `mikrotik`, `ikuai` use the standard
-   `Calling-Station-Id` on the request side (their VLAN VSAs such as
-   `Mikrotik-Wireless-VLANID` are Access-Accept reply attributes), so a dedicated
-   parser would be behaviorally identical to `DefaultParser`. Add one only if a
-   concrete deployment proves a vendor-specific request encoding. (The original
-   baseline listed these as batch 1 — that was a misjudgment, now corrected.)
-4. Remaining generated vendors with no current request-side parser value:
-   `cisco`, `f5`, `hillstone`, `pfSense`, `unix`, `microsoft` — close as
-   enhancer/registry work or when a deployment surfaces a real attribute need.
-   Note: `alcatel`, `aruba`, `unix` still lack a `vendors.Code*` constant; add it
-   before registering a parser/enhancer.
-5. For each vendor in M5.2, follow the same acceptance set:
-   - parser + registration + enhancer (if response VSA required)
-   - sample-based parser/enhancer tests
-   - `go test ./internal/radiusd/...` and `golangci-lint` green
+- `radback` request parser — MAC + VLAN (#449)
+- `alcatel` request parser — MAC, plus the `vendors.CodeAlcatel` constant (#450)
+- `aruba` request parser — VLAN, plus the `vendors.CodeAruba` constant (#451)
+- `juniper` request parser — VoIP VLAN (#453)
+- `aruba` Access-Accept response enhancer (#456, M5.3)
+
+The first baseline also reported `alcatel` / `aruba` as missing their `Code*`
+constant; both now exist in `codes.go`. Only `unix` still lacks a `Code*`
+constant.
+
+## Remaining gaps / backlog for the next M5 batch
+
+The high-value request-side parsers are now delivered (see Delta above), so the
+remaining TR-F005 work is response-enhancer and hygiene work:
+
+1. **Response enhancers (demand-driven), no parser dependency.** Highest value
+   first:
+   - `cisco` `cisco-avpair` — the most common vendor reply attribute; `cisco`
+     already has its `Code*` constant and dictionary package, only the enhancer
+     is missing. Tracked as **M5.4**.
+   - `alcatel`, `juniper`, `radback` — already have a request parser but no
+     response enhancer; add when a deployment needs their reply attributes.
+   - `microsoft`, `f5`, `hillstone`, `pfSense` — neither parser nor enhancer;
+     close as enhancer / registry work when demand surfaces.
+2. **Parsers — high-value request-side MAC/VLAN vendors are done.** Add a new
+   parser only when a vendor dictionary proves a vendor-specific MAC/VLAN
+   **request** encoding (otherwise it duplicates `DefaultParser`).
+3. **Symmetry-only parsers stay deferred.** `mikrotik`, `ikuai` already ship
+   response enhancers; their VLAN VSAs (e.g. `Mikrotik-Wireless-VLANID`) are
+   Access-Accept reply attributes and their request side uses the standard
+   `Calling-Station-Id`, so a dedicated parser would behave identically to
+   `DefaultParser`.
+4. **Hygiene.** `unix` (VendorID 4) has a generated package and a
+   `share/dictionary.unix` source but no `vendors.CodeUnix` constant; add the
+   constant only if/when a `unix` parser or enhancer is actually wired.
+5. **Per-vendor acceptance set (unchanged).**
+   - parser + registration in `parsers/init.go`, and/or enhancer + registration
+     in `plugins/init.go`
+   - sample-based parser / enhancer tests with real attribute samples
+   - `go test ./internal/radiusd/...` and `golangci-lint` (v2.12.2) green
 
 ## Non-Goals of M5.1
 


### PR DESCRIPTION
# Summary

Refreshes the **M5.1 vendor VSA inventory** to the current code truth and reconciles the M5 status across both roadmaps. The roadmap had M5.1 unchecked again after `#470` (English-first migration) re-opened the checkbox, even though M5.1 was delivered (`#433`) and the M5.2 parser batch (`#449`–`#454`) + M5.3 aruba enhancer (`#456`) have since landed in `main`. The old baseline doc was therefore **stale and misleading** — it still claimed `alcatel`/`aruba`/`juniper`/`radback` had no parser.

## Roadmap Mapping (Required for agent tasks)

- Milestone subtask: `M5.1`
- Feature ID(s): `TR-F005`
- Out-of-scope non-goals checked: `TR-N001` `TR-N002` `TR-N003` `TR-N004` `TR-N005` (none touched)

## What Changed

- **`docs/vendor-vsa-gap-baseline.md`** — refreshed to HEAD `9882f79e`:
  - Corrected gap matrix (parsers now `default + huawei + h3c + zte + radback + alcatel + aruba + juniper`; enhancers `default + huawei + h3c + zte + mikrotik + ikuai + aruba`).
  - Inspection sources/snapshot commands now point at the **registration files** (`parsers/init.go`, `plugins/init.go`) — the source of truth for what is actually active, not just `*_parser.go` files present.
  - Added a "Delta since the first baseline (#433)" section and a refreshed next-batch backlog; `unix` flagged as the only package still missing a `Code*` constant.
- **`docs/roadmap.md`** — marked M5.1/M5.2/M5.3 delivered, set M5 `Planned → In progress`, updated the execution queue, and added **M5.4** (Cisco `cisco-avpair` Access-Accept enhancer) as the next pickable subtask.
- **`docs/roadmap.zh.md`** — mirrored the M5 status with delivery records and M5.4 (CN/EN kept in sync).

## Acceptance Criteria Covered

- [x] The change only covers the mapped `TR-F005` scope
- [x] Protocol behavior updates include RFC clause references — N/A (docs-only, no protocol behavior change)
- [x] Protocol or E2E behavior changes include CI-runnable acceptance tests — N/A (docs-only)

## Verification

- [x] `go build ./...` (green; sanity check — only `.md` files changed)
- [x] `go test ./...` — unaffected; zero Go/code/workflow/frontend files changed (CI runs the full suite)
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run` — unaffected (no Go changes)
- [x] `cd web && npm run build` — N/A (no frontend changes)

## Risks and Rollback

- Risk level: `low`
- Main risk: documentation/bookkeeping only; no runtime behavior change.
- Rollback plan: revert this commit; no code or schema impact.

## Reviewer Notes

- Suggested review order: `docs/vendor-vsa-gap-baseline.md` (the inventory) → `docs/roadmap.md` → `docs/roadmap.zh.md`.
- Assumptions: M5.2 (`#449`–`#454`) and M5.3 (`#456`) are confirmed present in `origin/main`; the new gap matrix was verified against `codes.go`, `parsers/init.go`, `plugins/init.go`, and `share/dictionary*` at HEAD `9882f79e`.
- Next pick after merge: `M5.4` Cisco `cisco-avpair` enhancer (remaining enhancers stay demand-driven).