### PR TITLE
fix(adminapi): system config save always failed (#583)

### DIFF
--- a/internal/adminapi/helpers.go
+++ b/internal/adminapi/helpers.go
@@ -9,14 +9,34 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
+// parsePagination reads page/pageSize from the query string.
+// The React Admin dataProvider sends `perPage`; some older clients send
+// `pageSize`. Accept both. Values above maxPageSize are clamped (not reset),
+// so a client asking for 1000 items still gets the full first page up to the cap
+// instead of silently falling back to 20 (which truncated system settings and
+// broke bulk save on the system config page — see #583).
 func parsePagination(c echo.Context) (int, int) {
+	const (
+		defaultPage     = 1
+		defaultPageSize = 20
+		maxPageSize     = 1000
+	)
+
 	page, err := strconv.Atoi(c.QueryParam("page"))
 	if err != nil || page < 1 {
-		page = 1
+		page = defaultPage
 	}
-	pageSize, err := strconv.Atoi(c.QueryParam("pageSize"))
-	if err != nil || pageSize < 1 || pageSize > 200 {
-		pageSize = 20
+
+	rawSize := c.QueryParam("pageSize")
+	if rawSize == "" {
+		// Frontend dataProvider uses React Admin's `perPage` query key.
+		rawSize = c.QueryParam("perPage")
+	}
+	pageSize, err := strconv.Atoi(rawSize)
+	if err != nil || pageSize < 1 {
+		pageSize = defaultPageSize
+	} else if pageSize > maxPageSize {
+		pageSize = maxPageSize
 	}
 	return page, pageSize
 }

--- a/internal/adminapi/helpers_test.go
+++ b/internal/adminapi/helpers_test.go
@@ -24,6 +24,43 @@ func sortContext(t *testing.T, sort, order string) echo.Context {
 	return echo.New().NewContext(req, rec)
 }
 
+func paginationContext(t *testing.T, rawQuery string) echo.Context {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/?"+rawQuery, nil)
+	rec := httptest.NewRecorder()
+	return echo.New().NewContext(req, rec)
+}
+
+// TestParsePagination covers the React Admin / system-config contract (#583):
+// accept both pageSize and perPage, and clamp oversized values instead of
+// silently falling back to the default page size of 20.
+func TestParsePagination(t *testing.T) {
+	tests := []struct {
+		name         string
+		query        string
+		wantPage     int
+		wantPageSize int
+	}{
+		{"defaults when empty", "", 1, 20},
+		{"pageSize accepted", "page=2&pageSize=50", 2, 50},
+		{"perPage accepted (react-admin)", "page=1&perPage=1000", 1, 1000},
+		{"pageSize preferred over perPage", "page=1&pageSize=30&perPage=100", 1, 30},
+		{"oversized clamped to max", "page=1&perPage=5000", 1, 1000},
+		{"invalid page falls back", "page=0&perPage=10", 1, 10},
+		{"invalid size falls back", "page=1&perPage=abc", 1, 20},
+		{"negative size falls back", "page=1&pageSize=-5", 1, 20},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := paginationContext(t, tt.query)
+			page, pageSize := parsePagination(c)
+			assert.Equal(t, tt.wantPage, page)
+			assert.Equal(t, tt.wantPageSize, pageSize)
+		})
+	}
+}
+
 func TestParseSort(t *testing.T) {
 	allowed := map[string]bool{"id": true, "name": true, "created_at": true}
 

--- a/internal/adminapi/settings.go
+++ b/internal/adminapi/settings.go
@@ -16,13 +16,16 @@ import (
 	"github.com/talkincode/toughradius/v9/pkg/common"
 )
 
-// settingsPayload defines the system setting request structure
+// settingsPayload defines the system setting request structure.
+// Value/Remark/Sort use pointers so clients can intentionally clear a field
+// (empty string is a valid config value for optional settings such as
+// radius.EapTlsServerCert or ldap.SearchBindPassword).
 type settingsPayload struct {
-	Type   string `json:"type"`
-	Name   string `json:"name"`
-	Value  string `json:"value"`
-	Sort   int    `json:"sort"`
-	Remark string `json:"remark"`
+	Type   string  `json:"type"`
+	Name   string  `json:"name"`
+	Value  *string `json:"value"`
+	Sort   *int    `json:"sort"`
+	Remark *string `json:"remark"`
 }
 
 // registerSettingsRoutes registers system setting routes
@@ -158,8 +161,9 @@ func createSettings(c echo.Context) error {
 	payload.Type = strings.TrimSpace(payload.Type)
 	payload.Name = strings.TrimSpace(payload.Name)
 
-	if payload.Type == "" || payload.Name == "" || payload.Value == "" {
-		return fail(c, http.StatusBadRequest, "INVALID_REQUEST", "type, name, and value cannot be empty", nil)
+	// value may be an empty string (optional configs); only the field itself is required.
+	if payload.Type == "" || payload.Name == "" || payload.Value == nil {
+		return fail(c, http.StatusBadRequest, "INVALID_REQUEST", "type, name, and value are required", nil)
 	}
 
 	// Check whether a setting with the same type and name already exists (unique constraint)
@@ -171,13 +175,22 @@ func createSettings(c echo.Context) error {
 		return fail(c, http.StatusConflict, "SETTING_EXISTS", "A setting with the same name already exists under this type", nil)
 	}
 
+	sortVal := 0
+	if payload.Sort != nil {
+		sortVal = *payload.Sort
+	}
+	remark := ""
+	if payload.Remark != nil {
+		remark = *payload.Remark
+	}
+
 	setting := domain.SysConfig{
 		ID:        common.UUIDint64(),
 		Type:      payload.Type,
 		Name:      payload.Name,
-		Value:     payload.Value,
-		Sort:      payload.Sort,
-		Remark:    payload.Remark,
+		Value:     *payload.Value,
+		Sort:      sortVal,
+		Remark:    remark,
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
 	}
@@ -213,21 +226,21 @@ func updateSettings(c echo.Context) error {
 		return fail(c, http.StatusInternalServerError, "DATABASE_ERROR", "Failed to query system settings", err.Error())
 	}
 
-	// Update fields
+	// Update fields (pointers distinguish "omitted" from "set to empty/zero")
 	if payload.Type != "" {
 		setting.Type = strings.TrimSpace(payload.Type)
 	}
 	if payload.Name != "" {
 		setting.Name = strings.TrimSpace(payload.Name)
 	}
-	if payload.Value != "" {
-		setting.Value = payload.Value
+	if payload.Value != nil {
+		setting.Value = *payload.Value
 	}
-	if payload.Sort != 0 {
-		setting.Sort = payload.Sort
+	if payload.Sort != nil {
+		setting.Sort = *payload.Sort
 	}
-	if payload.Remark != "" {
-		setting.Remark = payload.Remark
+	if payload.Remark != nil {
+		setting.Remark = *payload.Remark
 	}
 	setting.UpdatedAt = time.Now()
 

--- a/internal/adminapi/settings.go
+++ b/internal/adminapi/settings.go
@@ -161,9 +161,13 @@ func createSettings(c echo.Context) error {
 	payload.Type = strings.TrimSpace(payload.Type)
 	payload.Name = strings.TrimSpace(payload.Name)
 
-	// value may be an empty string (optional configs); only the field itself is required.
+	// value may be an empty string for optional string configs; only the field itself is required.
 	if payload.Type == "" || payload.Name == "" || payload.Value == nil {
 		return fail(c, http.StatusBadRequest, "INVALID_REQUEST", "type, name, and value are required", nil)
+	}
+
+	if err := validateSettingValue(c, payload.Type, payload.Name, *payload.Value); err != nil {
+		return fail(c, http.StatusBadRequest, "INVALID_VALUE", err.Error(), nil)
 	}
 
 	// Check whether a setting with the same type and name already exists (unique constraint)
@@ -234,6 +238,9 @@ func updateSettings(c echo.Context) error {
 		setting.Name = strings.TrimSpace(payload.Name)
 	}
 	if payload.Value != nil {
+		if err := validateSettingValue(c, setting.Type, setting.Name, *payload.Value); err != nil {
+			return fail(c, http.StatusBadRequest, "INVALID_VALUE", err.Error(), nil)
+		}
 		setting.Value = *payload.Value
 	}
 	if payload.Sort != nil {
@@ -275,6 +282,17 @@ func deleteSettings(c echo.Context) error {
 	return ok(c, map[string]interface{}{
 		"id": id,
 	})
+}
+
+// validateSettingValue rejects values that fail the registered ConfigManager
+// schema (e.g. empty string for an int setting). Unregistered free-form keys
+// are left unchecked so custom rows still work.
+func validateSettingValue(c echo.Context, typ, name, value string) error {
+	cm := GetAppContext(c).ConfigMgr()
+	if cm == nil {
+		return nil
+	}
+	return cm.ValidateValue(typ, name, value)
 }
 
 // Filter conditions

--- a/internal/adminapi/settings_test.go
+++ b/internal/adminapi/settings_test.go
@@ -108,8 +108,11 @@ func TestCreateSettings(t *testing.T) {
 		expectedStatus int
 	}{
 		{"success", `{"type":"radius","name":"NewKey","value":"v1"}`, false, http.StatusOK},
-		// Empty string is a valid config value (optional EAP cert / LDAP password).
-		{"empty value allowed", `{"type":"radius","name":"EmptyVal","value":""}`, false, http.StatusOK},
+		// Empty string is valid for optional registered string schemas and free-form keys.
+		{"empty optional string schema", `{"type":"radius","name":"EapTlsServerCert","value":""}`, false, http.StatusOK},
+		{"empty free-form value allowed", `{"type":"radius","name":"EmptyVal","value":""}`, false, http.StatusOK},
+		// Empty int schema values must be rejected (Codex review on #591).
+		{"empty int schema rejected", `{"type":"radius","name":"AccountingHistoryDays","value":""}`, false, http.StatusBadRequest},
 		{"missing value field", `{"type":"radius","name":"NoVal"}`, false, http.StatusBadRequest},
 		{"missing type", `{"type":"","name":"NoType","value":"v"}`, false, http.StatusBadRequest},
 		{"invalid json", `{not-json`, false, http.StatusBadRequest},
@@ -132,25 +135,31 @@ func TestUpdateSettings(t *testing.T) {
 		name           string
 		id             string
 		seed           bool
+		seedName       string
+		seedValue      string
 		body           string
 		expectedStatus int
 		expectValue    string
 		checkValue     bool
 	}{
-		{"success", "401", true, `{"value":"updated","remark":"r"}`, http.StatusOK, "updated", true},
-		{"clear value to empty", "402", true, `{"value":""}`, http.StatusOK, "", true},
-		{"invalid id", "bad", false, `{"value":"x"}`, http.StatusBadRequest, "", false},
-		{"not found", "888888", false, `{"value":"x"}`, http.StatusNotFound, "", false},
+		{"success", "401", true, "UpdKey", "old", `{"value":"updated","remark":"r"}`, http.StatusOK, "updated", true},
+		{"clear optional string schema", "402", true, "EapTlsServerCert", "cert.pem", `{"value":""}`, http.StatusOK, "", true},
+		{"clear int schema rejected", "403", true, "AccountingHistoryDays", "90", `{"value":""}`, http.StatusBadRequest, "90", true},
+		{"invalid id", "bad", false, "", "", `{"value":"x"}`, http.StatusBadRequest, "", false},
+		{"not found", "888888", false, "", "", `{"value":"x"}`, http.StatusNotFound, "", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c, rec := newSettingsTestCtx(t, http.MethodPut, "/api/v1/system/settings/"+tt.id, tt.body)
 			seedID := int64(401)
-			if tt.id == "402" {
+			switch tt.id {
+			case "402":
 				seedID = 402
+			case "403":
+				seedID = 403
 			}
 			if tt.seed {
-				createSettingRow(t, c, seedID, "radius", "UpdKey", "old")
+				createSettingRow(t, c, seedID, "radius", tt.seedName, tt.seedValue)
 			}
 			c.SetParamNames("id")
 			c.SetParamValues(tt.id)

--- a/internal/adminapi/settings_test.go
+++ b/internal/adminapi/settings_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -107,7 +108,9 @@ func TestCreateSettings(t *testing.T) {
 		expectedStatus int
 	}{
 		{"success", `{"type":"radius","name":"NewKey","value":"v1"}`, false, http.StatusOK},
-		{"missing value", `{"type":"radius","name":"NoVal","value":""}`, false, http.StatusBadRequest},
+		// Empty string is a valid config value (optional EAP cert / LDAP password).
+		{"empty value allowed", `{"type":"radius","name":"EmptyVal","value":""}`, false, http.StatusOK},
+		{"missing value field", `{"type":"radius","name":"NoVal"}`, false, http.StatusBadRequest},
 		{"missing type", `{"type":"","name":"NoType","value":"v"}`, false, http.StatusBadRequest},
 		{"invalid json", `{not-json`, false, http.StatusBadRequest},
 		{"duplicate", `{"type":"radius","name":"DupKey","value":"v"}`, true, http.StatusConflict},
@@ -131,16 +134,23 @@ func TestUpdateSettings(t *testing.T) {
 		seed           bool
 		body           string
 		expectedStatus int
+		expectValue    string
+		checkValue     bool
 	}{
-		{"success", "401", true, `{"value":"updated","remark":"r"}`, http.StatusOK},
-		{"invalid id", "bad", false, `{"value":"x"}`, http.StatusBadRequest},
-		{"not found", "888888", false, `{"value":"x"}`, http.StatusNotFound},
+		{"success", "401", true, `{"value":"updated","remark":"r"}`, http.StatusOK, "updated", true},
+		{"clear value to empty", "402", true, `{"value":""}`, http.StatusOK, "", true},
+		{"invalid id", "bad", false, `{"value":"x"}`, http.StatusBadRequest, "", false},
+		{"not found", "888888", false, `{"value":"x"}`, http.StatusNotFound, "", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c, rec := newSettingsTestCtx(t, http.MethodPut, "/api/v1/system/settings/"+tt.id, tt.body)
+			seedID := int64(401)
+			if tt.id == "402" {
+				seedID = 402
+			}
 			if tt.seed {
-				createSettingRow(t, c, 401, "radius", "UpdKey", "old")
+				createSettingRow(t, c, seedID, "radius", "UpdKey", "old")
 			}
 			c.SetParamNames("id")
 			c.SetParamValues(tt.id)
@@ -148,13 +158,35 @@ func TestUpdateSettings(t *testing.T) {
 			_ = updateSettings(c)
 			assert.Equal(t, tt.expectedStatus, rec.Code)
 
-			if tt.expectedStatus == http.StatusOK {
+			if tt.checkValue {
 				var got domain.SysConfig
-				require.NoError(t, GetDB(c).Where("id = ?", 401).First(&got).Error)
-				assert.Equal(t, "updated", got.Value)
+				require.NoError(t, GetDB(c).Where("id = ?", seedID).First(&got).Error)
+				assert.Equal(t, tt.expectValue, got.Value)
 			}
 		})
 	}
+}
+
+// TestListSettings_PerPageAlias ensures the system config page can load every
+// setting in one request via React Admin's `perPage` query key (#583).
+func TestListSettings_PerPageAlias(t *testing.T) {
+	c, rec := newSettingsTestCtx(t, http.MethodGet, "/api/v1/system/settings?page=1&perPage=1000", "")
+	for i := 0; i < 24; i++ {
+		createSettingRow(t, c, int64(1000+i), "radius", "key"+strconv.Itoa(i), "v")
+	}
+
+	require.NoError(t, listSettings(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp Response
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.NotNil(t, resp.Meta)
+	assert.Equal(t, int64(24), resp.Meta.Total)
+	assert.Equal(t, 1000, resp.Meta.PageSize, "perPage=1000 must be accepted (not fall back to default 20)")
+
+	items, ok := resp.Data.([]interface{})
+	require.True(t, ok)
+	assert.Len(t, items, 24, "all seeded settings must be returned so the UI has ids for update")
 }
 
 func TestDeleteSettings(t *testing.T) {

--- a/internal/app/config_manager.go
+++ b/internal/app/config_manager.go
@@ -330,6 +330,24 @@ func (cm *ConfigManager) GetAllSchemas() map[string]*ConfigSchema {
 	return result
 }
 
+// ValidateValue checks a setting value against its registered schema.
+// Unregistered keys are accepted (free-form sys_config rows). Registered keys
+// must pass type/enum/min/max validation, so empty strings are allowed for
+// optional string settings but rejected for int/bool/duration/json schemas.
+func (cm *ConfigManager) ValidateValue(category, name, value string) error {
+	if cm == nil {
+		return nil
+	}
+	key := category + "." + name
+	cm.mu.RLock()
+	schema, exists := cm.schemas[key]
+	cm.mu.RUnlock()
+	if !exists {
+		return nil
+	}
+	return cm.validate(schema, value)
+}
+
 // validate validates configuration values
 func (cm *ConfigManager) validate(schema *ConfigSchema, value string) error {
 	// Check enum values

--- a/internal/app/config_manager_test.go
+++ b/internal/app/config_manager_test.go
@@ -114,6 +114,29 @@ func TestConfigManager_Validation(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid integer")
 }
 
+func TestConfigManager_ValidateValue(t *testing.T) {
+	cm := &ConfigManager{
+		configs: make(map[string]string),
+		schemas: make(map[string]*ConfigSchema),
+	}
+	cm.register(&ConfigSchema{
+		Key:     "radius.AccountingHistoryDays",
+		Type:    TypeInt,
+		Default: "90",
+		Min:     func() *int64 { v := int64(0); return &v }(),
+	})
+	cm.register(&ConfigSchema{
+		Key:     "radius.EapTlsServerCert",
+		Type:    TypeString,
+		Default: "",
+	})
+
+	require.NoError(t, cm.ValidateValue("radius", "EapTlsServerCert", ""))
+	require.Error(t, cm.ValidateValue("radius", "AccountingHistoryDays", ""))
+	require.NoError(t, cm.ValidateValue("radius", "AccountingHistoryDays", "30"))
+	require.NoError(t, cm.ValidateValue("custom", "freeform", ""), "unregistered keys are not schema-validated")
+}
+
 // Test boolean validation
 func TestConfigManager_BoolValidation(t *testing.T) {
 	cm := &ConfigManager{


### PR DESCRIPTION
## Summary
- Fix `parsePagination` to accept React Admin's `perPage` (in addition to `pageSize`) and **clamp** oversized sizes instead of silently falling back to 20.
- Allow empty string values on settings create/update so optional configs (EAP certs, LDAP password, etc.) can be saved/cleared.
- Add regression tests covering pagination aliases and empty-value create/update.

### Root cause (#583)
The system config page loads settings with `perPage=1000`, but the backend only read `pageSize` and defaulted to **20**. With 24 schema-backed settings (LDAP group pushed the count past 20), the last items had no `id` in the UI; save tried POST create → 409 conflict / 400 empty value → "配置保存失败" every time.

## Test plan
- [x] `go test ./internal/adminapi/ -count=1`
- [x] `golangci-lint run ./internal/adminapi/`
- [ ] Fresh install → System Config → Save without edits → success
- [ ] Edit an optional empty field (e.g. LDAP password / EAP cert) → Save → success
- [ ] Confirm list returns all settings when called with `?page=1&perPage=1000`

Fixes #583