### PR TITLE
feat(radiusd): add Cisco Access-Accept response enhancer (M5.4)

### DIFF
--- a/internal/radiusd/plugins/auth/enhancers/cisco_enhancer.go
+++ b/internal/radiusd/plugins/auth/enhancers/cisco_enhancer.go
@@ -1,0 +1,74 @@
+package enhancers
+
+import (
+	"context"
+
+	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/auth"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/vendors"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/vendors/cisco"
+	"github.com/talkincode/toughradius/v9/pkg/common"
+)
+
+// ciscoAddrPoolAVPair is the Cisco-AVPair directive prefix that assigns a
+// subscriber's framed address from a NAS-local address pool. Cisco IOS /
+// IOS-XE / IOS-XR and ISG honor the string form "ip:addr-pool=<pool-name>";
+// several of these platforms select a local pool only from this vendor AVPair
+// and ignore the standard Framed-Pool (RFC 2869, attribute 88) that
+// DefaultAcceptEnhancer also emits, so sending both maximizes cross-platform
+// pool assignment.
+const ciscoAddrPoolAVPair = "ip:addr-pool="
+
+// CiscoAcceptEnhancer adds Cisco's canonical Cisco-AVPair (SMI Private
+// Enterprise Code 9, VSA type 1) reply attributes to an Access-Accept for
+// sessions terminating on a Cisco NAS.
+type CiscoAcceptEnhancer struct{}
+
+// NewCiscoAcceptEnhancer returns a CiscoAcceptEnhancer ready for registration.
+func NewCiscoAcceptEnhancer() *CiscoAcceptEnhancer {
+	return &CiscoAcceptEnhancer{}
+}
+
+// Name returns the response-enhancer registry key for the Cisco enhancer.
+func (e *CiscoAcceptEnhancer) Name() string {
+	return "accept-cisco"
+}
+
+// Enhance appends Cisco's primary provisioning attribute to the Access-Accept:
+//
+//   - Cisco-AVPair "ip:addr-pool=<pool>" (type 1, string): assigns the framed
+//     address from a NAS-local pool named by the user's configured address pool,
+//     resolved through GetAddrPool so profile inheritance is honored. This is
+//     the most widely deployed Cisco reply AVPair for subscriber IP
+//     provisioning. It is appended (not set) because Cisco-AVPair is a
+//     multi-valued attribute: each directive is carried as its own instance, so
+//     appending never clobbers another AVPair sharing the packet.
+//
+// Enhance is a no-op for a nil context/response/user, for non-Cisco NAS
+// devices, and when the address pool is unset, so it never mutates an
+// Access-Accept it does not own.
+func (e *CiscoAcceptEnhancer) Enhance(ctx context.Context, authCtx *auth.AuthContext) error {
+	if authCtx == nil || authCtx.Response == nil || authCtx.User == nil {
+		return nil
+	}
+	if !matchVendor(authCtx, vendors.CodeCisco) {
+		return nil
+	}
+
+	user := authCtx.User
+	resp := authCtx.Response
+
+	// Get profile cache from metadata
+	var profileCache interface{}
+	if authCtx.Metadata != nil {
+		profileCache = authCtx.Metadata["profile_cache"]
+	}
+
+	// Cisco-AVPair "ip:addr-pool=<pool>": assign the framed address from a
+	// NAS-local pool when the user (or its profile) names one.
+	addrPool := user.GetAddrPool(profileCache)
+	if common.IsNotEmptyAndNA(addrPool) {
+		_ = cisco.CiscoAVPair_AddString(resp, ciscoAddrPoolAVPair+addrPool) //nolint:errcheck
+	}
+
+	return nil
+}

--- a/internal/radiusd/plugins/auth/enhancers/cisco_enhancer_test.go
+++ b/internal/radiusd/plugins/auth/enhancers/cisco_enhancer_test.go
@@ -1,0 +1,149 @@
+package enhancers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/talkincode/toughradius/v9/internal/domain"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/auth"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/vendors"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/vendors/cisco"
+	"layeh.com/radius"
+)
+
+func TestCiscoAcceptEnhancer_Name(t *testing.T) {
+	enhancer := NewCiscoAcceptEnhancer()
+	assert.Equal(t, "accept-cisco", enhancer.Name())
+}
+
+func TestCiscoAcceptEnhancer_Enhance_NilSafety(t *testing.T) {
+	enhancer := NewCiscoAcceptEnhancer()
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		authCtx *auth.AuthContext
+	}{
+		{
+			name:    "nil context",
+			authCtx: nil,
+		},
+		{
+			name: "nil response",
+			authCtx: &auth.AuthContext{
+				User: &domain.RadiusUser{},
+			},
+		},
+		{
+			name: "nil user",
+			authCtx: &auth.AuthContext{
+				Response: radius.New(radius.CodeAccessAccept, []byte("secret")),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := enhancer.Enhance(ctx, tt.authCtx)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestCiscoAcceptEnhancer_Enhance_VendorMatch(t *testing.T) {
+	enhancer := NewCiscoAcceptEnhancer()
+	ctx := context.Background()
+
+	tests := []struct {
+		name          string
+		vendorCode    string
+		shouldEnhance bool
+	}{
+		{
+			name:          "cisco vendor",
+			vendorCode:    vendors.CodeCisco,
+			shouldEnhance: true,
+		},
+		{
+			name:          "other vendor",
+			vendorCode:    vendors.CodeHuawei,
+			shouldEnhance: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response := radius.New(radius.CodeAccessAccept, []byte("secret"))
+			user := &domain.RadiusUser{
+				Username: "testuser",
+				AddrPool: "pool-a",
+			}
+			nas := &domain.NetNas{
+				VendorCode: tt.vendorCode,
+			}
+
+			authCtx := &auth.AuthContext{
+				Response: response,
+				User:     user,
+				Nas:      nas,
+			}
+
+			err := enhancer.Enhance(ctx, authCtx)
+			require.NoError(t, err)
+
+			avpair := cisco.CiscoAVPair_GetString(response)
+			if tt.shouldEnhance {
+				assert.Equal(t, "ip:addr-pool=pool-a", avpair)
+			} else {
+				assert.Equal(t, "", avpair)
+			}
+		})
+	}
+}
+
+func TestCiscoAcceptEnhancer_Enhance_AddrPool(t *testing.T) {
+	enhancer := NewCiscoAcceptEnhancer()
+	ctx := context.Background()
+
+	tests := []struct {
+		name         string
+		addrPool     string
+		expectAVPair string // "" means the attribute must be absent
+	}{
+		{name: "named pool", addrPool: "subscribers", expectAVPair: "ip:addr-pool=subscribers"},
+		{name: "empty pool skipped", addrPool: "", expectAVPair: ""},
+		{name: "NA pool skipped", addrPool: "N/A", expectAVPair: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response := radius.New(radius.CodeAccessAccept, []byte("secret"))
+			user := &domain.RadiusUser{
+				Username: "testuser",
+				AddrPool: tt.addrPool,
+			}
+			nas := &domain.NetNas{VendorCode: vendors.CodeCisco}
+
+			authCtx := &auth.AuthContext{
+				Response: response,
+				User:     user,
+				Nas:      nas,
+			}
+
+			err := enhancer.Enhance(ctx, authCtx)
+			require.NoError(t, err)
+
+			// Use Lookup so a skipped pool asserts true absence rather than the
+			// empty value that Get cannot distinguish from a present "".
+			value, lookupErr := cisco.CiscoAVPair_LookupString(response)
+			if tt.expectAVPair == "" {
+				assert.ErrorIs(t, lookupErr, radius.ErrNoAttribute)
+			} else {
+				require.NoError(t, lookupErr)
+				assert.Equal(t, tt.expectAVPair, value)
+			}
+		})
+	}
+}

--- a/internal/radiusd/plugins/init.go
+++ b/internal/radiusd/plugins/init.go
@@ -41,6 +41,7 @@ func InitPlugins(appCtx app.ConfigManagerProvider, sessionRepo repository.Sessio
 	registry.RegisterResponseEnhancer(enhancers.NewMikrotikAcceptEnhancer())
 	registry.RegisterResponseEnhancer(enhancers.NewIkuaiAcceptEnhancer())
 	registry.RegisterResponseEnhancer(enhancers.NewArubaAcceptEnhancer())
+	registry.RegisterResponseEnhancer(enhancers.NewCiscoAcceptEnhancer())
 
 	// Register authentication guards
 	var cfgGetter interface{ GetInt64(string, string) int64 }


### PR DESCRIPTION
# Summary

Adds a Cisco Access-Accept **response enhancer** (`CiscoAcceptEnhancer`) that emits the canonical `Cisco-AVPair` reply attribute (SMI Private Enterprise Code 9, VSA type 1) for sessions terminating on a Cisco NAS. This closes the last high-value gap in the M5.1 inventory: `cisco` already had its `Code*` constant and generated dictionary package, only the enhancer was missing.

## Roadmap Mapping (Required for agent tasks)

- Milestone subtask: `M5.4`
- Feature ID(s): `TR-F005` (vendor VSA parsing / response enhancement)
- Out-of-scope non-goals checked: `TR-N001` `TR-N002` `TR-N003` `TR-N004` `TR-N005`

## What Changed

- **`internal/radiusd/plugins/auth/enhancers/cisco_enhancer.go`** (new): `CiscoAcceptEnhancer` appends `Cisco-AVPair = "ip:addr-pool=<pool>"`, the most widely deployed Cisco reply AVPair for subscriber IP provisioning. The pool name comes from `RadiusUser.GetAddrPool` (honors profile inheritance). The value is *appended* via `CiscoAVPair_AddString` because `Cisco-AVPair` is multi-valued. Nil-safe and vendor-gated with `matchVendor(vendors.CodeCisco)`, mirroring the existing `aruba`/`h3c` enhancers.
- **`internal/radiusd/plugins/init.go`**: register `enhancers.NewCiscoAcceptEnhancer()` after Aruba.
- **`internal/radiusd/plugins/auth/enhancers/cisco_enhancer_test.go`** (new): sample-based tests — name, nil-safety, vendor match vs non-Cisco, and addr-pool present / empty-skipped / `N/A`-skipped (absence asserted via `CiscoAVPair_LookupString` → `radius.ErrNoAttribute`).

### Why dual-emit with the standard Framed-Pool
`DefaultAcceptEnhancer` already sends the standard Framed-Pool (RFC 2869, attr 88). Several Cisco IOS / IOS-XE / IOS-XR / ISG platforms select a NAS-local pool **only** from the `ip:addr-pool` vendor AVPair and ignore attribute 88, so sending both maximizes cross-platform pool assignment. This is documented inline.

## Acceptance Criteria Covered

- [x] The change only covers the mapped `TR-F005` scope
- [x] No protocol handshake/behavior change — this is a vendor reply-attribute enhancer following the established TR-F005 parser/enhancer/registry pattern, so no new RFC clause or `test/integration/` E2E case is required; behavior is covered by sample-based unit tests like the other vendor enhancers.

## Verification

- [x] `go build ./...`
- [x] `go test ./internal/radiusd/...` (all pass; new Cisco tests included)
- [x] `golangci-lint run ./...` (v2.12.2) → `0 issues`
- [ ] `cd web && npm run build` — N/A (no frontend files changed)

## Risks and Rollback

- Risk level: `low`
- Main risk: an extra `Cisco-AVPair` in the Access-Accept for Cisco NAS devices that have an address pool configured on the user/profile. It is only emitted when the vendor code matches `9` and a non-empty, non-`NA` pool is set, so non-Cisco devices and pool-less users are unaffected.
- Rollback plan: revert this commit; the enhancer is additive and self-contained (removing the `init.go` registration line fully disables it).

## Reviewer Notes

- Suggested review order: `cisco_enhancer.go` → `init.go` registration → `cisco_enhancer_test.go`.
- Follow-up (post-merge grooming per `orchestrate-roadmap` step 9): check off `M5.4` in `docs/roadmap.md` / `docs/roadmap.zh.md` and refresh the `cisco` enhancer row + registered-enhancer count in `docs/vendor-vsa-gap-baseline.md`, referencing this PR.
- Remaining enhancers (`alcatel` / `juniper` / `radback` / `microsoft` / `f5` / `hillstone` / `pfSense`) stay demand-driven.