### PR TITLE
docs(roadmap): groom M5.4 delivery + refresh vendor docs (Cisco enhancer)

### DIFF
--- a/docs-site/src/en/cookbook-vendors.md
+++ b/docs-site/src/en/cookbook-vendors.md
@@ -138,13 +138,15 @@ in the PPPoE server settings.
 
 ## Cisco — vendor code 9
 
-**Rate attributes**: **none**. ToughRADIUS has **no Cisco enhancer**, so a Cisco
-NAS receives only the standard attributes (`Session-Timeout`,
-`Acct-Interim-Interval`, `Framed-Pool`, `Framed-IP-Address`, …) from
-`default_enhancer.go`. Authentication (PAP / CHAP / MS-CHAPv2 / EAP), session
-control, accounting and CoA all work normally — **apply bandwidth policy on the
-device**, or build a custom integration using the bundled `Cisco-AVPair`
-dictionary.
+**Rate attributes**: **none** — Cisco has no portable numeric rate VSA, so
+bandwidth stays device-side. The `accept-cisco` enhancer emits one non-rate
+attribute — `Cisco-AVPair="ip:addr-pool=<pool>"` — when the plan has an address
+pool, complementing the standard `Framed-Pool`; otherwise a Cisco NAS receives
+only the standard attributes (`Session-Timeout`, `Acct-Interim-Interval`,
+`Framed-Pool`, `Framed-IP-Address`, …) from `default_enhancer.go`. Authentication
+(PAP / CHAP / MS-CHAPv2 / EAP), session control, accounting and CoA all work
+normally — **apply bandwidth policy on the device**, or build a custom
+integration using the bundled `Cisco-AVPair` dictionary.
 
 **Request parsing**: default parser — MAC from `Calling-Station-Id`, no VLAN. So
 **MAC binding works, VLAN binding does not**.

--- a/docs-site/src/en/vendor-guide.md
+++ b/docs-site/src/en/vendor-guide.md
@@ -54,7 +54,7 @@ Profile rates are stored in **Kbps**. Each vendor enhancer converts:
 | H3C (25506) | `H3C-Input/Output-Average-Rate`, peak variants | same ×1024 / ×4 scheme as Huawei |
 | ZTE (3902) | `ZTE-Rate-Ctrl-SCR-Up/Down` | `rate_kbps × 1024` |
 | iKuai (10055) | `RP-Upstream/Downstream-Speed-Limit` | `rate_kbps × 1024 × 8`, clamped to Int32 max |
-| Cisco (9), Standard (0) | — | standard attributes only; use device-side policy or `Cisco-AVPair` via custom integration |
+| Cisco (9), Standard (0) | — | no rate VSA — bandwidth is device-side; the `accept-cisco` enhancer emits a non-rate `Cisco-AVPair="ip:addr-pool=<pool>"` |
 
 ### Request parsing (MAC and VLAN)
 
@@ -136,10 +136,12 @@ For CoA/Disconnect, enable the RADIUS dynamic authorization extension
 ## Cisco — vendor code 9
 
 ToughRADIUS authenticates Cisco devices with standard attributes (PAP / CHAP /
-MS-CHAPv2 / EAP all work; sessions, accounting, CoA likewise). No
-Cisco-specific attributes are emitted by default — apply bandwidth policy on
-the device, or extend via the bundled `Cisco-AVPair` dictionary if you build a
-custom integration.
+MS-CHAPv2 / EAP all work; sessions, accounting, CoA likewise). When the user's
+plan has an address pool, the `accept-cisco` enhancer emits
+`Cisco-AVPair="ip:addr-pool=<pool>"` alongside the standard `Framed-Pool`; no
+other Cisco-specific attributes are sent. Apply bandwidth policy on the device
+(Cisco has no portable numeric rate VSA), or extend via the bundled
+`Cisco-AVPair` dictionary if you build a custom integration.
 
 ```text
 aaa new-model

--- a/docs-site/src/zh/cookbook-vendors.md
+++ b/docs-site/src/zh/cookbook-vendors.md
@@ -121,11 +121,12 @@ domain default enable system
 
 ## Cisco —— 厂商代码 9
 
-**限速属性**：**无**。ToughRADIUS **没有 Cisco 增强器**，所以 Cisco NAS 只会收到
-`default_enhancer.go` 下发的标准属性（`Session-Timeout`、`Acct-Interim-Interval`、
-`Framed-Pool`、`Framed-IP-Address` 等）。认证（PAP / CHAP / MS-CHAPv2 / EAP）、会话
-控制、计费与 CoA 都正常工作——**限速请在设备侧做**，或用随仓库附带的 `Cisco-AVPair`
-字典做自定义集成。
+**限速属性**：**无**——Cisco 无可移植的数值限速 VSA，带宽仍在设备侧。`accept-cisco`
+enhancer 会在套餐配置了地址池时下发一个非限速属性 `Cisco-AVPair="ip:addr-pool=<pool>"`，
+与标准 `Framed-Pool` 互补；否则 Cisco NAS 只会收到 `default_enhancer.go` 下发的标准属性
+（`Session-Timeout`、`Acct-Interim-Interval`、`Framed-Pool`、`Framed-IP-Address` 等）。认证
+（PAP / CHAP / MS-CHAPv2 / EAP）、会话控制、计费与 CoA 都正常工作——**限速请在设备侧做**，
+或用随仓库附带的 `Cisco-AVPair` 字典做自定义集成。
 
 **请求解析**：默认解析器——MAC 来自 `Calling-Station-Id`，不解析 VLAN。故 **MAC 绑定
 可用，VLAN 绑定不可用**。

--- a/docs-site/src/zh/vendor-guide.md
+++ b/docs-site/src/zh/vendor-guide.md
@@ -47,7 +47,7 @@ IPv4）、`Framed-IPv6-Prefix` / `Framed-IPv6-Address`（RFC 6911）、
 | H3C（25506） | `H3C-Input/Output-Average-Rate` 及峰值 | 与华为相同的 ×1024 / ×4 规则 |
 | 中兴（3902） | `ZTE-Rate-Ctrl-SCR-Up/Down` | `速率_kbps × 1024` |
 | 爱快（10055） | `RP-Upstream/Downstream-Speed-Limit` | `速率_kbps × 1024 × 8`，上限 Int32 |
-| Cisco（9）、标准（0） | —— | 仅标准属性；限速依赖设备侧策略，或基于内置 `Cisco-AVPair` 字典自行扩展 |
+| Cisco（9）、标准（0） | —— | 无限速 VSA——带宽在设备侧；`accept-cisco` enhancer 会下发非限速的 `Cisco-AVPair="ip:addr-pool=<pool>"` |
 
 ### 请求解析（MAC 与 VLAN）
 
@@ -125,7 +125,9 @@ aaa
 ## Cisco —— 厂商代码 9
 
 Cisco 设备使用标准属性认证（PAP / CHAP / MS-CHAPv2 / EAP 均可；会话、计费、
-CoA 同样可用）。默认不下发 Cisco 私有属性——带宽策略请在设备侧实施，或基于
+CoA 同样可用）。当用户套餐配置了地址池时，`accept-cisco` enhancer 会在标准
+`Framed-Pool` 之外下发 `Cisco-AVPair="ip:addr-pool=<pool>"`；除此之外不下发其它
+Cisco 私有属性。带宽策略请在设备侧实施（Cisco 无可移植的数值限速 VSA），或基于
 内置的 `Cisco-AVPair` 字典自行扩展。
 
 ```text

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -53,11 +53,11 @@ The Chinese roadmap keeps the detailed agent delivery log. This English roadmap 
 
 ## Current Execution Queue
 
-The next executable milestone is **M5 vendor VSA expansion**: the M5.1 inventory and the M5.2/M5.3 parser + enhancer batch are delivered, and **M5.4** (Cisco `cisco-avpair` Access-Accept enhancer) is the next pickable subtask. M14.6 now has CI-backed OpenLDAP acceptance coverage; M14.5 remains blocked until load evidence justifies connection pooling / reconnect work.
+The scheduled **M5 vendor VSA expansion** batch (M5.1 inventory + M5.2/M5.3/M5.4 parsers/enhancers) is delivered — M5.4 shipped the Cisco `cisco-avpair` Access-Accept enhancer (#543) — and the remaining vendor enhancers stay demand-driven, so the next pickable subtask is **M7.1** (evaluate upstream `layeh.com/radius` fixes). M14.6 now has CI-backed OpenLDAP acceptance coverage; M14.5 remains blocked until load evidence justifies connection pooling / reconnect work.
 
 | Order | Task | Status | Acceptance focus |
 | --- | --- | --- | --- |
-| 1 | M5 vendor VSA expansion | In progress | M5.1 inventory + M5.2/M5.3 parsers/enhancer delivered; M5.4 Cisco `cisco-avpair` enhancer next, with vendor packet samples |
+| 1 | M5 vendor VSA expansion | In progress | M5.1 inventory + M5.2/M5.3/M5.4 parsers/enhancers delivered (M5.4 Cisco `cisco-avpair` enhancer, #543); remaining vendor enhancers demand-driven |
 | 2 | M7 upstream and RFC compliance tracking | In progress | Evaluate upstream fixes and add RFC-backed regression tests when behavior changes |
 | 3 | M10 EAP-TLS 1.3 / RFC 9190 | Planned | Keep TLS 1.2 compatibility while adding TLS 1.3 key derivation and close-notify semantics |
 | 4 | M14.5 LDAP connection robustness | Blocked: waiting for load evidence | Revisit pooling/reconnect design only when connection cost or cancellation evidence justifies the complexity |
@@ -69,7 +69,7 @@ Agent-facing unchecked tasks:
 - [x] M5.1 Inventory pending vendor VSA gaps and dictionary differences. Delivered: `docs/vendor-vsa-gap-baseline.md` refreshed to HEAD `9882f79e` — registered parsers `default + huawei + h3c + zte + radback + alcatel + aruba + juniper`, response enhancers `default + huawei + h3c + zte + mikrotik + ikuai + aruba`, a corrected gap matrix, a delta-since-#433 section, and the next-batch backlog. (The first baseline #433 was superseded once M5.2/M5.3 landed; `#470` had re-opened this checkbox.)
 - [x] M5.2 Add request-side vendor parsers for genuine MAC/VLAN request VSAs. Delivered: `radback` (#449), `alcatel` (#450), `aruba` (#451), and `juniper` (#453) request parsers, plus the `vendors.CodeAlcatel` / `CodeAruba` constants.
 - [x] M5.3 Add the first vendor Access-Accept response enhancer. Delivered: `aruba` response enhancer registered in `plugins/init.go` (#456) with sample-based tests.
-- [ ] M5.4 Add a Cisco `cisco-avpair` Access-Accept response enhancer (the most common vendor reply attribute; `cisco` already has its `Code*` constant and dictionary package, only the enhancer is missing). Follow the enhancer + `plugins/init.go` registration + sample-test pattern. Remaining enhancers (`alcatel` / `juniper` / `radback` / `microsoft` / `f5` / `hillstone` / `pfSense`) stay demand-driven.
+- [x] M5.4 Add a Cisco `cisco-avpair` Access-Accept response enhancer. Delivered (#543): `CiscoAcceptEnhancer` (`accept-cisco`) emits `Cisco-AVPair="ip:addr-pool=<pool>"` from `GetAddrPool` (appended, since Cisco-AVPair is multi-valued), registered in `plugins/init.go`, with sample-based tests (named / empty / `N/A` / vendor-mismatch / nil-safety). Rate limiting stays device-side (Cisco has no portable numeric-rate VSA); the standard `Framed-Pool` from `default_enhancer` is complemented, not replaced. Remaining enhancers (`alcatel` / `juniper` / `radback` / `microsoft` / `f5` / `hillstone` / `pfSense`) stay demand-driven.
 - [ ] M7.1 Manually evaluate important upstream `layeh.com/radius` fixes and decide whether to sync the `talkincode/radius` fork and update the `go.mod` replacement.
 - [ ] M10.1 Add TLS 1.3 handshake negotiation and TLS 1.2 fallback for EAP-TLS.
 

--- a/docs/roadmap.zh.md
+++ b/docs/roadmap.zh.md
@@ -163,7 +163,7 @@
 - [x] M5.1 梳理待补厂商清单与字典差异<br/>**已交付**：`docs/vendor-vsa-gap-baseline.md` 刷新至 HEAD `9882f79e` 的当前真实状态——已注册 parser `default + huawei + h3c + zte + radback + alcatel + aruba + juniper`、响应 enhancer `default + huawei + h3c + zte + mikrotik + ikuai + aruba`；修正差距矩阵、补「自 #433 首版以来的增量」小节与下一批 backlog。首版基线 #433 在 M5.2/M5.3 落地后已过时，且 `#470`（路线图英文优先化）一度把本勾选项重新打开，本轮据实重勾并刷新。仅文档、无运行逻辑变更。
 - [x] M5.2 逐厂商按现有模式接入 request parser（针对真正的厂商私有 MAC/VLAN 请求 VSA）<br/>**已交付**：`radback`（#449，MAC + VLAN）、`alcatel`（#450，MAC）、`aruba`（#451，VLAN）、`juniper`（#453，VoIP VLAN）request parser，并补 `vendors.CodeAlcatel` / `CodeAruba` 常量；各带样例解析测试。`mikrotik` / `ikuai` 请求侧用标准 `Calling-Station-Id`，其 VLAN VSA 属 Access-Accept 回执属性，dedicated parser 与 `DefaultParser` 行为一致，故不补。
 - [x] M5.3 首个厂商 Access-Accept 响应 enhancer<br/>**已交付**：`aruba` 响应 enhancer 注册进 `plugins/init.go`（#456），带样例响应属性测试。（原子任务标题「样例包覆盖解析与响应属性」已并入每厂商验收集——parser/enhancer 均随样例测试交付。）
-- [ ] M5.4 新增 Cisco `cisco-avpair` Access-Accept 响应 enhancer（最常见的厂商回执属性；`cisco` 已有 `Code*` 常量与字典包，仅缺 enhancer）。按 enhancer + `plugins/init.go` 注册 + 样例测试模式实现。其余 enhancer（`alcatel` / `juniper` / `radback` / `microsoft` / `f5` / `hillstone` / `pfSense`）按部署需求驱动。
+- [x] M5.4 新增 Cisco `cisco-avpair` Access-Accept 响应 enhancer<br/>**已交付**（#543）：`CiscoAcceptEnhancer`（`accept-cisco`）从 `GetAddrPool` 下发 `Cisco-AVPair="ip:addr-pool=<pool>"`（Cisco 最常见的地址池回执属性；多值属性用 `AddString` 追加，不覆盖同包其它 AVPair），注册进 `plugins/init.go`，带样例测试（named / empty / `N/A` / 厂商不匹配 / nil 安全）。限速仍在设备侧（Cisco 无可移植的数值限速 VSA），本 enhancer 只做地址池；标准 `Framed-Pool` 由 `default_enhancer` 继续下发，二者同源（`GetAddrPool`）同守卫（`IsNotEmptyAndNA`）互补。其余 enhancer（`alcatel` / `juniper` / `radback` / `microsoft` / `f5` / `hillstone` / `pfSense`）按部署需求驱动。
 
 ## M6 — 可观测性与运维增强
 
@@ -332,7 +332,7 @@
 ## Agent 排期约定
 
 - **入口（自动委托）**：收到"自动委托开发 / 继续推进路线图"类指令时，由 [`.agents/skills/orchestrate-roadmap/SKILL.md`](../.agents/skills/orchestrate-roadmap/SKILL.md) 作为总调度统筹一轮：选题 → 选执行 SOP → 派工 → 质量门禁 → PR → 迭代路线图。
-- 调度优先级：先 P1（`M2 → M3 → M8 → M9`，均已交付），再 P2（已置顶交付 `M13` 文档站点与 `M4` agent 质量门禁；当前优先收尾 `M14`，其后 `M5 / M7 / M10`），最后 P3（`M6 / M11 / M12`）；同优先级里程碑按依赖与可执行性取，P2/P3 仅在更高优先级里程碑无可执行子任务时填充。**M13 置顶依据**：用户指令将 mdbook 文档站点列为优先实现，先收编散落文档并对外呈现既有能力（含 EAP 套件）。EAP 套件优先续接 M1（EAP-TLS）：先 PEAP-MSCHAPv2（兼容）、再 EAP-TTLS（后端适配），TLS 1.3 / TEAP / EAP-PWD 列为中长期 / 按需。
+- 调度优先级：先 P1（`M2 → M3 → M8 → M9`，均已交付），再 P2（已置顶交付 `M13` 文档站点与 `M4` agent 质量门禁；当前优先收尾 `M14`，其后 `M7 / M10`（`M5` 计划批次 M5.1–M5.4 已交付，余量按需驱动）），最后 P3（`M6 / M11 / M12`）；同优先级里程碑按依赖与可执行性取，P2/P3 仅在更高优先级里程碑无可执行子任务时填充。**M13 置顶依据**：用户指令将 mdbook 文档站点列为优先实现，先收编散落文档并对外呈现既有能力（含 EAP 套件）。EAP 套件优先续接 M1（EAP-TLS）：先 PEAP-MSCHAPv2（兼容）、再 EAP-TTLS（后端适配），TLS 1.3 / TEAP / EAP-PWD 列为中长期 / 按需。
 - 单次 agent 任务只认领一个未勾选子任务（最小闭环），完成后在本文件勾选并在 PR 引用里程碑编号。
 - **自我迭代**：每轮交付后由 [`.agents/skills/groom-roadmap/SKILL.md`](../.agents/skills/groom-roadmap/SKILL.md) 勾选已交付项、更新里程碑状态、回填/拆分/重排子任务，并保持本文件与功能清单状态一致。
 - 任何超出 `TR-F` 清单的需求，必须先提交清单更新 PR，再排入本路线图。

--- a/docs/vendor-vsa-gap-baseline.md
+++ b/docs/vendor-vsa-gap-baseline.md
@@ -4,9 +4,10 @@ This document is the M5.1 inventory for "vendor backlog and dictionary gaps"
 under TR-F005. It is intentionally snapshot-style so the next M5 batch can
 execute without re-discovering the same scope.
 
-> Refreshed after the M5.2 request-parser batch (#449–#454) and the M5.3 Aruba
-> response enhancer (#456) landed. The first baseline (#433) predated that work
-> and is superseded by the matrix below; see "Delta since the first baseline".
+> Refreshed after the M5.2 request-parser batch (#449–#454), the M5.3 Aruba
+> response enhancer (#456), and the M5.4 Cisco `cisco-avpair` response enhancer
+> (#543) landed. The first baseline (#433) predated that work and is superseded by
+> the matrix below; see "Delta since the first baseline".
 
 ## Scope and Method
 
@@ -38,7 +39,7 @@ grep -c '^\$INCLUDE' share/dictionary                       # 213
 - Registered vendor parsers (`parsers/init.go`): `default + huawei + h3c + zte +
   radback + alcatel + aruba + juniper` (7 vendors + default)
 - Registered response enhancers (`plugins/init.go`): `default + huawei + h3c +
-  zte + mikrotik + ikuai + aruba` (6 vendors + default)
+  zte + mikrotik + ikuai + aruba + cisco` (7 vendors + default)
 - `share/dictionary` includes `213` `$INCLUDE dictionary.*` entries; the repo
   ships generated packages for `15` of those vendors.
 
@@ -57,7 +58,7 @@ does not depend on a parser.
 | --- | ---: | --- | --- | --- | --- |
 | `alcatel` | 3041 | present | present | missing | `share/dictionary.alcatel` |
 | `aruba` | 14823 | present | present | present | `share/dictionary.aruba` |
-| `cisco` | 9 | present | missing | missing | `share/dictionary.cisco` |
+| `cisco` | 9 | present | missing | present | `share/dictionary.cisco` |
 | `f5` | 3375 | present | missing | missing | `share/dictionary.f5` |
 | `h3c` | 25506 | present | present | present | `share/dictionary.h3c` |
 | `hillstone` | 28557 | present | missing | missing | `share/dictionary.hillstone` |
@@ -81,6 +82,8 @@ first response enhancer that the first baseline listed as pending:
 - `aruba` request parser — VLAN, plus the `vendors.CodeAruba` constant (#451)
 - `juniper` request parser — VoIP VLAN (#453)
 - `aruba` Access-Accept response enhancer (#456, M5.3)
+- `cisco` Access-Accept response enhancer — emits `Cisco-AVPair="ip:addr-pool=<pool>"`
+  from `GetAddrPool` (#543, M5.4)
 
 The first baseline also reported `alcatel` / `aruba` as missing their `Code*`
 constant; both now exist in `codes.go`. Only `unix` still lacks a `Code*`
@@ -93,9 +96,10 @@ remaining TR-F005 work is response-enhancer and hygiene work:
 
 1. **Response enhancers (demand-driven), no parser dependency.** Highest value
    first:
-   - `cisco` `cisco-avpair` — the most common vendor reply attribute; `cisco`
-     already has its `Code*` constant and dictionary package, only the enhancer
-     is missing. Tracked as **M5.4**.
+   - `cisco` `cisco-avpair` — **delivered as M5.4** (#543): the `accept-cisco`
+     enhancer emits `Cisco-AVPair="ip:addr-pool=<pool>"` from `GetAddrPool`
+     (address pool only; rate stays device-side, Cisco has no portable numeric
+     rate VSA).
    - `alcatel`, `juniper`, `radback` — already have a request parser but no
      response enhancer; add when a deployment needs their reply attributes.
    - `microsoft`, `f5`, `hillstone`, `pfSense` — neither parser nor enhancer;


### PR DESCRIPTION
## What & why

Grooming follow-up for **M5.4** (Cisco `cisco-avpair` Access-Accept enhancer, delivered in #543 under **TR-F005**). Per the `groom-roadmap` SOP, this checks off the delivered subtask and syncs the plan/scope surfaces, plus the vendor docs that #543 directly falsified. **Docs-only — no product code.**

## Changes

**Plan / scope**
- `docs/roadmap.md`: check off `M5.4`; refresh the Current Execution Queue narrative + status table — M5's scheduled batch (M5.1 inventory + M5.2/M5.3/M5.4 parsers/enhancers) is delivered, remaining vendor enhancers are demand-driven, so the next pickable subtask is **M7.1**.
- `docs/roadmap.zh.md`: mirror the M5.4 delivery log (`**已交付**（#543）…`); tweak the scheduling-priority sentence.
- `docs/vendor-vsa-gap-baseline.md`: add `cisco` to the registered response enhancers (**7 vendors + default**), flip the `cisco` matrix Enhancer cell `missing → present`, add the M5.4 delta line, and mark the `cisco` backlog bullet delivered.

**Directly-affected vendor docs (docs-site en/zh)**
- `vendor-guide.md` + `cookbook-vendors.md`: correct the now-false "no Cisco enhancer / standard attributes only" statements to describe the `accept-cisco` enhancer emitting `Cisco-AVPair="ip:addr-pool=<pool>"` from `GetAddrPool`.
- Rate statements are preserved as **device-side** (Cisco has no portable numeric rate VSA); the rate/MAC/VLAN capability matrix is unchanged (the addr-pool AVPair is not a rate/MAC/VLAN capability).

## Verification

- Doc-only; no build/test impact. `mdbook` is not installed locally — relying on the CI **Docs (mdbook)** job. Changes are prose/table edits only (no structural or link changes).

## Traceability

- Milestone: **M5.4** · Feature: **TR-F005** · Delivery PR: **#543**
