### PR TITLE
feat(eap-tls): tolerate peer close_notify after the success point (M10.3)

### DIFF
--- a/internal/radiusd/plugins/eap/handlers/tls_handler_handshake_test.go
+++ b/internal/radiusd/plugins/eap/handlers/tls_handler_handshake_test.go
@@ -207,11 +207,13 @@ type supplicant struct {
 // data before returning.
 type clientRunFunc func(client *tls.Conn) error
 
-// defaultClientRun performs the TLS handshake and exits. It deliberately does
-// not Close the conn: a close_notify alert would surface as an extra non-ACK
-// EAP-TLS round after the server's pending-success point and break the
-// exchange (most visibly with a TLS 1.2 pinned client, where the client is the
-// last to finish).
+// defaultClientRun performs the TLS handshake and exits without closing the
+// conn, so the exchange ends on the RFC 9190 Figure 1 bare ACK. A client that
+// Close()s instead emits a close_notify alert that arrives as a non-ACK EAP-TLS
+// round after the server's pending-success point; the handler now completes the
+// authentication on a clean close_notify (see the
+// TestTLSHandler_PendingSuccess_* tests), but the default run keeps the
+// ACK-terminated flow the other handshake tests assert.
 func defaultClientRun(client *tls.Conn) error {
 	return client.Handshake()
 }
@@ -331,6 +333,58 @@ func (s *supplicant) run() (success bool, err error) {
 	}
 	s.t.Fatal("EAP-TLS exchange did not complete within the round budget")
 	return false, nil
+}
+
+// driveToPendingSuccess runs the handshake until the server reaches its success
+// point (stateKeyPendingSuccess) and returns, leaving the live engine parked
+// awaiting the peer's terminal message. It is used by the pending-success
+// rejection tests to inject a crafted post-success TLS record (e.g. a corrupt
+// alert) that a real crypto/tls client cannot be made to emit. The client run
+// must be handshake-only (no Close), so the exchange settles at pending-success
+// instead of driving itself to a grant.
+func (s *supplicant) driveToPendingSuccess() {
+	s.t.Helper()
+	respData := s.nextClientFlight()
+	require.NotEmpty(s.t, respData, "client should produce a ClientHello")
+
+	var serverBuf []byte
+	for round := 0; round < 64; round++ {
+		state, err := s.sm.GetState(s.stateID)
+		require.NoError(s.t, err)
+		if getBool(state, stateKeyPendingSuccess) {
+			return
+		}
+
+		writer := &mockResponseWriter{}
+		ctx := s.responseCtx(writer, respData)
+		ok, herr := s.h.HandleResponse(ctx)
+		require.NoError(s.t, herr)
+		require.False(s.t, ok, "handshake must not grant before the injection point")
+
+		frag := s.parseChallenge(writer.response)
+		serverBuf = append(serverBuf, frag.Data...)
+		if frag.More() {
+			respData = nil
+			continue
+		}
+		flight := serverBuf
+		serverBuf = nil
+		if !s.finished && len(flight) > 0 {
+			_, werr := s.toClient.Write(flight)
+			require.NoError(s.t, werr)
+		}
+		respData = s.nextClientFlight()
+	}
+	s.t.Fatal("server did not reach the pending-success point within the round budget")
+}
+
+// sendTLSRecord feeds raw bytes to the handler as a single EAP-TLS message
+// (Length bit set, no More) and returns the handler's verdict. It lets a test
+// deliver an arbitrary post-success TLS record without a real TLS client.
+func (s *supplicant) sendTLSRecord(record []byte) (bool, error) {
+	writer := &mockResponseWriter{}
+	ctx := s.responseCtx(writer, record)
+	return s.h.HandleResponse(ctx)
 }
 
 func (s *supplicant) responseCtx(writer *mockResponseWriter, tlsData []byte) *eap.EAPContext {
@@ -623,6 +677,190 @@ func TestTLSHandler_FullHandshake_TLS12FallbackNoIndication(t *testing.T) {
 	assert.True(t, state.Success)
 
 	assertMPPEKeysMatchMSK(t, sup.acceptResponse, clientMSK)
+}
+
+// TestTLSHandler_PendingSuccess_TLS12ClientCloseGrants pins the client to TLS
+// 1.2 and, instead of the RFC 9190 Figure 1 bare ACK, has the peer Close() its
+// TLS stack once the handshake completes. A TLS 1.2 client is the last to
+// finish, so its close_notify alert reliably arrives as a distinct non-ACK
+// EAP-TLS round after the server's pending-success point. RFC 9190 §2.1.4 and
+// RFC 8446 §6.1 make close_notify a benign closure, so the server must complete
+// the authentication rather than reject the round.
+func TestTLSHandler_PendingSuccess_TLS12ClientCloseGrants(t *testing.T) {
+	ca := newHSTestCA(t, "Test Root CA")
+	clientCert := ca.issue(t, "alice", func(c *x509.Certificate) {
+		c.EmailAddresses = []string{"alice@example.com"}
+	})
+
+	cfg := serverEngineConfig(t, ca, ca)
+	h := NewTLSHandlerWithConfig(func() (*tlsengine.Config, error) { return cfg, nil })
+
+	sm := statemanager.NewMemoryStateManager()
+	defer sm.Close()
+
+	stateID := startHandshake(t, h, sm, "alice@example.com", "secret")
+
+	tlsCfg := clientCfg(ca, clientCert)
+	tlsCfg.MaxVersion = tls.VersionTLS12
+
+	closeAfterHandshake := func(client *tls.Conn) error {
+		if err := client.Handshake(); err != nil {
+			return err
+		}
+		if v := client.ConnectionState().Version; v != tls.VersionTLS12 {
+			return fmt.Errorf("negotiated version %#x, want TLS 1.2", v)
+		}
+		// Tear down the TLS stack: crypto/tls emits a close_notify alert.
+		return client.Close()
+	}
+
+	sup := newSupplicantWithClient(t, h, eap.TypeTLS, sm, stateID, "secret", tlsCfg, closeAfterHandshake)
+	success, err := sup.run()
+	require.NoError(t, err, "a clean close_notify after success must not reject")
+	assert.True(t, success, "TLS 1.2 EAP-TLS peer that Close()s must still authenticate")
+	require.NoError(t, sup.clientErr)
+
+	state, err := sm.GetState(stateID)
+	require.NoError(t, err)
+	assert.True(t, state.Success)
+}
+
+// TestTLSHandler_PendingSuccess_TLS13ClientCloseGrants pins the client to TLS
+// 1.3, has it read the RFC 9190 §2.1.1 protected success indication (0x00) and
+// then Close() its TLS stack. Reading the indication keeps the client alive
+// until after the server's pending-success point, so the resulting close_notify
+// arrives as its own non-ACK round and must complete the authentication.
+func TestTLSHandler_PendingSuccess_TLS13ClientCloseGrants(t *testing.T) {
+	ca := newHSTestCA(t, "Test Root CA")
+	clientCert := ca.issue(t, "alice", func(c *x509.Certificate) {
+		c.EmailAddresses = []string{"alice@example.com"}
+	})
+
+	cfg := serverEngineConfig(t, ca, ca)
+	h := NewTLSHandlerWithConfig(func() (*tlsengine.Config, error) { return cfg, nil })
+
+	sm := statemanager.NewMemoryStateManager()
+	defer sm.Close()
+
+	stateID := startHandshake(t, h, sm, "alice@example.com", "secret")
+
+	tlsCfg := clientCfg(ca, clientCert)
+	tlsCfg.MinVersion = tls.VersionTLS13
+	tlsCfg.MaxVersion = tls.VersionTLS13
+
+	readThenClose := func(client *tls.Conn) error {
+		if err := client.Handshake(); err != nil {
+			return err
+		}
+		if v := client.ConnectionState().Version; v != tls.VersionTLS13 {
+			return fmt.Errorf("negotiated version %#x, want TLS 1.3", v)
+		}
+		buf := make([]byte, 1)
+		if _, err := io.ReadFull(client, buf); err != nil {
+			return fmt.Errorf("read protected success indication: %w", err)
+		}
+		if buf[0] != 0x00 {
+			return fmt.Errorf("protected success indication byte %#x, want 0x00", buf[0])
+		}
+		return client.Close()
+	}
+
+	sup := newSupplicantWithClient(t, h, eap.TypeTLS, sm, stateID, "secret", tlsCfg, readThenClose)
+	success, err := sup.run()
+	require.NoError(t, err, "a clean close_notify after the 0x00 indication must not reject")
+	assert.True(t, success, "TLS 1.3 EAP-TLS peer that Close()s must still authenticate")
+	require.NoError(t, sup.clientErr)
+
+	state, err := sm.GetState(stateID)
+	require.NoError(t, err)
+	assert.True(t, state.Success)
+}
+
+// TestTLSHandler_PendingSuccess_StrayApplicationDataRejected verifies the
+// handler does not blindly grant on any post-success message: a peer that sends
+// ordinary application data (not a closure alert) after the success point is
+// out of the plain EAP-TLS flow, which has no inner phase, so the handler
+// rejects the fragment rather than authenticating.
+func TestTLSHandler_PendingSuccess_StrayApplicationDataRejected(t *testing.T) {
+	ca := newHSTestCA(t, "Test Root CA")
+	clientCert := ca.issue(t, "alice", func(c *x509.Certificate) {
+		c.EmailAddresses = []string{"alice@example.com"}
+	})
+
+	cfg := serverEngineConfig(t, ca, ca)
+	h := NewTLSHandlerWithConfig(func() (*tlsengine.Config, error) { return cfg, nil })
+
+	sm := statemanager.NewMemoryStateManager()
+	defer sm.Close()
+
+	stateID := startHandshake(t, h, sm, "alice@example.com", "secret")
+
+	tlsCfg := clientCfg(ca, clientCert)
+	tlsCfg.MaxVersion = tls.VersionTLS12
+
+	writeStrayData := func(client *tls.Conn) error {
+		if err := client.Handshake(); err != nil {
+			return err
+		}
+		// Encrypted application data, not a close_notify: this is not a valid
+		// terminal message for plain EAP-TLS.
+		_, err := client.Write([]byte("stray"))
+		return err
+	}
+
+	sup := newSupplicantWithClient(t, h, eap.TypeTLS, sm, stateID, "secret", tlsCfg, writeStrayData)
+	success, err := sup.run()
+	assert.False(t, success)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, eap.ErrTLSUnexpectedFragment)
+
+	state, err := sm.GetState(stateID)
+	require.NoError(t, err)
+	assert.False(t, state.Success, "stray application data must not authenticate")
+}
+
+// TestTLSHandler_PendingSuccess_TLSErrorAlertRejected drives the handshake to
+// the server's success point and then injects a corrupt (undecryptable) TLS
+// record in place of the peer's terminal message. RFC 9190 §2.5 makes a TLS
+// error alert a failure result indication, so the handler must reject rather
+// than grant. crypto/tls offers no way to make a client emit a raw error alert,
+// so the record is injected directly.
+func TestTLSHandler_PendingSuccess_TLSErrorAlertRejected(t *testing.T) {
+	ca := newHSTestCA(t, "Test Root CA")
+	clientCert := ca.issue(t, "alice", func(c *x509.Certificate) {
+		c.EmailAddresses = []string{"alice@example.com"}
+	})
+
+	cfg := serverEngineConfig(t, ca, ca)
+	h := NewTLSHandlerWithConfig(func() (*tlsengine.Config, error) { return cfg, nil })
+
+	sm := statemanager.NewMemoryStateManager()
+	defer sm.Close()
+
+	stateID := startHandshake(t, h, sm, "alice@example.com", "secret")
+
+	sup := newSupplicant(t, h, sm, stateID, "secret", clientCfg(ca, clientCert))
+	sup.driveToPendingSuccess()
+
+	// A complete but undecryptable TLS application-data record: a valid 5-octet
+	// header (content type 23, version 0x0303, length 32) followed by 32 octets
+	// that fail the record's AEAD. crypto/tls surfaces this as a non-EOF read
+	// error, which the handler maps to a failure result indication.
+	corrupt := make([]byte, 5+32)
+	corrupt[0] = 23   // application_data
+	corrupt[1] = 0x03 // legacy record version major
+	corrupt[2] = 0x03 // legacy record version minor
+	corrupt[3] = 0x00
+	corrupt[4] = 0x20 // length = 32
+
+	success, err := sup.sendTLSRecord(corrupt)
+	assert.False(t, success)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, eap.ErrTLSHandshakeFailed)
+
+	state, err := sm.GetState(stateID)
+	require.NoError(t, err)
+	assert.False(t, state.Success, "a TLS error alert must not authenticate")
 }
 
 // assertMPPEKeysMatchMSK decrypts the MS-MPPE-Recv-Key / MS-MPPE-Send-Key from

--- a/internal/radiusd/plugins/eap/handlers/tls_handler_test.go
+++ b/internal/radiusd/plugins/eap/handlers/tls_handler_test.go
@@ -173,7 +173,16 @@ func TestTLSHandler_HandleResponse_MalformedFragment(t *testing.T) {
 	assert.NotErrorIs(t, err, eap.ErrTLSNotConfigured)
 }
 
-func TestTLSHandler_HandleResponse_PendingSuccessRequiresACK(t *testing.T) {
+// TestTLSHandler_HandleResponse_PendingSuccessNonACKIsPeerClosure verifies the
+// RFC 9190 §2.1.4 close_notify handling introduced for plain EAP-TLS: a peer
+// that sends a non-ACK message after the server's success point is treated as
+// tearing down its TLS connection, so the handler consults the live TLS session
+// to classify the closure (close_notify grants, a TLS error alert rejects)
+// rather than rejecting every non-ACK outright as it did before. This synthetic
+// state carries no live session, so the closure path fails closed instead of
+// granting. The full close_notify -> grant and error-alert -> reject behavior is
+// covered against a real engine by the TestTLSHandler_PendingSuccess_* tests.
+func TestTLSHandler_HandleResponse_PendingSuccessNonACKIsPeerClosure(t *testing.T) {
 	h := NewTLSHandler()
 	sm := statemanager.NewMemoryStateManager()
 	const stateID = "state-tls-pending"
@@ -188,8 +197,9 @@ func TestTLSHandler_HandleResponse_PendingSuccessRequiresACK(t *testing.T) {
 	writer := &mockResponseWriter{}
 	ctx := newTLSResponseCtx(t, stateID, writer, sm, 10, []byte{TLSFlagStart})
 	success, err := h.HandleResponse(ctx)
-	assert.False(t, success)
-	assert.ErrorIs(t, err, eap.ErrTLSUnexpectedFragment)
+	assert.False(t, success, "a non-ACK after the success point must never silently grant")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, eap.ErrTLSNotConfigured, "closure handling without a live session must fail closed")
 	assert.Nil(t, writer.response)
 }
 

--- a/internal/radiusd/plugins/eap/handlers/tls_tunnel.go
+++ b/internal/radiusd/plugins/eap/handlers/tls_tunnel.go
@@ -2,7 +2,9 @@ package handlers
 
 import (
 	"crypto/tls"
+	"errors"
 	"fmt"
+	"io"
 
 	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap"
 	"github.com/talkincode/toughradius/v9/internal/radiusd/plugins/eap/tlsengine"
@@ -92,15 +94,33 @@ func (t *tlsTunnel) HandleResponse(ctx *eap.EAPContext) (bool, error) {
 			setBool(state, stateKeyInnerActive, true)
 			return t.handleInnerRound(ctx, state, frag)
 		}
-		if !frag.IsACK() {
-			closeEngine(state)
-			return false, eap.ErrTLSUnexpectedFragment
-		}
+
 		engine, err := t.engineFor(state)
 		if err != nil {
 			return false, err
 		}
-		return t.onHandshakeComplete(ctx, state, engine)
+
+		// The RFC's ideal terminal response is a bare ACK (an empty EAP-TLS
+		// message, RFC 9190 Figure 1): the peer acknowledges the success
+		// indication and the exchange ends. Grant on it.
+		if frag.IsACK() && !reassemblyInProgress(state) {
+			return t.onHandshakeComplete(ctx, state, engine)
+		}
+
+		// A non-ACK message after the success point is the peer tearing down its
+		// TLS connection, which emits a close_notify alert. Real supplicants
+		// (wpa_supplicant, hostapd, Windows) close their TLS stack once the
+		// handshake completes rather than send the empty ACK the ideal flow
+		// shows. For plain EAP-TLS (no inner phase) treat a clean close_notify
+		// as benign closure and complete the authentication; a TLS *error* alert
+		// is a failure result indication and rejects (RFC 9190 §2.1.4 / §2.5,
+		// RFC 8446 §6.1). Tunneled methods (PEAP/TTLS) keep the strict handling.
+		if t.onApplicationData == nil {
+			return t.finishAfterPeerClosure(ctx, state, engine, frag)
+		}
+
+		closeEngine(state)
+		return false, eap.ErrTLSUnexpectedFragment
 	}
 
 	if t.hasQueuedFragments(state) {
@@ -174,6 +194,57 @@ func (t *tlsTunnel) advanceHandshake(ctx *eap.EAPContext, state *eap.EAPState, t
 	}
 
 	return t.startFlight(ctx, state, out, done)
+}
+
+// finishAfterPeerClosure completes a plain EAP-TLS exchange when, instead of the
+// empty ACK the RFC's ideal flow shows, the peer sends a TLS record after the
+// server's success point. Real supplicants tear down their TLS stack once the
+// handshake completes, which emits a close_notify alert carried as an ordinary
+// (non-ACK) EAP-TLS message.
+//
+// RFC 9190 §2.1.4 classifies close_notify as a warning-level closure ("the
+// connection is not going to continue normally") and §2.5 makes only TLS *error*
+// alerts a failure result indication; RFC 8446 §6.1 confirms close_notify "does
+// not indicate an error". So a clean close_notify (surfaced by the TLS engine as
+// io.EOF) completes the authentication, a TLS error alert (any other read error)
+// is a failure and rejects, and stray post-success application data is an
+// unexpected fragment. Only plain EAP-TLS reaches this path; PEAP/TTLS keep their
+// tunneled success semantics.
+func (t *tlsTunnel) finishAfterPeerClosure(ctx *eap.EAPContext, state *eap.EAPState, engine *tlsengine.Engine, frag *tlsfragment.Packet) (bool, error) {
+	reassembler := loadReassembler(state)
+	complete, err := reassembler.Accept(frag)
+	if err != nil {
+		closeEngine(state)
+		return false, err
+	}
+	if !complete {
+		saveReassembler(state, reassembler)
+		if serr := ctx.StateManager.SetState(state.StateID, state); serr != nil {
+			closeEngine(state)
+			return false, serr
+		}
+		return false, t.writeChallenge(ctx, state.StateID, t.buildFragmentACK(ctx.EAPMessage.Identifier+1))
+	}
+
+	records := reassembler.Buffer()
+	resetReassembler(state)
+
+	_, rerr := engine.ReadApplication(records)
+	switch {
+	case errors.Is(rerr, io.EOF):
+		// Clean close_notify: benign closure, the success was already committed.
+		return t.onHandshakeComplete(ctx, state, engine)
+	case rerr != nil:
+		// A TLS error alert (or otherwise unreadable record) is a failure result
+		// indication (RFC 9190 §2.5): reject rather than grant.
+		closeEngine(state)
+		return false, fmt.Errorf("%w: %v", eap.ErrTLSHandshakeFailed, rerr)
+	default:
+		// The peer sent application data after the success point. Plain EAP-TLS
+		// has no inner phase, so this violates the expected terminal flow.
+		closeEngine(state)
+		return false, eap.ErrTLSUnexpectedFragment
+	}
 }
 
 func (t *tlsTunnel) startFlight(ctx *eap.EAPContext, state *eap.EAPState, tlsData []byte, done bool) (bool, error) {

--- a/test/integration/eap_tls_test.go
+++ b/test/integration/eap_tls_test.go
@@ -247,6 +247,54 @@ func TestEAPTLSEndToEnd(t *testing.T) {
 		// RFC 5216 §2.3: the TLS 1.2 fallback also derives MS-MPPE keys.
 		assertEAPTLSMPPEKeys(t, resp, sup, secret)
 	})
+
+	t.Run("tls 1.2 client close_notify still authenticates", func(t *testing.T) {
+		// Real supplicants (wpa_supplicant, hostapd, Windows) tear down their
+		// TLS stack once the handshake completes instead of sending the RFC 9190
+		// Figure 1 bare ACK. The resulting close_notify alert arrives as a
+		// non-ACK EAP-TLS round after the server's success point; RFC 9190
+		// §2.1.4 and RFC 8446 §6.1 make it a benign closure (not a failure
+		// result indication, §2.5), so the exchange must still Access-Accept. A
+		// TLS 1.2 client finishes last, so its close_notify reliably lands as
+		// its own post-success round.
+		ca := newEAPTLSTestCA(t, "IT EAP-TLS close CA "+suffix)
+		serverCert := ca.issueServer(t, "radius.example.com")
+		username := "it-eaptls-close-" + suffix + "@example.com"
+		clientCert := ca.issueClient(t, "close", username)
+		seedEAPTLSUser(t, profileID, username)
+
+		configureEAPTLS(t, serverCert, ca.certPEM())
+
+		cfg := clientTLSConfig(ca, clientCert)
+		cfg.MaxVersion = tls.VersionTLS12
+
+		sup := &eapTLSSupplicant{
+			serverAddr: serverAddr,
+			secret:     secret,
+			username:   username,
+			nasID:      nasID,
+			nasIP:      nasIP,
+			clientCfg:  cfg,
+			clientRun: func(client *tls.Conn) error {
+				if err := client.Handshake(); err != nil {
+					return err
+				}
+				if v := client.ConnectionState().Version; v != tls.VersionTLS12 {
+					return fmt.Errorf("negotiated version %#x, want TLS 1.2", v)
+				}
+				// Tear down the TLS stack: crypto/tls emits a close_notify alert.
+				return client.Close()
+			},
+		}
+		resp := sup.authenticate(t)
+		assert.Equalf(t, radius.CodeAccessAccept, resp.Code,
+			"EAP-TLS peer that Close()s after the handshake must authenticate, got %v (%q)", resp.Code, rfc2865.ReplyMessage_GetString(resp))
+		assertEAPCode(t, resp, eap.CodeSuccess)
+		require.NoError(t, sup.clientErr)
+		// The benign close_notify must not disturb key derivation: the Accept
+		// still carries the MS-MPPE session keys (RFC 5216 §2.3).
+		assertEAPTLSMPPEKeys(t, resp, sup, secret)
+	})
 }
 
 // assertEAPTLSMPPEKeys verifies the Access-Accept carries the MS-MPPE session
@@ -651,11 +699,12 @@ func (s *eapTLSSupplicant) exchange(packet *radius.Packet) (*radius.Packet, erro
 
 // startClient launches the crypto/tls client bound to in-memory duplex streams
 // that the supplicant bridges to the RADIUS transport. The default behavior
-// runs the handshake only and deliberately does not Close the conn: a
-// close_notify alert would surface as an extra non-ACK EAP-TLS round after the
-// server's pending-success point (most visibly with a TLS 1.2 pinned client,
-// where the client finishes last). Tests may override clientRun to also read
-// application data, e.g. the TLS 1.3 protected success indication.
+// runs the handshake only and ends the exchange on the RFC 9190 Figure 1 bare
+// ACK. Tests may override clientRun to also read application data (e.g. the TLS
+// 1.3 protected success indication) or to Close the conn: a client that Close()s
+// emits a close_notify alert that arrives as a non-ACK EAP-TLS round after the
+// server's pending-success point, which the handler now completes as a benign
+// closure (RFC 9190 §2.1.4).
 func (s *eapTLSSupplicant) startClient() {
 	s.toClient = newEAPStream()
 	s.fromClient = newEAPStream()


### PR DESCRIPTION
# Summary

Make the EAP-TLS handler tolerate a real supplicant's TLS `close_notify` alert after the success point instead of rejecting it, so interop with wpa_supplicant / hostapd / Windows no longer turns a successful authentication into an Access-Reject (M10.3).

## Roadmap Mapping (Required for agent tasks)

- Milestone subtask: `M10.3`
- Feature ID(s): `TR-F004`
- Out-of-scope non-goals checked: `TR-N001` `TR-N002` `TR-N003` `TR-N004` `TR-N005`

## What Changed

- `internal/radiusd/plugins/eap/handlers/tls_tunnel.go`: at the pending-success point, plain EAP-TLS (no inner phase) now routes a non-ACK terminal message to a new `finishAfterPeerClosure` helper instead of returning `ErrTLSUnexpectedFragment`. The helper reassembles the TLS record and feeds it to `engine.ReadApplication`:
  - a clean `close_notify` (surfaced by `crypto/tls` as `io.EOF`) **completes** the authentication;
  - a TLS **error** alert / otherwise unreadable record (any non-EOF error) is a failure result indication and **rejects** (`ErrTLSHandshakeFailed`);
  - stray post-success application data **rejects** (`ErrTLSUnexpectedFragment`).
- Tunneled methods (PEAP/TTLS) keep the strict handling: the new branch is gated on `onApplicationData == nil`, and TTLS's peer-initiated phase-2 routing is unchanged.
- Tests + stale-comment updates in `tls_handler_handshake_test.go`, `tls_handler_test.go`, and `test/integration/eap_tls_test.go`.

### Why (RFC anchors)

- RFC 9190 §2.1.4 — `close_notify` (and `user_canceled`) are warning-level closures: "the connection is not going to continue normally". It is not an error.
- RFC 9190 §2.5 — only a TLS **error** alert is a failure result indication; a warning closure is not.
- RFC 8446 §6.1 — `close_notify` "does not indicate an error".

## Acceptance Criteria Covered

- [x] The change only covers the mapped `TR-F` scope (EAP-TLS termination semantics; anonymous-NAI/identity-protection deferred to a follow-up subtask)
- [x] Protocol behavior updates include RFC clause references in code/tests/PR description
- [x] Protocol or E2E behavior changes include CI-runnable acceptance tests under `test/integration/`

### Tests

- Unit (`internal/radiusd/plugins/eap/handlers/tls_handler_handshake_test.go`):
  - `TestTLSHandler_PendingSuccess_TLS12ClientCloseGrants` — TLS 1.2 client `Close()`s → grant.
  - `TestTLSHandler_PendingSuccess_TLS13ClientCloseGrants` — TLS 1.3 client reads the 0x00 indication then `Close()`s → grant.
  - `TestTLSHandler_PendingSuccess_StrayApplicationDataRejected` — stray app data → `ErrTLSUnexpectedFragment`.
  - `TestTLSHandler_PendingSuccess_TLSErrorAlertRejected` — corrupt post-success record → `ErrTLSHandshakeFailed`.
- Integration (`test/integration/eap_tls_test.go`, `//go:build integration`, real UDP RADIUS + PostgreSQL):
  - `TestEAPTLSEndToEnd/tls 1.2 client close_notify still authenticates` → Access-Accept with MS-MPPE keys.

## Verification

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run` (0 issues on changed packages; the 6 pre-existing `gosec`/`misspell` findings in other `integration`-tagged files are untouched and out of scope)
- [x] `go test -tags=integration ./test/integration/...` (EAP-TLS suite green against docker-compose PostgreSQL)
- [ ] `cd web && npm run build` (not applicable — no frontend files changed)

## Risks and Rollback

- Risk level: `low`
- Main risk: over-accepting a post-success message. Mitigated by only granting on `io.EOF` (a clean `close_notify`); every other read error or stray record still rejects, and the change is scoped to plain EAP-TLS (`onApplicationData == nil`), leaving PEAP/TTLS byte-identical.
- Rollback plan: revert this commit; the pre-change behavior (reject any non-ACK at pending-success) is restored with no schema/config impact.

## Reviewer Notes

- Suggested review order: `tls_tunnel.go` (pending-success branch + `finishAfterPeerClosure`) → unit tests → integration subtest.
- Assumptions: `crypto/tls` `Conn.Read` returns `io.EOF` on a peer `close_notify` and a non-EOF error on a TLS error alert; validated by the new unit and integration tests. A TLS 1.2 client finishes last, so its `close_notify` deterministically lands as its own post-success round; the TLS 1.3 case reads the 0x00 indication first to force the same ordering.
- Follow-up (to be split via roadmap grooming): full anonymous-NAI / identity-protection (RFC 9190 §2.1.7/§2.1.8) requires reordering the auth pipeline (`stageLoadUser` currently resolves the account by the outer User-Name before EAP runs) and is intentionally out of scope here.
