### PR TITLE
docs(roadmap): close M7 with upstream no-sync evaluation (TR-F021/TR-F022)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -36,7 +36,7 @@ The Chinese roadmap keeps the detailed agent delivery log. This English roadmap 
 | M4 | Agent development system and quality gates | TR-F022 / TR-F024 | P2 | Delivered |
 | M5 | Vendor VSA coverage expansion | TR-F005 | P2 | In progress |
 | M6 | Observability and operations improvements | TR-F015 | P3 | Planned |
-| M7 | Upstream RADIUS library tracking and protocol compliance | TR-F021 / TR-F022 | P2 | In progress |
+| M7 | Upstream RADIUS library tracking and protocol compliance | TR-F021 / TR-F022 | P2 | Delivered |
 | M8 | PEAPv0 / EAP-MSCHAPv2 authentication | TR-F004 | P1 | Delivered |
 | M9 | EAP-TTLS tunneled authentication | TR-F004 | P1 | Delivered |
 | M10 | EAP-TLS 1.3 / RFC 9190 upgrade | TR-F004 | P2 | Planned |
@@ -53,13 +53,13 @@ The Chinese roadmap keeps the detailed agent delivery log. This English roadmap 
 
 ## Current Execution Queue
 
-The scheduled **M5 vendor VSA expansion** batch (M5.1 inventory + M5.2/M5.3/M5.4 parsers/enhancers) is delivered — M5.4 shipped the Cisco `cisco-avpair` Access-Accept enhancer (#543) — and the remaining vendor enhancers stay demand-driven, so the next pickable subtask is **M7.1** (evaluate upstream `layeh.com/radius` fixes). M14.6 now has CI-backed OpenLDAP acceptance coverage; M14.5 remains blocked until load evidence justifies connection pooling / reconnect work.
+The scheduled **M5 vendor VSA expansion** batch (M5.1 inventory + M5.2/M5.3/M5.4 parsers/enhancers) is delivered — M5.4 shipped the Cisco `cisco-avpair` Access-Accept enhancer (#543) — and the remaining vendor enhancers stay demand-driven. **M7.1** (evaluate upstream `layeh.com/radius` fixes) is delivered with a documented no-sync decision, so the next pickable subtask is **M10.1** (TLS 1.3 negotiation with TLS 1.2 fallback for EAP-TLS). M14.6 now has CI-backed OpenLDAP acceptance coverage; M14.5 remains blocked until load evidence justifies connection pooling / reconnect work.
 
 | Order | Task | Status | Acceptance focus |
 | --- | --- | --- | --- |
 | 1 | M5 vendor VSA expansion | In progress | M5.1 inventory + M5.2/M5.3/M5.4 parsers/enhancers delivered (M5.4 Cisco `cisco-avpair` enhancer, #543); remaining vendor enhancers demand-driven |
-| 2 | M7 upstream and RFC compliance tracking | In progress | Evaluate upstream fixes and add RFC-backed regression tests when behavior changes |
-| 3 | M10 EAP-TLS 1.3 / RFC 9190 | Planned | Keep TLS 1.2 compatibility while adding TLS 1.3 key derivation and close-notify semantics |
+| 2 | M7 upstream and RFC compliance tracking | Delivered | M7.1 evaluation closed with a no-sync decision; recurring upstream checks continue via `.agents/skills/sync-upstream-radius/SKILL.md` and the cross-cutting baseline |
+| 3 | M10 EAP-TLS 1.3 / RFC 9190 | Planned (next pickable) | Keep TLS 1.2 compatibility while adding TLS 1.3 key derivation and close-notify semantics |
 | 4 | M14.5 LDAP connection robustness | Blocked: waiting for load evidence | Revisit pooling/reconnect design only when connection cost or cancellation evidence justifies the complexity |
 
 Agent-facing unchecked tasks:
@@ -70,7 +70,7 @@ Agent-facing unchecked tasks:
 - [x] M5.2 Add request-side vendor parsers for genuine MAC/VLAN request VSAs. Delivered: `radback` (#449), `alcatel` (#450), `aruba` (#451), and `juniper` (#453) request parsers, plus the `vendors.CodeAlcatel` / `CodeAruba` constants.
 - [x] M5.3 Add the first vendor Access-Accept response enhancer. Delivered: `aruba` response enhancer registered in `plugins/init.go` (#456) with sample-based tests.
 - [x] M5.4 Add a Cisco `cisco-avpair` Access-Accept response enhancer. Delivered (#543): `CiscoAcceptEnhancer` (`accept-cisco`) emits `Cisco-AVPair="ip:addr-pool=<pool>"` from `GetAddrPool` (appended, since Cisco-AVPair is multi-valued), registered in `plugins/init.go`, with sample-based tests (named / empty / `N/A` / vendor-mismatch / nil-safety). Rate limiting stays device-side (Cisco has no portable numeric-rate VSA); the standard `Framed-Pool` from `default_enhancer` is complemented, not replaced. Remaining enhancers (`alcatel` / `juniper` / `radback` / `microsoft` / `f5` / `hillstone` / `pfSense`) stay demand-driven.
-- [ ] M7.1 Manually evaluate important upstream `layeh.com/radius` fixes and decide whether to sync the `talkincode/radius` fork and update the `go.mod` replacement.
+- [x] M7.1 Manually evaluate important upstream `layeh.com/radius` fixes and decide whether to sync the `talkincode/radius` fork and update the `go.mod` replacement. Delivered (2026-07-15 evaluation, no code change required): upstream `layeh/radius` has been dormant since `1006025d` (2023-12-13, "fix IPv6Prefix bug"); `talkincode/radius` `master` already contains every upstream commit plus two fork-only fixes (IPv6Prefix non-zero-bit tolerance, generated `_SetVendor` delete-index panic), leaving upstream 2 commits **behind** the fork with nothing to sync; `go.mod` pins `replace layeh.com/radius => github.com/talkincode/radius v0.1.0`, which tags the exact fork `master` tip. Decision: no fork sync or `go.mod` change needed. Future upstream activity is handled by the recurring `.agents/skills/sync-upstream-radius/SKILL.md` check rather than a scheduled subtask.
 - [ ] M10.1 Add TLS 1.3 handshake negotiation and TLS 1.2 fallback for EAP-TLS.
 
 ## Non-Goals

--- a/docs/roadmap.zh.md
+++ b/docs/roadmap.zh.md
@@ -36,7 +36,7 @@
 | M4 | Agent 开发体系与质量门禁 | TR-F022 | P2 | 已交付 |
 | M5 | 厂商 VSA 覆盖扩展 | TR-F005 | P2 | 进行中 |
 | M6 | 可观测性与运维增强 | TR-F015 | P3 | 计划中 |
-| M7 | 上游 RADIUS 库跟踪与协议合规 | TR-F021 / TR-F022 | P2 | 进行中 |
+| M7 | 上游 RADIUS 库跟踪与协议合规 | TR-F021 / TR-F022 | P2 | 已交付 |
 | M8 | PEAPv0 / EAP-MSCHAPv2 认证支持 | TR-F004 | P1 | 已交付 |
 | M9 | EAP-TTLS 隧道认证支持 | TR-F004 | P1 | 已交付 |
 | M10 | EAP-TLS 1.3 / RFC 9190 升级 | TR-F004 | P2 | 计划中 |
@@ -184,10 +184,10 @@
 - **技能**：`.agents/skills/sync-upstream-radius/SKILL.md`、`.agents/skills/reference-rfc/SKILL.md`、`.agents/skills/add-acceptance-test/SKILL.md`
 
 子任务：
-- [ ] M7.1 人工核对上游发现新提交后，评估安全/协议修复并决定是否同步 fork（更新 `go.mod` replace 版本）
-- [ ] M7.2 同步后跑全量 + 集成测试，必要时补充回归用例
-- [ ] M7.3 定期核对协议行为与 `docs/rfcs/` 规范，缺失规范按技能补录
-- [ ] M7.4 关键协议路径（认证、计费、CoA、EAP）补齐 CI 自动化验收用例
+- [x] M7.1 人工核对上游发现新提交后，评估安全/协议修复并决定是否同步 fork（更新 `go.mod` replace 版本）——**已交付**（2026-07-15 评估，无需代码变更）：上游 `layeh/radius` 自 `1006025d`（2023-12-13，"fix IPv6Prefix bug"）起休眠；`talkincode/radius` `master` 已包含全部上游提交并**额外领先 2 个 fork 独有修复**（IPv6Prefix 前缀外非零位容忍、generated `_SetVendor` 删除索引 panic），上游反而落后 fork 2 个提交，无可同步内容；`go.mod` 的 `replace layeh.com/radius => github.com/talkincode/radius v0.1.0` 恰好钉在 fork `master` tip。**决策：不同步、不改 `go.mod`**。未来上游若恢复活跃，由 `.agents/skills/sync-upstream-radius/SKILL.md` 例行核对承接，不再保留排期子任务。
+- [x] M7.2 同步后跑全量 + 集成测试，必要时补充回归用例——随 M7.1「无需同步」决策本轮无同步动作可验；该门禁已固化进 `sync-upstream-radius` skill：任何未来 fork 同步必须跑全量 + 集成测试并按需补回归用例，不再作为独立排期项。
+- [x] M7.3 定期核对协议行为与 `docs/rfcs/` 规范，缺失规范按技能补录——已由横切基线吸收为常态守则：协议行为改动必须引用 `docs/rfcs/` 对应条款（缺失规范经 `reference-rfc` skill 补录），在 M1/M2/M3/M8/M9/M14 各协议交付中持续执行，无独立交付物。
+- [x] M7.4 关键协议路径（认证、计费、CoA、EAP）补齐 CI 自动化验收用例——**已交付**（随各里程碑累积完成）：`test/integration/` 现有认证（`radius_test.go` PAP）、计费（`ipv6_test.go` 真实 Accounting-Start 达 1813 端口）、CoA/DM（`coa_test.go` 4 个端到端用例含签名伪造丢弃）、EAP（`eap_tls_test.go` / `peap_mschapv2_test.go` / `ttls_test.go` / `eap_external_acceptance_test.go`）及 `message_authenticator_test.go` / `ldap_test.go` 全链路 CI 用例，四大协议路径验收覆盖闭环。
 
 验收口径：上游重要修复有评估记录与同步决策；协议改动均引用 RFC 并有 CI 验收用例背书。
 
@@ -332,7 +332,7 @@
 ## Agent 排期约定
 
 - **入口（自动委托）**：收到"自动委托开发 / 继续推进路线图"类指令时，由 [`.agents/skills/orchestrate-roadmap/SKILL.md`](../.agents/skills/orchestrate-roadmap/SKILL.md) 作为总调度统筹一轮：选题 → 选执行 SOP → 派工 → 质量门禁 → PR → 迭代路线图。
-- 调度优先级：先 P1（`M2 → M3 → M8 → M9`，均已交付），再 P2（已置顶交付 `M13` 文档站点与 `M4` agent 质量门禁；当前优先收尾 `M14`，其后 `M7 / M10`（`M5` 计划批次 M5.1–M5.4 已交付，余量按需驱动）），最后 P3（`M6 / M11 / M12`）；同优先级里程碑按依赖与可执行性取，P2/P3 仅在更高优先级里程碑无可执行子任务时填充。**M13 置顶依据**：用户指令将 mdbook 文档站点列为优先实现，先收编散落文档并对外呈现既有能力（含 EAP 套件）。EAP 套件优先续接 M1（EAP-TLS）：先 PEAP-MSCHAPv2（兼容）、再 EAP-TTLS（后端适配），TLS 1.3 / TEAP / EAP-PWD 列为中长期 / 按需。
+- 调度优先级：先 P1（`M2 → M3 → M8 → M9`，均已交付），再 P2（已置顶交付 `M13` 文档站点与 `M4` agent 质量门禁；`M7` 已交付（上游评估收口、协议路径 CI 验收闭环）；当前优先收尾 `M14`，其后 `M10`（`M5` 计划批次 M5.1–M5.4 已交付，余量按需驱动）），最后 P3（`M6 / M11 / M12`）；同优先级里程碑按依赖与可执行性取，P2/P3 仅在更高优先级里程碑无可执行子任务时填充。**M13 置顶依据**：用户指令将 mdbook 文档站点列为优先实现，先收编散落文档并对外呈现既有能力（含 EAP 套件）。EAP 套件优先续接 M1（EAP-TLS）：先 PEAP-MSCHAPv2（兼容）、再 EAP-TTLS（后端适配），TLS 1.3 / TEAP / EAP-PWD 列为中长期 / 按需。
 - 单次 agent 任务只认领一个未勾选子任务（最小闭环），完成后在本文件勾选并在 PR 引用里程碑编号。
 - **自我迭代**：每轮交付后由 [`.agents/skills/groom-roadmap/SKILL.md`](../.agents/skills/groom-roadmap/SKILL.md) 勾选已交付项、更新里程碑状态、回填/拆分/重排子任务，并保持本文件与功能清单状态一致。
 - 任何超出 `TR-F` 清单的需求，必须先提交清单更新 PR，再排入本路线图。


### PR DESCRIPTION
## Summary

Roadmap grooming (per `.agents/skills/groom-roadmap/SKILL.md`): closes milestone **M7 — Upstream RADIUS library tracking and protocol compliance** with a documented evaluation, and points the execution queue at **M10.1** as the next pickable subtask.

## M7.1 evaluation evidence (2026-07-15)

| Item | Finding |
| --- | --- |
| Upstream `layeh/radius` | Dormant since `1006025d` (2023-12-13, "fix IPv6Prefix bug"); repo last pushed 2024-08 |
| Fork `talkincode/radius` | `master` contains **all** upstream commits **plus 2 fork-only fixes** (IPv6Prefix non-zero-bit tolerance, `_SetVendor` delete-index panic); upstream is 2 commits *behind* the fork (`compare`: ahead_by 0 / behind_by 2) |
| `go.mod` | `replace layeh.com/radius => github.com/talkincode/radius v0.1.0`, and `v0.1.0` tags the exact fork `master` tip |

**Decision: nothing to sync — no fork sync, no `go.mod` change.** Future upstream activity is handled by the recurring `sync-upstream-radius` skill check instead of a scheduled subtask.

## Remaining CN subtasks closed

- **M7.2** (post-sync full+integration tests) — moot for this round (no sync); the gate is codified in the `sync-upstream-radius` skill for any future sync.
- **M7.3** (periodic RFC conformance checks) — absorbed by the cross-cutting baseline (protocol changes must cite `docs/rfcs/`), continuously enforced across M1/M2/M3/M8/M9/M14 deliveries.
- **M7.4** (CI acceptance for auth/acct/CoA/EAP paths) — already satisfied by existing `test/integration/` coverage: `radius_test.go` (PAP auth), `ipv6_test.go` (real Accounting-Start to 1813), `coa_test.go` (4 E2E cases incl. forged-reply discard), `eap_tls_test.go` / `peap_mschapv2_test.go` / `ttls_test.go` / `eap_external_acceptance_test.go`, plus `message_authenticator_test.go` / `ldap_test.go`.

## Changes

- `docs/roadmap.md` — M7 → Delivered; M7.1 checked with evidence; queue narrative + table point to M10.1 (next pickable)
- `docs/roadmap.zh.md` — M7 → 已交付; M7.1–M7.4 checked with per-item rationale; scheduling paragraph updated (`M7 / M10` → `M10`)

Docs-only; no code or checklist status changes (TR-F021/TR-F022 already 已实现 in both CN/EN checklists). No dangling references (`sync-upstream-radius` skill path verified).