### PR TITLE
docs(roadmap): check off M10.1 (EAP-TLS 1.3, #562) and point queue at M10.2

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -39,7 +39,7 @@ The Chinese roadmap keeps the detailed agent delivery log. This English roadmap 
 | M7 | Upstream RADIUS library tracking and protocol compliance | TR-F021 / TR-F022 | P2 | Delivered |
 | M8 | PEAPv0 / EAP-MSCHAPv2 authentication | TR-F004 | P1 | Delivered |
 | M9 | EAP-TTLS tunneled authentication | TR-F004 | P1 | Delivered |
-| M10 | EAP-TLS 1.3 / RFC 9190 upgrade | TR-F004 | P2 | Planned |
+| M10 | EAP-TLS 1.3 / RFC 9190 upgrade | TR-F004 | P2 | In progress (M10.1 delivered #562; next M10.2 key derivation) |
 | M11 | TEAP tunneled authentication | TR-F004 | P3 | Planned |
 | M12 | EAP-PWD password authentication | TR-F004 | P3 | Planned |
 | M13 | Bilingual documentation site with mdbook | TR-F023 | P2 | Delivered |
@@ -53,13 +53,13 @@ The Chinese roadmap keeps the detailed agent delivery log. This English roadmap 
 
 ## Current Execution Queue
 
-The scheduled **M5 vendor VSA expansion** batch (M5.1 inventory + M5.2/M5.3/M5.4 parsers/enhancers) is delivered — M5.4 shipped the Cisco `cisco-avpair` Access-Accept enhancer (#543) — and the remaining vendor enhancers stay demand-driven. **M7.1** (evaluate upstream `layeh.com/radius` fixes) is delivered with a documented no-sync decision, so the next pickable subtask is **M10.1** (TLS 1.3 negotiation with TLS 1.2 fallback for EAP-TLS). M14.6 now has CI-backed OpenLDAP acceptance coverage; M14.5 remains blocked until load evidence justifies connection pooling / reconnect work.
+The scheduled **M5 vendor VSA expansion** batch (M5.1 inventory + M5.2/M5.3/M5.4 parsers/enhancers) is delivered — M5.4 shipped the Cisco `cisco-avpair` Access-Accept enhancer (#543) — and the remaining vendor enhancers stay demand-driven. **M10.1** (TLS 1.3 negotiation + RFC 9190 protected success indication for EAP-TLS, #562) is delivered, so the next pickable subtask is **M10.2** (TLS 1.3 key derivation per RFC 9190 — TLS-Exporter MSK/EMSK and MS-MPPE key population). M14.6 now has CI-backed OpenLDAP acceptance coverage; M14.5 remains blocked until load evidence justifies connection pooling / reconnect work.
 
 | Order | Task | Status | Acceptance focus |
 | --- | --- | --- | --- |
 | 1 | M5 vendor VSA expansion | In progress | M5.1 inventory + M5.2/M5.3/M5.4 parsers/enhancers delivered (M5.4 Cisco `cisco-avpair` enhancer, #543); remaining vendor enhancers demand-driven |
 | 2 | M7 upstream and RFC compliance tracking | Delivered | M7.1 evaluation closed with a no-sync decision; recurring upstream checks continue via `.agents/skills/sync-upstream-radius/SKILL.md` and the cross-cutting baseline |
-| 3 | M10 EAP-TLS 1.3 / RFC 9190 | Planned (next pickable) | Keep TLS 1.2 compatibility while adding TLS 1.3 key derivation and close-notify semantics |
+| 3 | M10 EAP-TLS 1.3 / RFC 9190 | In progress | M10.1 delivered (#562): TLS 1.3 negotiation + §2.1.1 protected success indication with 1.2 fallback; next M10.2 key derivation (TLS-Exporter MSK/EMSK → MS-MPPE), then M10.3 close-notify semantics |
 | 4 | M14.5 LDAP connection robustness | Blocked: waiting for load evidence | Revisit pooling/reconnect design only when connection cost or cancellation evidence justifies the complexity |
 
 Agent-facing unchecked tasks:
@@ -71,7 +71,7 @@ Agent-facing unchecked tasks:
 - [x] M5.3 Add the first vendor Access-Accept response enhancer. Delivered: `aruba` response enhancer registered in `plugins/init.go` (#456) with sample-based tests.
 - [x] M5.4 Add a Cisco `cisco-avpair` Access-Accept response enhancer. Delivered (#543): `CiscoAcceptEnhancer` (`accept-cisco`) emits `Cisco-AVPair="ip:addr-pool=<pool>"` from `GetAddrPool` (appended, since Cisco-AVPair is multi-valued), registered in `plugins/init.go`, with sample-based tests (named / empty / `N/A` / vendor-mismatch / nil-safety). Rate limiting stays device-side (Cisco has no portable numeric-rate VSA); the standard `Framed-Pool` from `default_enhancer` is complemented, not replaced. Remaining enhancers (`alcatel` / `juniper` / `radback` / `microsoft` / `f5` / `hillstone` / `pfSense`) stay demand-driven.
 - [x] M7.1 Manually evaluate important upstream `layeh.com/radius` fixes and decide whether to sync the `talkincode/radius` fork and update the `go.mod` replacement. Delivered (2026-07-15 evaluation, no code change required): upstream `layeh/radius` has been dormant since `1006025d` (2023-12-13, "fix IPv6Prefix bug"); `talkincode/radius` `master` already contains every upstream commit plus two fork-only fixes (IPv6Prefix non-zero-bit tolerance, generated `_SetVendor` delete-index panic), leaving upstream 2 commits **behind** the fork with nothing to sync; `go.mod` pins `replace layeh.com/radius => github.com/talkincode/radius v0.1.0`, which tags the exact fork `master` tip. Decision: no fork sync or `go.mod` change needed. Future upstream activity is handled by the recurring `.agents/skills/sync-upstream-radius/SKILL.md` check rather than a scheduled subtask.
-- [ ] M10.1 Add TLS 1.3 handshake negotiation and TLS 1.2 fallback for EAP-TLS.
+- [x] M10.1 Add TLS 1.3 handshake negotiation and TLS 1.2 fallback for EAP-TLS. Delivered (#562): the shared `tlsengine` (Go `crypto/tls`) negotiates TLS 1.3 by default with automatic 1.2 fallback; pure EAP-TLS now sends the RFC 9190 §2.1.1 protected success indication (one octet `0x00` as protected app data, EAP-Success gated on the peer's ACK) with the certificate identity binding (RFC 5216 §5.2) enforced *before* commitment via an `onCommit` hook; `SessionTicketsDisabled` per §2.1.3; `NegotiatedVersion()` accessor added; PEAP/TTLS unchanged. Unit tests (1.3 indication decrypt, 1.2 no-indication fallback, mismatch-rejected-before-commit) plus `test/integration/` end-to-end subtests over RADIUS UDP; RFC filed at `docs/rfcs/rfc9190-eap-tls13.txt`. Key material export (TLS-Exporter MSK/EMSK → MPPE) deferred to M10.2.
 
 ## Non-Goals
 

--- a/docs/roadmap.zh.md
+++ b/docs/roadmap.zh.md
@@ -39,7 +39,7 @@
 | M7 | 上游 RADIUS 库跟踪与协议合规 | TR-F021 / TR-F022 | P2 | 已交付 |
 | M8 | PEAPv0 / EAP-MSCHAPv2 认证支持 | TR-F004 | P1 | 已交付 |
 | M9 | EAP-TTLS 隧道认证支持 | TR-F004 | P1 | 已交付 |
-| M10 | EAP-TLS 1.3 / RFC 9190 升级 | TR-F004 | P2 | 计划中 |
+| M10 | EAP-TLS 1.3 / RFC 9190 升级 | TR-F004 | P2 | 进行中（M10.1 已交付 #562，下一个 M10.2 密钥派生） |
 | M11 | TEAP 隧道认证（中长期） | TR-F004 | P3 | 计划中 |
 | M12 | EAP-PWD 口令认证（按需） | TR-F004 | P3 | 计划中 |
 | M13 | 双语文档站点（mdbook） | TR-F023 | P2（优先） | 已交付 |
@@ -237,10 +237,10 @@
 - **目标**：在 M1 已交付的 TLS 1.2 EAP-TLS 基线上，按 RFC 9190 支持 TLS 1.3 握手与会话密钥派生。
 - **开发边界**：保持与 TLS 1.2 客户端向后兼容；先协商再切换，不破坏既有 CA 链校验与身份映射；遵循 RFC 9427 的 TLS 1.3 派生规则。
 - **技能**：`.agents/skills/add-eap-method/SKILL.md`、`.agents/skills/reference-rfc/SKILL.md`、`.agents/skills/add-acceptance-test/SKILL.md`、`.agents/skills/write-go-tests/SKILL.md`
-- **协议规范**：`rfc9190`（EAP-TLS 1.3，本地缺失，按 `reference-rfc` 登记）、`rfc9427`（TLS-Based EAP Types and TLS 1.3，本地缺失）、`docs/rfcs/rfc5216-eap-tls.txt`（1.2 基线）、`rfc3748-eap.txt`。
+- **协议规范**：`docs/rfcs/rfc9190-eap-tls13.txt`（EAP-TLS 1.3，M10.1 已补录）、`rfc9427`（TLS-Based EAP Types and TLS 1.3，本地缺失）、`docs/rfcs/rfc5216-eap-tls.txt`（1.2 基线）、`rfc3748-eap.txt`。
 
 子任务：
-- [ ] M10.1 TLS 1.3 握手协商与版本回退（兼容 1.2 客户端）
+- [x] M10.1 TLS 1.3 握手协商与版本回退（兼容 1.2 客户端）——已交付（#562）：共享 `tlsengine` 默认协商 TLS 1.3 并自动回退 1.2；纯 EAP-TLS 实现 RFC 9190 §2.1.1 受保护成功指示（0x00 应用数据承诺消息，EAP-Success 以对端 ACK 为门），证书身份绑定（RFC 5216 §5.2）通过 `onCommit` 钩子在承诺**之前**执行；按 §2.1.3 禁用会话票据；新增 `NegotiatedVersion()`；PEAP/TTLS 不受影响。单测（1.3 指示解密、1.2 无指示回退、身份不匹配先拒绝不承诺）+ `test/integration/` 端到端子用例；RFC 文本登记于 `docs/rfcs/rfc9190-eap-tls13.txt`。密钥导出（MSK/EMSK → MPPE）延后至 M10.2。
 - [ ] M10.2 按 RFC 9190 / RFC 9427 实现 TLS 1.3 密钥派生（MSK/EMSK）
 - [ ] M10.3 `close_notify` / 身份保护等 TLS 1.3 语义差异处理
 - [ ] M10.4 单元测试 + `test/integration/` TLS 1.3 端到端验收用例（CI 自动执行）


### PR DESCRIPTION
Post-merge grooming for M10.1 (TR-F004, delivered in #562) per `.agents/skills/groom-roadmap/SKILL.md`:

- Check off **M10.1** in `docs/roadmap.md` + `docs/roadmap.zh.md` with delivery notes (RFC 9190 §2.1.1 protected success indication, commit-before-indicate identity binding, §2.1.3 session-ticket disable, unit + `test/integration/` coverage, `docs/rfcs/rfc9190-eap-tls13.txt` filed)
- Overview tables: M10 → **In progress**
- Queue pointer: next pickable = **M10.2** (TLS 1.3 key derivation — TLS-Exporter MSK/EMSK → MS-MPPE)
- ZH M10 spec list: rfc9190 no longer 'locally missing'

Docs-only; no code changes.