### PR TITLE
feat(eap-tls): TLS 1.3/1.2 MSK derivation and MS-MPPE keys on Access-Accept (M10.2)

### DIFF
--- a/internal/radiusd/plugins/eap/handlers/tls_handler.go
+++ b/internal/radiusd/plugins/eap/handlers/tls_handler.go
@@ -1,11 +1,13 @@
 package handlers
 
 import (
+	"crypto/tls"
 	"fmt"
 
 	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap"
 	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap/tlsengine"
 	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap/tlsfragment"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/vendors/microsoft"
 	"github.com/talkincode/toughradius/v9/pkg/common"
 	"layeh.com/radius"
 	"layeh.com/radius/rfc2865"
@@ -48,6 +50,22 @@ const (
 	// fragment so that each EAP-Request comfortably fits within one RADIUS
 	// packet (RFC 5216 §2.1.5 / RFC 7499).
 	defaultMaxTLSFragment = 1024
+
+	// eapTLS12KeyLabel is the RFC 5705 exporter label for EAP-TLS with TLS 1.2
+	// (RFC 5216 §2.3): Key_Material = TLS-PRF-128("client EAP encryption").
+	// Only the first 64 octets (the MSK) are needed for the MS-MPPE keys, so a
+	// 64-octet export suffices — with TLS 1.2 the PRF stream can be truncated.
+	eapTLS12KeyLabel  = "client EAP encryption"
+	eapTLS12KeyLength = 64
+
+	// eapTLS13KeyLabel is the TLS 1.3 exporter label for EAP-TLS (RFC 9190
+	// §2.3): Key_Material = TLS-Exporter("EXPORTER_EAP_TLS_Key_Material",
+	// Type-Code, 128) where Type-Code is the single octet 0x0D (EAP-TLS).
+	// Unlike TLS 1.2, a TLS 1.3 exporter output MUST be requested at its full
+	// 128-octet length and then sliced: truncating the requested length yields
+	// different bytes, not a prefix. MSK = Key_Material(0,63).
+	eapTLS13KeyLabel  = "EXPORTER_EAP_TLS_Key_Material"
+	eapTLS13KeyLength = 128
 )
 
 // TLSConfigProvider supplies the per-handshake TLS materials for EAP-TLS and
@@ -191,12 +209,60 @@ func (h *TLSHandler) finalizeWithEngine(ctx *eap.EAPContext, state *eap.EAPState
 		return false, err
 	}
 
+	if err := h.deriveMPPEKeys(ctx.Response, engine); err != nil {
+		return false, err
+	}
+
 	state.Success = true
 	clearKey(state, stateKeyEngine)
 	if err := ctx.StateManager.SetState(state.StateID, state); err != nil {
 		return false, err
 	}
 	return true, nil
+}
+
+// deriveMPPEKeys exports the EAP-TLS MSK from the completed TLS session and
+// adds the MS-MPPE-Recv-Key / MS-MPPE-Send-Key plus encryption policy to the
+// Access-Accept (RFC 2548). Without these keys a WPA2/WPA3-Enterprise
+// authenticator cannot derive the PMK, so export failure rejects the request
+// rather than granting keyless access.
+//
+// The exporter parameters depend on the negotiated TLS version:
+//   - TLS 1.3 (RFC 9190 §2.3): label "EXPORTER_EAP_TLS_Key_Material" with the
+//     EAP-TLS Type-Code 0x0D as context, exported at the full 128 octets and
+//     then sliced — MSK = Key_Material(0,63). RECV-IV/SEND-IV are obsolete
+//     (RFC 5247) and are not derived.
+//   - TLS 1.2 (RFC 5216 §2.3): label "client EAP encryption" with no context;
+//     the first 64 octets form the MSK. crypto/tls additionally requires the
+//     Extended Master Secret extension (RFC 7627) to export keying material.
+//
+// In both cases MSK(0,31) is the MS-MPPE-Recv-Key and MSK(32,63) the
+// MS-MPPE-Send-Key, matching the PEAP/TTLS derivation.
+func (h *TLSHandler) deriveMPPEKeys(response *radius.Packet, engine *tlsengine.Engine) error {
+	label, context, length := eapTLS12KeyLabel, []byte(nil), eapTLS12KeyLength
+	if engine.NegotiatedVersion() == tls.VersionTLS13 {
+		label, context, length = eapTLS13KeyLabel, []byte{eap.TypeTLS}, eapTLS13KeyLength
+	}
+
+	keyMaterial, err := engine.ExportKey(label, context, length)
+	if err != nil {
+		return fmt.Errorf("failed to export EAP-TLS MPPE keys: %w", err)
+	}
+	if len(keyMaterial) != length {
+		return fmt.Errorf("unexpected EAP-TLS key material length: %d", len(keyMaterial))
+	}
+	msk := keyMaterial[:64]
+
+	recvKey := msk[:32]
+	sendKey := msk[32:64]
+
+	_ = microsoft.MSMPPERecvKey_Add(response, recvKey) //nolint:errcheck
+	_ = microsoft.MSMPPESendKey_Add(response, sendKey) //nolint:errcheck
+	_ = microsoft.MSMPPEEncryptionPolicy_Add(response, //nolint:errcheck
+		microsoft.MSMPPEEncryptionPolicy_Value_EncryptionAllowed)
+	_ = microsoft.MSMPPEEncryptionTypes_Add(response, //nolint:errcheck
+		microsoft.MSMPPEEncryptionTypes_Value_RC440or128BitAllowed)
+	return nil
 }
 
 // writeChallenge sends eapData inside a RADIUS Access-Challenge, echoing the

--- a/internal/radiusd/plugins/eap/handlers/tls_handler_handshake_test.go
+++ b/internal/radiusd/plugins/eap/handlers/tls_handler_handshake_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap/statemanager"
 	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap/tlsengine"
 	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap/tlsfragment"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/vendors/microsoft"
 	"layeh.com/radius"
 	"layeh.com/radius/rfc2865"
 	"layeh.com/radius/rfc2869"
@@ -195,6 +196,10 @@ type supplicant struct {
 	// lands here when the client does not read application data; a TLS 1.2
 	// exchange must never produce one.
 	postFinishedFlights int
+	// acceptResponse is the ctx.Response captured on the round where the
+	// handler reported success, i.e. the would-be Access-Accept carrying the
+	// MS-MPPE keys.
+	acceptResponse *radius.Packet
 }
 
 // clientRunFunc drives the test TLS client. The default runs the handshake
@@ -294,6 +299,7 @@ func (s *supplicant) run() (success bool, err error) {
 			return false, herr
 		}
 		if ok {
+			s.acceptResponse = ctx.Response
 			return true, nil
 		}
 		require.NotNil(s.t, writer.response, "handler must answer with a challenge")
@@ -340,6 +346,7 @@ func (s *supplicant) responseCtx(writer *mockResponseWriter, tlsData []byte) *ea
 	return &eap.EAPContext{
 		Request:        &radius.Request{Packet: packet},
 		ResponseWriter: writer,
+		Response:       packet.Response(radius.CodeAccessAccept),
 		StateManager:   s.sm,
 		Secret:         s.secret,
 		EAPMessage:     &eap.EAPMessage{Code: eap.CodeResponse, Identifier: s.ident, Type: s.eapType, Data: data},
@@ -520,7 +527,10 @@ func TestTLSHandler_FullHandshake_TLS13ProtectedSuccess(t *testing.T) {
 	tlsCfg.MinVersion = tls.VersionTLS13
 	tlsCfg.MaxVersion = tls.VersionTLS13
 
-	// After the handshake, read and verify the protected success indication.
+	// After the handshake, export the client-side MSK (RFC 9190 §2.3: full
+	// 128-octet exporter output, MSK = first 64) and then read and verify the
+	// protected success indication.
+	var clientMSK []byte
 	readIndication := func(client *tls.Conn) error {
 		if err := client.Handshake(); err != nil {
 			return err
@@ -528,6 +538,13 @@ func TestTLSHandler_FullHandshake_TLS13ProtectedSuccess(t *testing.T) {
 		if v := client.ConnectionState().Version; v != tls.VersionTLS13 {
 			return fmt.Errorf("negotiated version %#x, want TLS 1.3", v)
 		}
+		cs := client.ConnectionState()
+		km, err := cs.ExportKeyingMaterial(
+			"EXPORTER_EAP_TLS_Key_Material", []byte{eap.TypeTLS}, 128)
+		if err != nil {
+			return fmt.Errorf("client-side key export: %w", err)
+		}
+		clientMSK = km[:64]
 		buf := make([]byte, 1)
 		if _, err := io.ReadFull(client, buf); err != nil {
 			return fmt.Errorf("read protected success indication: %w", err)
@@ -547,6 +564,8 @@ func TestTLSHandler_FullHandshake_TLS13ProtectedSuccess(t *testing.T) {
 	state, err := sm.GetState(stateID)
 	require.NoError(t, err)
 	assert.True(t, state.Success)
+
+	assertMPPEKeysMatchMSK(t, sup.acceptResponse, clientMSK)
 }
 
 // TestTLSHandler_FullHandshake_TLS12FallbackNoIndication pins the client to TLS
@@ -571,6 +590,10 @@ func TestTLSHandler_FullHandshake_TLS12FallbackNoIndication(t *testing.T) {
 	tlsCfg := clientCfg(ca, clientCert)
 	tlsCfg.MaxVersion = tls.VersionTLS12
 
+	// Export the client-side MSK per RFC 5216 §2.3 ("client EAP encryption",
+	// 64 octets). crypto/tls requires EMS (RFC 7627) for TLS 1.2 export, which
+	// Go negotiates by default.
+	var clientMSK []byte
 	verify12 := func(client *tls.Conn) error {
 		if err := client.Handshake(); err != nil {
 			return err
@@ -578,6 +601,12 @@ func TestTLSHandler_FullHandshake_TLS12FallbackNoIndication(t *testing.T) {
 		if v := client.ConnectionState().Version; v != tls.VersionTLS12 {
 			return fmt.Errorf("negotiated version %#x, want TLS 1.2", v)
 		}
+		cs := client.ConnectionState()
+		km, err := cs.ExportKeyingMaterial("client EAP encryption", nil, 64)
+		if err != nil {
+			return fmt.Errorf("client-side key export: %w", err)
+		}
+		clientMSK = km
 		return nil
 	}
 
@@ -592,6 +621,26 @@ func TestTLSHandler_FullHandshake_TLS12FallbackNoIndication(t *testing.T) {
 	state, err := sm.GetState(stateID)
 	require.NoError(t, err)
 	assert.True(t, state.Success)
+
+	assertMPPEKeysMatchMSK(t, sup.acceptResponse, clientMSK)
+}
+
+// assertMPPEKeysMatchMSK decrypts the MS-MPPE-Recv-Key / MS-MPPE-Send-Key from
+// the captured Access-Accept and verifies they equal the client-side exported
+// MSK halves (RFC 5216 §2.3 / RFC 9190 §2.3: recv = MSK(0,31), send =
+// MSK(32,63)). Matching both proves server and client derived the same MSK.
+func assertMPPEKeysMatchMSK(t *testing.T, accept *radius.Packet, clientMSK []byte) {
+	t.Helper()
+	require.NotNil(t, accept, "success round must capture the Access-Accept")
+	require.Len(t, clientMSK, 64, "client must have exported the 64-octet MSK")
+
+	recvKey, err := microsoft.MSMPPERecvKey_Lookup(accept)
+	require.NoError(t, err, "MS-MPPE-Recv-Key must be present on the Access-Accept")
+	sendKey, err := microsoft.MSMPPESendKey_Lookup(accept)
+	require.NoError(t, err, "MS-MPPE-Send-Key must be present on the Access-Accept")
+
+	assert.Equal(t, clientMSK[:32], recvKey, "MS-MPPE-Recv-Key must be MSK(0,31)")
+	assert.Equal(t, clientMSK[32:64], sendKey, "MS-MPPE-Send-Key must be MSK(32,63)")
 }
 
 // TestTLSHandler_TLS13_IdentityMismatchRejectedBeforeIndication pins the client

--- a/internal/radiusd/plugins/eap/tlsengine/appdata.go
+++ b/internal/radiusd/plugins/eap/tlsengine/appdata.go
@@ -106,10 +106,13 @@ func (e *Engine) ReadApplication(records []byte) ([]byte, error) {
 }
 
 // ExportKey returns exported keying material derived from the completed TLS
-// session per RFC 5705, used by tunneled EAP methods to derive the MSK and the
-// MS-MPPE-Send-Key / MS-MPPE-Recv-Key (RFC 2548). For PEAP/TTLS the label is
-// "client EAP encryption" with a 64-octet length (RFC 5216 §2.3): octets 0..31
-// form the MS-MPPE-Recv-Key and octets 32..63 the MS-MPPE-Send-Key.
+// session per RFC 5705, used by EAP methods to derive the MSK and the
+// MS-MPPE-Send-Key / MS-MPPE-Recv-Key (RFC 2548). For PEAP/TTLS and EAP-TLS
+// with TLS 1.2 the label is "client EAP encryption" with a 64-octet length
+// (RFC 5216 §2.3); EAP-TLS with TLS 1.3 uses "EXPORTER_EAP_TLS_Key_Material"
+// with the EAP type octet as context and the full 128-octet length (RFC 9190
+// §2.3). In both layouts octets 0..31 of the MSK form the MS-MPPE-Recv-Key
+// and octets 32..63 the MS-MPPE-Send-Key.
 //
 // The handshake must have completed. crypto/tls requires TLS 1.3 or the
 // Extended Master Secret extension (RFC 7627) to export keying material; both

--- a/test/integration/eap_tls_test.go
+++ b/test/integration/eap_tls_test.go
@@ -30,6 +30,7 @@ import (
 	eap "github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap"
 	eaphandlers "github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap/handlers"
 	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap/tlsfragment"
+	"github.com/talkincode/toughradius/v9/internal/radiusd/vendors/microsoft"
 	"github.com/talkincode/toughradius/v9/pkg/common"
 )
 
@@ -94,6 +95,7 @@ func TestEAPTLSEndToEnd(t *testing.T) {
 		assert.Equalf(t, radius.CodeAccessAccept, resp.Code,
 			"trusted EAP-TLS client must authenticate, got %v (%q)", resp.Code, rfc2865.ReplyMessage_GetString(resp))
 		assertEAPCode(t, resp, eap.CodeSuccess)
+		assertEAPTLSMPPEKeys(t, resp, sup, secret)
 	})
 
 	t.Run("untrusted client certificate is rejected", func(t *testing.T) {
@@ -201,6 +203,8 @@ func TestEAPTLSEndToEnd(t *testing.T) {
 		assertEAPCode(t, resp, eap.CodeSuccess)
 		require.NoError(t, sup.clientErr,
 			"client must decrypt the 0x00 protected success indication before EAP-Success")
+		// RFC 9190 §2.3: the TLS 1.3 MSK feeds the MS-MPPE keys on the Accept.
+		assertEAPTLSMPPEKeys(t, resp, sup, secret)
 	})
 
 	t.Run("tls 1.2 pinned client falls back", func(t *testing.T) {
@@ -239,7 +243,28 @@ func TestEAPTLSEndToEnd(t *testing.T) {
 			"TLS 1.2 pinned EAP-TLS client must authenticate, got %v (%q)", resp.Code, rfc2865.ReplyMessage_GetString(resp))
 		assertEAPCode(t, resp, eap.CodeSuccess)
 		require.NoError(t, sup.clientErr)
+		// RFC 5216 §2.3: the TLS 1.2 fallback also derives MS-MPPE keys.
+		assertEAPTLSMPPEKeys(t, resp, sup, secret)
 	})
+}
+
+// assertEAPTLSMPPEKeys verifies the Access-Accept carries the MS-MPPE session
+// keys derived from the EAP-TLS MSK (RFC 5216 §2.3 for TLS 1.2, RFC 9190 §2.3
+// for TLS 1.3). The keys are salt-encrypted (RFC 2548 §2.4) with the Request
+// Authenticator of the Access-Request that triggered the Accept, so both the
+// secret and authenticator are rebound before decrypting.
+func assertEAPTLSMPPEKeys(t *testing.T, resp *radius.Packet, sup *eapTLSSupplicant, secret string) {
+	t.Helper()
+	resp.Secret = []byte(secret)
+	resp.Authenticator = sup.lastReqAuth
+
+	recvKey, err := microsoft.MSMPPERecvKey_Lookup(resp)
+	require.NoError(t, err, "Access-Accept must carry an MS-MPPE-Recv-Key")
+	assert.Lenf(t, recvKey, 32, "MS-MPPE-Recv-Key must be a 32-byte session key, got %d bytes", len(recvKey))
+
+	sendKey, err := microsoft.MSMPPESendKey_Lookup(resp)
+	require.NoError(t, err, "Access-Accept must carry an MS-MPPE-Send-Key")
+	assert.Lenf(t, sendKey, 32, "MS-MPPE-Send-Key must be a 32-byte session key, got %d bytes", len(sendKey))
 }
 
 // radiusServerAddr returns the auth server's UDP address.
@@ -480,6 +505,10 @@ type eapTLSSupplicant struct {
 	// The TLS 1.3 test uses it to decrypt and verify the RFC 9190 §2.1.1
 	// protected success indication.
 	clientRun func(client *tls.Conn) error
+	// lastReqAuth is the Request Authenticator of the most recent
+	// Access-Request, needed to decrypt the salt-encrypted MS-MPPE keys on the
+	// final Access-Accept (RFC 2548 §2.4).
+	lastReqAuth [16]byte
 }
 
 // authenticate runs the whole EAP-TLS exchange and returns the final RADIUS
@@ -590,6 +619,7 @@ func (s *eapTLSSupplicant) newAccessRequest() *radius.Packet {
 }
 
 func (s *eapTLSSupplicant) exchange(packet *radius.Packet) (*radius.Packet, error) {
+	s.lastReqAuth = packet.Authenticator
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	return radius.Exchange(ctx, packet, s.serverAddr)


### PR DESCRIPTION
## Summary

M10.2 (TR-F004): pure EAP-TLS now derives the MSK from the completed TLS session and emits **MS-MPPE-Recv-Key / MS-MPPE-Send-Key** (plus encryption policy/types) on the Access-Accept. Previously the EAP-TLS success path carried no keying material, so a WPA2/WPA3-Enterprise authenticator could not derive the PMK — PEAP/TTLS already did this, pure EAP-TLS was the gap.

## Key derivation (version-dependent)

| Negotiated | Exporter parameters | Spec |
| --- | --- | --- |
| TLS 1.3 | `TLS-Exporter("EXPORTER_EAP_TLS_Key_Material", 0x0D, 128)` — full 128-octet output, then `MSK = Key_Material(0,63)` (a TLS 1.3 exporter MUST be requested at full length; truncation yields different bytes) | RFC 9190 §2.3 |
| TLS 1.2 | `"client EAP encryption"`, 64 octets (requires EMS per crypto/tls; RFC 7627) | RFC 5216 §2.3 |

In both cases `MSK(0,31)` → MS-MPPE-Recv-Key, `MSK(32,63)` → MS-MPPE-Send-Key (RFC 2548 §2.4), identical to the PEAP/TTLS layout. RECV-IV/SEND-IV are obsolete (RFC 5247) and not derived. **Export failure rejects the request** rather than granting keyless access.

Specs in-repo: `docs/rfcs/rfc9190-eap-tls13.txt`, `docs/rfcs/rfc5216-eap-tls.txt`, `docs/rfcs/rfc2548-microsoft-vsa.txt`.

## Changes

- `tls_handler.go` — `deriveMPPEKeys` hooked into `finalizeWithEngine` after identity validation; version-branched exporter constants with RFC citations
- `tlsengine/appdata.go` — `ExportKey` doc updated for the TLS 1.3 label
- `tls_handler_handshake_test.go` — harness now sets/captures `ctx.Response`; both pinned-version tests export the client-side MSK and assert the decrypted MPPE keys equal `MSK(0,31)`/`MSK(32,63)` byte-for-byte (proves server MSK == client MSK)
- `test/integration/eap_tls_test.go` — supplicant captures the last Request Authenticator (RFC 2548 salt decryption); trusted-cert, TLS 1.3 and TLS 1.2 subtests assert both MS-MPPE keys decrypt to 32-byte session keys

## Validation

- `go build ./...` ✅
- `go test ./...` (full suite) ✅
- `golangci-lint run` → 0 issues ✅
- `make test-integration-pg` (docker PostgreSQL/LDAP, full `-tags=integration` suite) ✅ — `TestEAPTLSEndToEnd` 5/5 subtests

Milestone: M10.2 | TR-F004 | RFC 9190 §2.3 / RFC 5216 §2.3 / RFC 2548 §2.4

## Behavior change note

A TLS 1.2 EAP-TLS client that does not negotiate Extended Master Secret (RFC 7627) previously received a keyless Access-Accept and is now **rejected**: Go's `crypto/tls` refuses to export keying material on ≤1.2 without EMS (triple-handshake hardening). This is the intended fail-closed outcome — a keyless Accept cannot complete a WPA-Enterprise 4-way handshake — and modern supplicants negotiate EMS by default.
